### PR TITLE
User authorizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 
 services:
   - docker
+  - postgres
 
 language: ruby
 
@@ -38,3 +39,6 @@ rvm:
 
 notifications:
     email: false
+
+addons:
+  postgresql: "9.4"

--- a/decidim-core/app/commands/decidim/authorize_user.rb
+++ b/decidim-core/app/commands/decidim/authorize_user.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Decidim
+  # A command to authorize a user with an authorization handler.
+  class AuthorizeUser < Rectify::Command
+    # Public: Initializes the command.
+    #
+    # handler - An AuthorizationHandler object.
+    def initialize(handler)
+      @handler = handler
+    end
+
+    # Executes the command. Braodcasts these events:
+    #
+    # - :ok when everything is valid.
+    # - :invalid if the handler wasn't valid and we couldn't proceed.
+    #
+    # Returns nothing.
+    def call
+      return broadcast(:invalid) unless handler.valid?
+
+      create_authorization
+      broadcast(:ok)
+    end
+
+    private
+
+    attr_reader :handler
+
+    def create_authorization
+      Authorization.create!(
+        user: handler.user,
+        name: handler.handler_name,
+        metadata: handler.metadata
+      )
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/account_controller.rb
+++ b/decidim-core/app/controllers/decidim/account_controller.rb
@@ -5,6 +5,7 @@ module Decidim
   # The controller to handle the user's account page.
   class AccountController < ApplicationController
     helper_method :authorizations, :handlers
+    authorize_resource :user_account, class: false
 
     private
 

--- a/decidim-core/app/controllers/decidim/account_controller.rb
+++ b/decidim-core/app/controllers/decidim/account_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require_dependency "decidim/application_controller"
+
+module Decidim
+  # The controller to handle the user's account page.
+  class AccountController < ApplicationController
+    helper_method :authorizations, :handlers
+
+    private
+
+    def handlers
+      @handlers ||= Decidim.authorization_handlers.reject do |handler|
+        authorized_handlers.include?(handler.handler_name)
+      end
+    end
+
+    def authorizations
+      @authorizations ||= current_user.authorizations
+    end
+
+    def authorized_handlers
+      authorizations.map(&:name)
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require_dependency "decidim/application_controller"
+
+module Decidim
+  # This controller allows users to create and destroy their authorizations. It
+  # shouldn't be necessary to expand it to add new authorization schemes.
+  class AuthorizationsController < ApplicationController
+    helper_method :handler, :handlers
+    before_action :valid_handler, only: [:new, :create]
+    before_action :only_one_handler?, only: [:index]
+
+    def create
+      AuthorizeUser.call(handler) do
+        on(:ok) do
+          flash[:notice] = t("authorizations.create.success", scope: "decidim")
+          redirect_to account_path
+        end
+
+        on(:invalid) do
+          flash[:alert] = t("authorizations.create.error", scope: "decidim")
+          render action: :new
+        end
+      end
+    end
+
+    def destroy
+      @authorization = current_user.authorizations.find(params[:id])
+      @authorization.destroy
+      flash[:notice] = t("authorizations.destroy.success", scope: "decidim")
+      redirect_to account_path
+    end
+
+    def handler
+      @handler ||= AuthorizationHandler.handler_for(handler_name, handler_params)
+    end
+
+    def handlers
+      @handlers ||= Decidim.authorization_handlers
+    end
+
+    protected
+
+    def handler_params
+      (params[:authorization_handler] || {}).merge(user: current_user)
+    end
+
+    def handler_name
+      params[:handler] || params[:authorization_handler][:handler_name]
+    end
+
+    def valid_handler
+      return true if handler
+
+      logger.warn "Invalid authorization handler given: #{handler_name} doesn't"\
+        "exist or you haven't added it to `Decidim.authorization_handlers`"
+
+      redirect_to(account_path) && (return false)
+    end
+
+    def only_one_handler?
+      redirect_to(action: :new, handler: handlers.first.handler_name) && return if handlers.length == 1
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -9,7 +9,17 @@ module Decidim
     before_action :valid_handler, only: [:new, :create]
     before_action :only_one_handler?, only: [:index]
 
+    def new
+      authorize! current_user, Authorization
+    end
+
+    def index
+      authorize! current_user, Authorization
+    end
+
     def create
+      authorize! current_user, Authorization
+
       AuthorizeUser.call(handler) do
         on(:ok) do
           flash[:notice] = t("authorizations.create.success", scope: "decidim")
@@ -25,6 +35,8 @@ module Decidim
 
     def destroy
       @authorization = current_user.authorizations.find(params[:id])
+      authorize! current_user, @authorization
+
       @authorization.destroy
       flash[:notice] = t("authorizations.destroy.success", scope: "decidim")
       redirect_to account_path

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -6,6 +6,14 @@ module Decidim
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
       layout "application"
+
+      def after_sign_in_path_for(user)
+        if user.is_a?(User) && user.sign_in_count == 1 && Decidim.authorization_handlers.any?
+          authorizations_path
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/authorization_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/authorization_form_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module Decidim
+  # A heper to expose an easy way to add authorization forms in a view.
+  module AuthorizationFormHelper
+    # Creates a ew authorization form in a view, accepts the same arguments as
+    # `form_for`.
+    #
+    # record  - The record to use in the form, it shoulde be a descendant of
+    # AuthorizationHandler.
+    # options - An optional hash with options to pass wo the form builder.
+    # block   - A block with the content of the form.
+    #
+    # Returns a String.
+    def authorization_form_for(record, options = {}, &block)
+      default_options = {
+        builder: AuthorizationFormBuilder,
+        as: "authorization_handler",
+        url: authorizations_path
+      }
+
+      options = default_options.merge(options)
+      form_for(record, options, &block)
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/ability.rb
+++ b/decidim-core/app/models/decidim/ability.rb
@@ -21,6 +21,12 @@ module Decidim
       Decidim.abilities.each do |ability|
         merge ability.new(user)
       end
+
+      can :manage, Authorization do |authorization|
+        authorization.user == user
+      end
+
+      can :read, :user_account if user
     end
   end
 end

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module Decidim
+  # An authorization is a record that a User has been authorized somehow. Other
+  # models in the system can use different kind of authorizations to allow a
+  # user to perform actions.
+  #
+  # To create an authorization for a user we need to use an
+  # AuthorizationHandler that validates the user against a set of rules. An
+  # example could be a handler that validates a user email against an API and
+  # depending on the response it allows the creation of the authorization or
+  # not.
+  class Authorization < ApplicationRecord
+    belongs_to :user, foreign_key: "decidim_user_id", class_name: Decidim::User, inverse_of: :authorizations
+
+    validates :name, :user, :handler, presence: true
+    validates :name, uniqueness: { scope: :decidim_user_id }
+
+    # The handler that created this authorization.
+    #
+    # Returns an instance that inherits from Decidim::AuthorizationHandler.
+    def handler
+      @handler ||= AuthorizationHandler.handler_for(name, metadata)
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -8,6 +8,7 @@ module Decidim
            :recoverable, :rememberable, :trackable, :decidim_validatable
 
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: Decidim::Organization
+    has_many :authorizations, foreign_key: "decidim_user_id", class_name: Decidim::Authorization, inverse_of: :user
 
     ROLES = %w(admin moderator official).freeze
 

--- a/decidim-core/app/services/decidim/authorization_handler.rb
+++ b/decidim-core/app/services/decidim/authorization_handler.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+module Decidim
+  # This is the base class for authorization handlers, all implementations
+  # should inherit from it.
+  # Each AuthorizationHandler must define an `authorized?` method that will be
+  # used to check if the authorization is valid or not. When it is valid a new
+  # authorization will be created for the user.
+  #
+  # It also sets two default attributes, `user` and `handler_name`.
+  class AuthorizationHandler < Rectify::Form
+    # The user that is trying to authorize, it's initialized with the
+    # `current_user` from the controller.
+    attribute :user, Decidim::User
+    # The String name of the handler, should not be modified since it's used to
+    # infer the class name of the authorization handler.
+    attribute :handler_name, String
+
+    # THe attributes of the handler that should be exposed as form input when
+    # rendering the handler in a form.
+    #
+    # Returns an Array of Strings.
+    def form_attributes
+      attributes.except(:id, :user).keys
+    end
+
+    # Whether the authorization is valid or not. Each AuthorizationHandler
+    # implementation must implemement this method. This is were you check for
+    # validation errors or against third party systems to validate the
+    # authorization.
+    #
+    # Returns a Boolean.
+    def authorized?
+      raise NotImplementedError
+    end
+
+    # The String partial path so Rails can render the handler as a form. This
+    # is useful if you want to have a custom view to render the form instead of
+    # the default view.
+    #
+    # Example:
+    #
+    #   A handler named Decidim::CensusHandler would look for its partial in:
+    #   decidim/census/form
+    #
+    # Returns a String.
+    def to_partial_path
+      handler_name.sub!(/_handler$/, "") + "/form"
+    end
+
+    # Any data that the developer would like to inject to the `metadata` field
+    # of an authorization when it's created. Can be useful if some of the
+    # params the user sent with the authorization form want to be persisted for
+    # future use.
+    #
+    # Returns a Hash.
+    def metadata
+      {}
+    end
+
+    # A serialized version of the handler's name.
+    #
+    # Returns a String.
+    def self.handler_name
+      name.underscore
+    end
+
+    # Same as the class method but accessible from the instance.
+    #
+    # Returns a String.
+    def handler_name
+      self.class.handler_name
+    end
+
+    # Finds a handler class from a String. This is necessary when processing
+    # the form data. It will only look for valid handlers that have also been
+    # configured in `Decidim.authorization_handlers`.
+    #
+    # name - The String name of the class to find, usually in the same shape as
+    # the one returned by `handler_name`.
+    # params - An optional Hash with params to initialize the handler.
+    #
+    # Returns an AuthorizationHandler descendant.
+    # Returns nil when no handlers could be found.
+    def self.handler_for(name, params = {})
+      handler_klass = name.classify.constantize
+
+      return unless Decidim.authorization_handlers.include?(handler_klass)
+
+      handler_klass.new(params || {})
+    rescue NameError
+      nil
+    end
+  end
+end

--- a/decidim-core/app/views/decidim/account/_authorizations.html.erb
+++ b/decidim-core/app/views/decidim/account/_authorizations.html.erb
@@ -1,0 +1,52 @@
+<div class="tabs-panel" id="authorizations">
+  <div class="row column">
+    <% if authorizations.any? %>
+      <section class="section">
+        <div class="card card--list">
+          <% authorizations.each do |authorization| %>
+            <div class="card--list__item">
+              <div class="card--list__text">
+                <%= icon "lock-unlocked", class: "card--list__icon" %>
+                <div>
+                  <h5 class="card--list__heading">
+                    <%= t(authorization.name, scope: "decidim.authorization_handlers") %>
+                  </h5>
+                  <span class="text-small"><%= l(authorization.created_at, format: :long) %></span>
+                </div>
+              </div>
+              <div class="card--list__data">
+                <%= link_to authorization, method: :delete, class: "card--list__data__icon", data: { confirm: t(".authorization_confirm_destroy") } do %>
+                  <%= icon "circle-x" %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+      <% if handlers.any? %>
+        <div class="card card--list">
+          <% handlers.each do |handler| %>
+            <div class="card--list__item">
+              <div class="card--list__text">
+                <a href="#">
+                  <%= icon "lock-locked", class: "card--list__icon" %>
+                </a>
+                <div>
+                  <h5 class="card--list__heading">
+                    <%= link_to t(handler.handler_name, scope: "decidim.authorization_handlers"), new_authorization_path(handler: handler.handler_name) %>
+                  </h5>
+                </div>
+              </div>
+              <div class="card--list__data">
+                <%= link_to new_authorization_path(handler: handler.handler_name), class: "card--list__data__icon" do %>
+                  <%= icon "chevron-right" %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </section>
+    <% end %>
+  </div>
+</div>
+

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -1,0 +1,32 @@
+<main class="wrapper">
+<div class="row collapse">
+  <div class="columns">
+    <h1 class="heading1 user-header"><%= t(".title") %></h1>
+  </div>
+</div>
+<div class="row collapse">
+  <div class="main-container">
+    <div class="row collapse main-container--side-panel">
+      <div class="columns medium-4 large-3">
+        <div class="side-panel">
+          <ul class="tabs vertical side-panel__tabs" id="user-settings-tabs"
+            data-tabs>
+            <% if handlers.any? || authorizations.any? %>
+              <li class="tabs-title">
+                <a href="#authorizations"><%= t(".authorizations") %></a>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+      <div class="columns medium-8 large-9">
+        <div class="main-container__content">
+          <div class="tabs-content vertical" data-tabs-content="user-settings-tabs">
+            <%= render partial: "authorizations" %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</main>

--- a/decidim-core/app/views/decidim/authorizations/index.html.erb
+++ b/decidim-core/app/views/decidim/authorizations/index.html.erb
@@ -1,0 +1,22 @@
+<main class="wrapper">
+  <div class="row collapse">
+    <div class="row collapse">
+      <div class="columns large-8 large-centered text-center">
+        <h1 class="heading1 page-title"><%= t(".title") %></h1>
+        <p class="heading5"><%= t(".verify_with_these_options") %></p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="columns medium-7 large-5 medium-centered">
+        <div class="card">
+          <div class="card__content">
+            <% handlers.each do |handler| %>
+              <%= link_to t(handler.handler_name, scope: "decidim.authorizations.index.actions"), new_authorization_path(handler: handler.handler_name), class: "button expanded" %>
+            <% end %>
+            <p class="text-center skip"><%= t("decidim.authorizations.skip_verification", link: link_to(t("decidim.authorizations.current_participatory_processes"), participatory_processes_path).html_safe).html_safe %>.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/decidim-core/app/views/decidim/authorizations/new.html.erb
+++ b/decidim-core/app/views/decidim/authorizations/new.html.erb
@@ -1,0 +1,29 @@
+<main class="wrapper">
+  <div class="row collapse">
+    <div class="row collapse">
+      <div class="columns large-8 large-centered text-center page-title">
+        <h1><%= t(".authorize_with", authorizer: t(handler.handler_name, scope: "decidim.authorization_handlers")) %></h1>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="columns large-6 medium-centered">
+        <div class="card">
+          <div class="card__content">
+            <%= authorization_form_for(handler) do |form| %>
+              <% if lookup_context.exists?(handler.to_partial_path, [], true) %>
+                <%= render partial: handler, as: "handler", locals: { form: form } %>
+              <% else %>
+                <%= form.all_fields %>
+                <div class="actions">
+                  <%= form.submit t(".authorize"), class: "button expanded" %>
+                </div>
+              <% end %>
+            <% end %>
+            <p class="text-center skip"><%= t("decidim.authorizations.skip_verification", link: link_to(t("decidim.authorizations.current_participatory_processes"), participatory_processes_path).html_safe).html_safe %>.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/decidim-core/app/views/layouts/decidim/_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_header.html.erb
@@ -46,7 +46,7 @@
               <div class="topbar__dropmenu topbar__user__logged">
                 <ul class="dropdown menu" data-dropdown-menu>
                   <li class="is-dropdown-submenu-parent show-for-medium">
-                    <%= link_to current_user.name, root_path %>
+                    <%= link_to current_user.name, account_path %>
                     <ul class="menu is-dropdown-subeenu js-append usermenu-off-canvas">
                       <li><%= link_to t('.sign_out'), destroy_user_session_path, method: :delete, class: "sign-out-link" %></li>
                     </ul>

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -16,6 +16,30 @@ ca:
     'false': 'No'
     'true': Sí
   decidim:
+    account:
+      authorizations:
+        authorization_confirm_destroy: Segur que vols suprimir aquesta autorització?
+      show:
+        authorizations: Autoritzacions
+        title: El meu compte
+    authorization_handlers:
+      decidim/dummy_authorization_handler: Autorització d'exemple
+    authorizations:
+      create:
+        error: S'ha produït un error al crear l'autorització.
+        success: Has estat autoritzat/da correctament.
+      current_participatory_processes: fer una ullada als processos actuals
+      destroy:
+        success: Autorització destruïda correctament.
+      index:
+        actions:
+          decidim/dummy_authorization_handler: Verificar-me amb l'exemple
+        title: Verificar la teva identitat
+        verify_with_these_options: 'Aquestes són les opcions disponibles per verificar la teva identitat:'
+      new:
+        authorize: Enviar
+        authorize_with: Verificar-me amb %{authorizer}
+      skip_verification: Pots saltar-te aquest pas per ara i %{link}
     core:
       actions:
         unauthorized: No tens permís per realitzar aquesta acció.
@@ -75,10 +99,10 @@ ca:
             one: "%{count} procés"
             other: "%{count} processos"
         participatory_process:
-          active_step: "Fase actual:"
+          active_step: 'Fase actual:'
           take_part: Participa
         promoted_process:
-          active_step: "Fase actual:"
+          active_step: 'Fase actual:'
           more_info: Més informació
           take_part: Participa
   locales:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -16,6 +16,30 @@ en:
     'false': 'No'
     'true': 'Yes'
   decidim:
+    account:
+      authorizations:
+        authorization_confirm_destroy: Are you sure you want to delete this authorization?
+      show:
+        authorizations: Authorizations
+        title: My account
+    authorization_handlers:
+      decidim/dummy_authorization_handler: Example authorization
+    authorizations:
+      create:
+        error: There was an error creating the authorization.
+        success: You've been successfully authorized.
+      current_participatory_processes: take a look at the current processes
+      destroy:
+        success: Authorization successfully destroyed
+      index:
+        actions:
+          decidim/dummy_authorization_handler: Verify against the example authorization
+        title: Verify your identity
+        verify_with_these_options: 'These are the available options to verify your identity:'
+      new:
+        authorize: Send
+        authorize_with: Verify with %{authorizer}
+      skip_verification: You can skip this for now and %{link}
     core:
       actions:
         unauthorized: You are not authorized to perform this action
@@ -71,10 +95,10 @@ en:
             one: "%{count} process"
             other: "%{count} processes"
         participatory_process:
-          active_step: "Current step:"
+          active_step: 'Current step:'
           take_part: Take part
         promoted_process:
-          active_step: "Current step:"
+          active_step: 'Current step:'
           more_info: More info
           take_part: Take part
   locales:

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -16,6 +16,30 @@ es:
     'false': 'No'
     'true': Sí
   decidim:
+    account:
+      authorizations:
+        authorization_confirm_destroy: "¿Seguro que quieres eliminar esta autorización?"
+      show:
+        authorizations: Autorizaciones
+        title: Mi cuenta
+    authorization_handlers:
+      decidim/dummy_authorization_handler: ejemplo de autorización
+    authorizations:
+      create:
+        error: Se ha producido un error al crear la autorización.
+        success: Has sido autorizado/a correctamente.
+      current_participatory_processes: echar un vistazo a los procesos actuales
+      destroy:
+        success: Autorización destruida con éxito
+      index:
+        actions:
+          decidim/dummy_authorization_handler: Verificarme con el ejemplo
+        title: Verifica tu identidad
+        verify_with_these_options: 'Estas son las opciones disponibles para verificar tu identidad:'
+      new:
+        authorize: Enviar
+        authorize_with: Verificarme con %{authorizer}
+      skip_verification: Puede saltarte este paso por ahora y %{link}
     core:
       actions:
         unauthorized: No tienes permiso para realizar esta acción.
@@ -75,10 +99,10 @@ es:
             one: "%{count} proceso"
             other: "%{count} procesos"
         participatory_process:
-          active_step: "Fase actual:"
+          active_step: 'Fase actual:'
           take_part: Participa
         promoted_process:
-          active_step: "Fase actual:"
+          active_step: 'Fase actual:'
           more_info: Más información
           take_part: Participa
   locales:

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -16,6 +16,11 @@ Decidim::Core::Engine.routes.draw do
   resource :locale, only: [:create]
   resources :participatory_processes, only: [:index, :show]
 
+  authenticate(:user) do
+    resources :authorizations, only: [:new, :create, :destroy, :index]
+    resource :account, only: [:show], controller: "account"
+  end
+
   get "/pages/*id" => "pages#show", as: :page, format: false
 
   match "/404", to: "pages#show", id: "404", via: :all

--- a/decidim-core/db/migrate/20161018091013_create_decidim_authorizations.rb
+++ b/decidim-core/db/migrate/20161018091013_create_decidim_authorizations.rb
@@ -1,0 +1,13 @@
+class CreateDecidimAuthorizations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :decidim_authorizations do |t|
+      t.string :name, null: false
+      t.jsonb :metadata
+      t.references :decidim_user, null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+
+    add_index :decidim_authorizations, [:decidim_user_id, :name], unique: true
+  end
+end

--- a/decidim-core/lib/decidim/authorization_form_builder.rb
+++ b/decidim-core/lib/decidim/authorization_form_builder.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require "decidim/form_builder"
+
+module Decidim
+  # A customf orm builder to render AuthorizationHandler forms.
+  class AuthorizationFormBuilder < Decidim::FormBuilder
+    # Renders all form attributes defined by the handler.
+    #
+    # Returns a String.
+    def all_fields
+      fields = public_attributes.map do |name, type|
+        @template.content_tag(:div, input_field(name, type), class: "field")
+      end
+
+      safe_join(fields)
+    end
+
+    # Renders a single attribute from the form handlers.
+    #
+    # name - The String name of the attribute.
+    # options - An optional Hash, accepted options are:
+    #           :as - A String name with the type the field to render
+    #           :input - An optional Hash to pass to the field method.
+    #
+    # Returns a String.
+    def input(name, options = {})
+      if options[:as]
+        send(options[:as].to_s, name, options[:input] || {})
+      else
+        type = find_input_type(name.to_s)
+        input_field(name, type)
+      end
+    end
+
+    private
+
+    def input_field(name, type)
+      return hidden_field(name) if name.to_s == "handler_name"
+
+      case type.name
+      when "Date"
+        date_field name
+      else
+        text_field name
+      end
+    end
+
+    def find_input_type(name)
+      found_attribute = object.class.attribute_set.detect do |attribute|
+        attribute.name.to_s == name
+      end
+
+      raise "Could not find attribute #{name} in #{object.class.name}" unless found_attribute
+
+      found_attribute.type.primitive
+    end
+
+    def public_attributes
+      form_attributes.inject({}) do |all, attribute|
+        all.update(attribute.name => attribute.type.primitive)
+      end
+    end
+
+    def form_attributes
+      object.class.attribute_set.select do |attribute|
+        object.form_attributes.include?(attribute.name)
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -6,6 +6,7 @@ require "decidim/core/version"
 module Decidim
   autoload :TranslatableAttributes, "decidim/translatable_attributes"
   autoload :FormBuilder, "decidim/form_builder"
+  autoload :AuthorizationFormBuilder, "decidim/authorization_form_builder"
   autoload :DeviseFailureApp, "decidim/devise_failure_app"
   include ActiveSupport::Configurable
 
@@ -26,6 +27,12 @@ module Decidim
   # Exposes a configuration option: an Array of `cancancan`'s Ability classes
   # that will be automatically included to the base `Decidim::Ability` class.
   config_accessor :abilities do
+    []
+  end
+
+  # Exposes a configuration option: an Array of classes that can be used as
+  # AuthorizaionHandlers so users can be verified against different systems.
+  config_accessor :authorization_handlers do
     []
   end
 end

--- a/decidim-core/lib/tasks/decidim_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_tasks.rake
@@ -5,6 +5,6 @@
 # end
 
 namespace :decidim do
-  # Install migrations from Decidim to the app.
+  desc "Install migrations from Decidim to the app."
   task upgrade: ["railties:install:migrations"]
 end

--- a/decidim-core/spec/controllers/authorizations_controller_spec.rb
+++ b/decidim-core/spec/controllers/authorizations_controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe AuthorizationsController, type: :controller do
+    include_context "authenticated user"
+
+    describe "handler" do
+      it "injects the current_user" do
+        controller.params[:handler] = "decidim/dummy_authorization_handler"
+        expect(controller.handler.user).to eq(user)
+      end
+    end
+
+    describe "POST create" do
+      context "when the handler is not valid" do
+        it "redirects the user" do
+          post :create, params: { handler: "foo" }
+          expect(response).to redirect_to(account_path)
+        end
+      end
+    end
+
+    describe "GET new" do
+      context "when the handler is not valid" do
+        it "redirects the user" do
+          get :new, params: { handler: "foo" }
+          expect(response).to redirect_to(account_path)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/controllers/locales_controller_spec.rb
+++ b/decidim-core/spec/controllers/locales_controller_spec.rb
@@ -3,12 +3,10 @@ require "spec_helper"
 
 module Decidim
   describe LocalesController, type: :controller do
-    routes { Decidim::Core::Engine.routes }
     let(:organization) { create(:organization) }
 
     before do
       @request.env["decidim.current_organization"] = organization
-      @request.env["devise.mapping"] = Devise.mappings[:user]
     end
 
     describe "POST create" do

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Devise
+    describe SessionsController, type: :controller do
+      describe "after_sign_in_path_for" do
+        subject { controller.after_sign_in_path_for(user) }
+
+        context "when the given resource is a user" do
+          context "when it is the first time to log in" do
+            let(:user) { build(:user, sign_in_count: 1) }
+
+            context "when there are authorization handlers" do
+              before do
+                Decidim.authorization_handlers = [Decidim::DummyAuthorizationHandler]
+              end
+
+              it { is_expected.to eq("/authorizations") }
+            end
+
+            context "otherwise" do
+              before do
+                Decidim.authorization_handlers = []
+              end
+
+              it { is_expected.to eq("/") }
+            end
+          end
+
+          context "otherwise" do
+            let(:user) { build(:user, sign_in_count: 2) }
+
+            it { is_expected.to eq("/") }
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -64,4 +64,10 @@ FactoryGirl.define do
       roles ["official"]
     end
   end
+
+  factory :authorization, class: Decidim::Authorization do
+    name "decidim/dummy_authorization_handler"
+    user
+    metadata { {} }
+  end
 end

--- a/decidim-core/spec/features/authorizations_spec.rb
+++ b/decidim-core/spec/features/authorizations_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe "Authorizations", type: :feature, perform_enqueued: true do
+  let(:organization) { user.organization }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  context "a new user" do
+    let(:user) { create(:user, :confirmed) }
+
+    context "when one authorization has been configured" do
+      before do
+        Decidim.authorization_handlers = [Decidim::DummyAuthorizationHandler]
+        visit decidim.root_path
+        find(".sign-in-link").click
+        fill_in :user_email, with: user.email
+        fill_in :user_password, with: "password1234"
+        find("*[type=submit]").click
+      end
+
+      it "redirects the user to the authorization form after the first sign in" do
+        fill_in "Document number", with: "123456789X"
+        fill_in "Birthday", with: "01/01/1970"
+        click_button "Send"
+        expect(page).to have_content("You've been successfully authorized")
+      end
+
+      it "allows the user to skip it" do
+        find(".skip a").click
+        expect(page).to have_content("processes")
+      end
+    end
+
+    context "when multiple authorizations have been configured" do
+      before do
+        Decidim.authorization_handlers = [
+          Decidim::DummyAuthorizationHandler,
+          Decidim::DummyAuthorizationHandler
+        ]
+
+        visit decidim.root_path
+        find(".sign-in-link").click
+        fill_in :user_email, with: user.email
+        fill_in :user_password, with: "password1234"
+        find("*[type=submit]").click
+      end
+
+      it "allows the user to choose which one to authorize against to" do
+        expect(page).to have_css("a.button.expanded", count: 2)
+      end
+    end
+  end
+
+  context "user account" do
+    let(:user) { create(:user, :confirmed) }
+
+    before do
+      login_as user, scope: :user
+      visit decidim.root_path
+    end
+
+    it "allows the user to authorize against available authorizations" do
+      click_link user.name
+      click_link "Authorizations"
+      click_link "Example authorization"
+
+      fill_in "Document number", with: "123456789X"
+      fill_in "Birthday", with: "01/01/1970"
+      click_button "Send"
+
+      expect(page).to have_content("You've been successfully authorized")
+
+      within "#authorizations" do
+        expect(page).to have_content("Example authorization")
+        expect(page).to_not have_link("Example authorization")
+      end
+    end
+
+    context "when the user has already been authorised" do
+      let!(:authorization) do
+        create(:authorization,
+               name: Decidim::DummyAuthorizationHandler.handler_name,
+               user: user
+              )
+      end
+
+      it "shows the authorization at their account" do
+        click_link user.name
+        click_link "Authorizations"
+
+        within "#authorizations" do
+          expect(page).to have_content("Example authorization")
+          expect(page).to_not have_link("Example authorization")
+          expect(page).to have_content(I18n.localize(authorization.created_at, format: :long))
+        end
+      end
+
+      it "allows the user to delete an authorization" do
+        click_link user.name
+        click_link "Authorizations"
+        find("#authorizations a.card--list__data__icon").click
+
+        expect(page).to have_content("Authorization successfully destroyed")
+        within "#authorizations" do
+          expect(page).to have_link("Example authorization")
+        end
+      end
+    end
+
+    context "when no authorizations are configured" do
+      before do
+        Decidim.authorization_handlers = []
+      end
+
+      it "doesn't list authorizations" do
+        click_link user.name
+        expect(page).to_not have_content("Authorizations")
+      end
+    end
+  end
+end

--- a/decidim-core/spec/helpers/decidim/authorization_form_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/authorization_form_helper_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe AuthorizationFormHelper do
+    let(:record) do
+      DummyAuthorizationHandler.new({})
+    end
+
+    before do
+      allow(helper).to receive(:authorizations_path).and_return("/authorizations")
+    end
+
+    describe "authorization_form_for" do
+      it "creates form" do
+        form = helper.authorization_form_for(record) {|f| }
+        expect(form).to include("<form")
+        expect(form).to include("new_authorization_handler")
+        expect(form).to include('action="/authorizations"')
+        expect(form).to include('method="post"')
+      end
+
+      it "allows custom options" do
+        form = helper.authorization_form_for(record, html: { class: "custom_form" }) {|f| }
+        expect(form).to include('class="custom_form"')
+      end
+    end
+  end
+end

--- a/decidim-core/spec/lib/authorization_form_builder_spec.rb
+++ b/decidim-core/spec/lib/authorization_form_builder_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+require "nokogiri"
+
+module Decidim
+  describe AuthorizationFormBuilder do
+    let(:record) do
+      DummyAuthorizationHandler.new({})
+    end
+    let(:helper) { Class.new(ActionView::Base).new }
+    let(:builder) { described_class.new(:authorization_handler, record, helper, {}) }
+
+    before do
+      allow(helper).to receive(:authorizations_path).and_return("/authorizations")
+    end
+
+    def find(selector)
+      subject.css(selector).first
+    end
+
+    describe "all_fields" do
+      subject { Nokogiri::HTML(builder.all_fields) }
+
+      it "includes the handler name" do
+        expect(find("input#authorization_handler_handler_name")["value"]).to eq("decidim/dummy_authorization_handler")
+      end
+
+      it "includes the public handler attributes" do
+        expect(find("input#authorization_handler_birthday")["type"]).to eq("date")
+        expect(find("input#authorization_handler_document_number")["type"]).to eq("text")
+      end
+
+      it "does not include other handler attributes" do
+        expect(find("input#authorization_handler_id")).to eq(nil)
+        expect(find("input#authorization_handler_user")).to eq(nil)
+      end
+    end
+
+    describe "input" do
+      it "renders a single field for an attribute" do
+        html = builder.input(:birthday)
+        expect(html).to eq('<label for="authorization_handler_birthday">Birthday</label><input type="date" name="authorization_handler[birthday]" id="authorization_handler_birthday" />')
+      end
+
+      context "specifying the input type" do
+        it "renders it" do
+          html = builder.input(:document_number, as: :email_field)
+          expect(html).to eq('<label for="authorization_handler_document_number">Document number</label><input type="email" name="authorization_handler[document_number]" id="authorization_handler_document_number" />')
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe Authorization, :db do
+    let(:authorization) { build(:authorization) }
+
+    it "is valid" do
+      expect(authorization).to be_valid
+    end
+  end
+end

--- a/decidim-core/spec/services/decidim/authorization_handler_spec.rb
+++ b/decidim-core/spec/services/decidim/authorization_handler_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe AuthorizationHandler do
+    let(:handler) { described_class.new(params) }
+    let(:params) { {} }
+
+    describe "form_attributes" do
+      subject { handler.form_attributes }
+
+      it { is_expected.to match_array([:handler_name]) }
+      it { is_expected.to_not match_array([:id, :user]) }
+    end
+
+    describe "to_partial_path" do
+      subject { handler.to_partial_path }
+      it { is_expected.to eq("decidim/authorization/form") }
+    end
+
+    describe "handler_name" do
+      subject { handler.handler_name }
+      it { is_expected.to eq("decidim/authorization_handler") }
+    end
+
+    describe "user" do
+      subject { handler.user }
+      let(:user) { instance_double(Decidim::User) }
+      let(:params) { { user: user } }
+
+      it { is_expected.to eq(user) }
+    end
+
+    describe "metadata" do
+      subject { handler.metadata }
+      it { is_expected.to be_kind_of(Hash) }
+    end
+
+    describe "handler_for" do
+      subject { described_class.handler_for(name, params) }
+
+      context "when the handler does not exist" do
+        let(:name) { "decidim/foo" }
+        it { is_expected.to eq(nil) }
+      end
+
+      context "when the handler exists" do
+        context "when the handler is not valid" do
+          let(:name) { "decidim/authorization_handler" }
+          it { is_expected.to eq(nil) }
+        end
+
+        context "when the handler is valid" do
+          let(:name) { "decidim/dummy_authorization_handler" }
+
+          context "when the handler is not configured" do
+            before do
+              Decidim.config.authorization_handlers = []
+            end
+
+            it { is_expected.to eq(nil) }
+          end
+
+          context "when the handler is configured" do
+            it { is_expected.to be_kind_of(described_class) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/services/decidim/dummy_authorization_handler_spec.rb
+++ b/decidim-core/spec/services/decidim/dummy_authorization_handler_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "decidim/test/authorization_shared_examples"
+
+module Decidim
+  describe DummyAuthorizationHandler do
+    let(:handler) { described_class.new(params) }
+    let(:params) { {} }
+
+    it_behaves_like "an authorization handler"
+
+    describe "metadata" do
+      subject { handler.metadata }
+      let(:params) { { document_number: "123456" } }
+
+      it { is_expected.to eq(document_number: "123456") }
+    end
+
+    describe "authorized?" do
+      subject { handler.authorized? }
+      let(:params) { { document_number: document_number } }
+
+      context "when no document number" do
+        let(:document_number) { nil }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "when document number is not valid" do
+        let(:document_number) { "123456" }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context "when document number is valid" do
+        let(:document_number) { "123456X" }
+
+        it { is_expected.to eq(true) }
+      end
+    end
+  end
+end

--- a/decidim-core/spec/views/decidim/authorizations/new.html.erb_spec.rb
+++ b/decidim-core/spec/views/decidim/authorizations/new.html.erb_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+module Decidim
+  describe "decidim/authorizations/new" do
+    let(:handler) do
+      DummyAuthorizationHandler.new({})
+    end
+
+    before do
+      view.extend AuthorizationFormHelper
+      allow(view).to receive(:handler).and_return(handler)
+      allow(view).to receive(:authorizations_path).and_return("/authorizations")
+      allow(view).to receive(:participatory_processes_path).and_return("/processes")
+    end
+
+    context "when there's a partial to render the form" do
+      before do
+        filepath = File.join(Dir.pwd, "/app/views/", handler.to_partial_path).split("/")
+        filename = "_" + filepath.pop + ".html.erb"
+        @filepath = filepath.join("/")
+        FileUtils.mkdir_p(@filepath)
+        File.open(File.join(filepath, "/", filename), 'w') { |file| file.write("Custom partial") }
+      end
+
+      after do
+        FileUtils.rm_rf(@filepath)
+      end
+
+      it "renders the form with the partial" do
+        expect(render).to include("Custom partial")
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dummy_authorization_handler.rb
+++ b/decidim-dev/lib/decidim/dummy_authorization_handler.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Decidim
+  # A n example implementation of an AuthorizationHandler to be used in tests.
+  class DummyAuthorizationHandler < AuthorizationHandler
+    attribute :document_number, String
+    attribute :birthday, Date
+
+    validates :document_number, presence: true
+
+    def authorized?
+      valid? && document_number.end_with?("X")
+    end
+
+    def metadata
+      super.merge(document_number: document_number)
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/test/authorization_shared_examples.rb
+++ b/decidim-dev/lib/decidim/test/authorization_shared_examples.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+RSpec.shared_examples "an authorization handler" do
+  before do
+    unless respond_to?(:handler)
+      raise "You need to define `handler` (an instance of the authorization handler) in order to run the shared examples."
+    end
+  end
+
+  describe "authorized?" do
+    it "is implemented" do
+      expect do
+        handler.authorized?
+      end.to_not raise_error
+    end
+  end
+
+  describe "to_partial_path" do
+    subject { handler.to_partial_path }
+    it { is_expected.to be_kind_of(String) }
+  end
+
+  describe "handler_name" do
+    subject { handler.handler_name }
+    it { is_expected.to be_kind_of(String) }
+  end
+
+  describe "metadata" do
+    subject { handler.metadata }
+    it { is_expected.to be_kind_of(Hash) }
+  end
+end

--- a/decidim-dev/lib/decidim/test/rspec_support/authenticated_controller_context.rb
+++ b/decidim-dev/lib/decidim/test/rspec_support/authenticated_controller_context.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+RSpec.shared_context "authenticated user" do
+  let(:user) { create(:user, :confirmed) }
+
+  before do
+    @request.env["decidim.current_organization"] = user.organization
+    sign_in user, scope: :user
+  end
+end

--- a/decidim-dev/lib/decidim/test/rspec_support/authorization_handlers.rb
+++ b/decidim-dev/lib/decidim/test/rspec_support/authorization_handlers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require "decidim/dummy_authorization_handler"
+RSpec.configure do |config|
+  config.before(:each) do
+    Decidim.config.authorization_handlers = [Decidim::DummyAuthorizationHandler]
+  end
+end

--- a/decidim-dev/lib/decidim/test/rspec_support/engine_routes.rb
+++ b/decidim-dev/lib/decidim/test/rspec_support/engine_routes.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+module Decidim
+  # This is a quick hack so all controller specs have their engine's routes
+  # included as well as our Devise mapping.
+  module ControllerRequests
+    extend ActiveSupport::Concern
+
+    included do
+      begin
+        engine = (ENV["ENGINE_NAME"].to_s.split("-").map(&:capitalize).join("::") + "::Engine").constantize
+
+        if engine.respond_to?(:routes)
+          routes do
+            engine.routes
+          end
+        end
+      rescue NameError => _exception
+        puts "Failed to automatically inject routes for engine #{ENV["ENGINE_NAME"]}"
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Decidim::ControllerRequests, type: :controller
+
+  config.before :each, type: :controller do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+end

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -85,6 +85,10 @@ module Decidim
         remove_file "public/500.html"
       end
 
+      def authorization_handler
+        template "authorization_handler.rb", "app/services/example_authorization_handler.rb", force: true
+      end
+
       private
 
       def get_builder_class

--- a/lib/generators/decidim/templates/authorization_handler.rb
+++ b/lib/generators/decidim/templates/authorization_handler.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+# An example authorization handler used so that users can be verified against
+# third party systems.
+#
+# You should probably rename this class and file to match your needs.
+#
+# If you need a custom form to be rendered, you can create a file matching the
+# class name named "_form".
+#
+# Example:
+#
+#   A handler named Decidim::CensusHandler would look for its partial in:
+#   decidim/census/form
+#
+# When testing your authorization handler, add this line to be sure it has a
+# valid public api:
+#
+#   it_behaves_like "an authorization handler"
+#
+# See Decidim::AuthorizationHandler for more documentation.
+class ExampleAuthorizationHandler < Decidim::AuthorizationHandler
+  # Define the attributes you need for this authorization handler. Attributes
+  # are defined using Virtus.
+  #
+  # Example:
+  # attribute :document_number, String
+  # attribute :birthday, Date
+  #
+  # You can (and should) also define validations on each attribute:
+  #
+  # validates :document_number, presence: true
+  # validate :custom_method_to_validate_an_attribute
+
+  # The only method that needs to be implemented for an authorization handler.
+  # Here you can add your business logic to check if the authorization should
+  # be created or not, you should return a Boolean value.
+  def authorized?
+    raise NotImplementedError
+  end
+
+  # If you need to store any of the defined attributes in the authorization you
+  # can do it here.
+  #
+  # You must return a Hash that will be serialized to the authorization when
+  # it's created, and available though authorization.metadata
+  #
+  # def metadata
+  #   {}
+  # end
+end

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -2,4 +2,5 @@
 Decidim.configure do |config|
   config.application_name = "My Application Name"
   config.mailer_sender    = "change-me@domain.org"
+  config.authorization_handlers = [ExampleAuthorizationHandler]
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Create a _framework_ that allows developers to create different kind of authorizations for users, i.e.: a census authorization.
#### :dart: Acceptance criteria?
#### :clipboard: Subtasks
- [x] Auto-generate a form for an authorization
- [x] Create an authorization if the AuthorizationHandler is valid
- [x] Infer the field type for the form 
- [x] Allow a custom template to render the form
- [x] Save metadata to an authorization
- [x] Users can manage their authorizations
- [x] Handle wrong handler name params
- [x] Specs
- [x] Docs
- [x] Feature specs with a dummy handler
- [x] Docs on how to add your own handler
- [x] Add a template authorization to generated apps

#### :ghost: GIF

![horse](https://cloud.githubusercontent.com/assets/5254/19513308/c71b6db0-95ef-11e6-88b3-c44baf4868e5.gif)
### 📷  Screenshots

![authorizations list](https://i.imgur.com/vuCnbds.png)
