### PR TITLE
Use a `dev` locale for translations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ services:
 
 language: ruby
 
+branches:
+  except:
+    - translations
+
 cache:
   bundler: true
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Build Status](https://travis-ci.org/codegram/decidim.svg?branch=master)](https://travis-ci.org/codegram/decidim)
 [![codecov](https://codecov.io/gh/codegram/decidim/branch/master/graph/badge.svg)](https://codecov.io/gh/codegram/decidim)
 [![Dependency Status](https://gemnasium.com/badges/github.com/codegram/decidim.svg)](https://gemnasium.com/github.com/codegram/decidim)
+[![Crowdin](https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg)](https://crowdin.com/project/decidim/invite)
 
 ## Requirements
 

--- a/decidim-admin/config/i18n-tasks.yml
+++ b/decidim-admin/config/i18n-tasks.yml
@@ -1,7 +1,7 @@
 # i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
 
 # The "main" locale.
-base_locale: en
+base_locale: dev
 ## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
 # locales: [es, fr]
 ## Reporting locale, default: en. Available: en, ru.

--- a/decidim-admin/config/locales/dev.yml
+++ b/decidim-admin/config/locales/dev.yml
@@ -1,5 +1,5 @@
 ---
-en:
+dev:
   activerecord:
     attributes:
       decidim/participatory_process:

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require "spec_helper"
 
@@ -6,48 +7,37 @@ module Decidim
     describe ParticipatoryProcessForm do
       let(:title) do
         {
-          en: "Title",
-          es: "Título",
-          ca: "Títol"
+          dev: "Title"
         }
       end
+
       let(:subtitle) do
         {
-          en: "Subtitle",
-          es: "Subtítulo",
-          ca: "Subtítol"
+          dev: "Subtitle"
         }
       end
+
       let(:description) do
         {
-          en: "Description",
-          es: "Descripción",
-          ca: "Descripció"
+          dev: "Description"
         }
       end
+
       let(:short_description) do
         {
-          en: "Short description",
-          es: "Descripción corta",
-          ca: "Descripció curta"
+          dev: "Short description"
         }
       end
+
       let(:slug) { "slug" }
+
       let(:attributes) do
         {
           "participatory_process" => {
-            "title_en" => title[:en],
-            "title_es" => title[:es],
-            "title_ca" => title[:ca],
-            "subtitle_en" => subtitle[:en],
-            "subtitle_es" => subtitle[:es],
-            "subtitle_ca" => subtitle[:ca],
-            "description_en" => description[:en],
-            "description_es" => description[:es],
-            "description_ca" => description[:ca],
-            "short_description_en" => short_description[:en],
-            "short_description_es" => short_description[:es],
-            "short_description_ca" => short_description[:ca],
+            "title_dev" => title[:dev],
+            "subtitle_dev" => subtitle[:dev],
+            "description_dev" => description[:dev],
+            "short_description_dev" => short_description[:dev],
             "slug" => slug
           }
         }
@@ -56,14 +46,16 @@ module Decidim
       subject { described_class.from_params(attributes) }
 
       context "when everything is OK" do
+        before do
+          subject.valid?
+        end
         it { is_expected.to be_valid }
       end
 
       context "when some language in title is missing" do
         let(:title) do
           {
-            en: "Title",
-            ca: "Títol"
+            en: "Title"
           }
         end
 
@@ -73,8 +65,7 @@ module Decidim
       context "when some language in subtitle is missing" do
         let(:subtitle) do
           {
-            en: "Subtitle",
-            ca: "Subtítol"
+            en: "Subtitle"
           }
         end
 
@@ -84,7 +75,7 @@ module Decidim
       context "when some language in description is missing" do
         let(:description) do
           {
-            ca: "Descripció"
+            en: "Descripció"
           }
         end
 

--- a/decidim-core/app/views/layouts/decidim/_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_header.html.erb
@@ -30,7 +30,7 @@
                   <% if available_locales.length > 1 %>
                     <ul class="menu is-dropdown-submenu">
                     <% available_locales.each do |locale| %>
-                      <li><%= link_to t(locale, scope: "locales"), locale_path(locale: locale), method: :post%></li>
+                      <li><%= link_to t("locale.name", locale: locale), locale_path(locale: locale), method: :post%></li>
                     <% end %>
                   <% end %>
                   </ul>

--- a/decidim-core/config/i18n-tasks.yml
+++ b/decidim-core/config/i18n-tasks.yml
@@ -1,7 +1,7 @@
 # i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
 
 # The "main" locale.
-base_locale: en
+base_locale: dev
 ## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
 # locales: [es, fr]
 ## Reporting locale, default: en. Available: en, ru.

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -78,10 +78,8 @@ ca:
           active_step: "Fase actual:"
           more_info: Més informació
           take_part: Participa
-  locales:
-    ca: Català
-    en: English
-    es: Castellano
+  locale:
+    name: Català
   pages:
     '404':
       back_home: Tornar a l'inici

--- a/decidim-core/config/locales/dev.yml
+++ b/decidim-core/config/locales/dev.yml
@@ -1,5 +1,5 @@
 ---
-en:
+dev:
   activerecord:
     attributes:
       decidim/user:

--- a/decidim-core/config/locales/dev.yml
+++ b/decidim-core/config/locales/dev.yml
@@ -74,10 +74,8 @@ dev:
           active_step: "Current step:"
           more_info: More info
           take_part: Take part
-  locales:
-    ca: Català
-    en: English
-    es: Castellano
+  locale:
+    name: Development
   pages:
     '404':
       back_home: Back home

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -78,10 +78,8 @@ es:
           active_step: "Fase actual:"
           more_info: Más información
           take_part: Participa
-  locales:
-    ca: Català
-    en: English
-    es: Castellano
+  locale:
+    name: Castellano
   pages:
     '404':
       back_home: Volver al inicio

--- a/decidim-core/spec/controllers/locales_controller_spec.rb
+++ b/decidim-core/spec/controllers/locales_controller_spec.rb
@@ -9,6 +9,8 @@ module Decidim
     before do
       @request.env["decidim.current_organization"] = organization
       @request.env["devise.mapping"] = Devise.mappings[:user]
+      I18n.available_locales = %{en ca es}
+      I18n.default_locale = :en
     end
 
     describe "POST create" do

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
   factory :participatory_process, class: Decidim::ParticipatoryProcess do
     sequence(:title) { |n| { dev: "Participatory Process ##{n}" } }
     sequence(:slug) { |n| { dev: "participatory-process-#{n}" } }
-    subtitle          dev: "Subtitle", ca: "Subtítol"
+    subtitle          dev: "Subtitle"
     short_description dev: "<p>Short description</p>"
     description       dev: "<p>Description</p>"
     hero_image { Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "decidim-dev", "spec", "support", "city.jpeg")) }
@@ -41,7 +41,7 @@ FactoryGirl.define do
     password_confirmation "password1234"
     name                  "Responsible Citizen"
     organization
-    locale                "en"
+    locale                "dev"
     tos_agreement         "1"
 
     trait :confirmed do

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 FactoryGirl.define do
   factory :organization, class: Decidim::Organization do
     sequence(:name) { |n| "Citizen Corp ##{n}" }
@@ -6,11 +7,11 @@ FactoryGirl.define do
   end
 
   factory :participatory_process, class: Decidim::ParticipatoryProcess do
-    sequence(:title) { |n| { en: "Participatory Process ##{n}", ca: "Procés participatiu ##{n}", es: "Proceso participativo ##{n}" } }
-    sequence(:slug) { |n| { en: "participatory-process-#{n}" } }
-    subtitle          en: "Subtitle", ca: "Subtítol", es: "Subtítulo"
-    short_description en: "<p>Short description</p>", ca: "<p>Descripció curta</p>", es: "<p>Descripción corta</p>"
-    description       en: "<p>Description</p>", ca: "<p>Descripció</p>", es: "<p>Descripción</p>"
+    sequence(:title) { |n| { dev: "Participatory Process ##{n}" } }
+    sequence(:slug) { |n| { dev: "participatory-process-#{n}" } }
+    subtitle          dev: "Subtitle", ca: "Subtítol"
+    short_description dev: "<p>Short description</p>"
+    description       dev: "<p>Description</p>"
     hero_image { Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "decidim-dev", "spec", "support", "city.jpeg")) }
     banner_image { Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "decidim-dev", "spec", "support", "city2.jpeg")) }
     organization
@@ -21,9 +22,9 @@ FactoryGirl.define do
   end
 
   factory :participatory_process_step, class: Decidim::ParticipatoryProcessStep do
-    sequence(:title) { |n| { en: "Participatory Process Step ##{n}", ca: "Fase de procés participatiu ##{n}", es: "Fase de proceso participativo ##{n}" } }
-    short_description en: "<p>Short description</p>", ca: "<p>Descripció curta</p>", es: "<p>Descripción corta</p>"
-    description       en: "<p>Description</p>", ca: "<p>Descripció</p>", es: "<p>Descripción</p>"
+    sequence(:title) { |n| { dev: "Participatory Process Step ##{n}" } }
+    short_description dev: "<p>Short description</p>"
+    description       dev: "<p>Description</p>"
     start_date 1.month.ago.at_midnight
     end_date 2.month.from_now.at_midnight
     position nil

--- a/decidim-core/spec/features/locales_spec.rb
+++ b/decidim-core/spec/features/locales_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require "spec_helper"
 
@@ -6,6 +7,7 @@ describe "Locales", type: :feature do
     let(:organization) { create(:organization) }
 
     before do
+      I18n.available_locales = %w{en es ca}
       switch_to_host(organization.host)
       visit decidim.root_path
     end

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require "spec_helper"
 
@@ -7,8 +8,8 @@ describe "Participatory Processes", type: :feature do
     create(
       :participatory_process,
       organization: organization,
-      description: { en: "Description", ca: "Descripció", es: "Descripción" },
-      short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
+      description: { dev: "Description" },
+      short_description: { dev: "Short description" }
     )
   end
 
@@ -26,7 +27,7 @@ describe "Participatory Processes", type: :feature do
     it "lists all the highlighted processes" do
       within "#highlighted-processes" do
         expect(page).to have_content("Highlighted processes")
-        expect(page).to have_content(translated(promoted_process.title, locale: :en))
+        expect(page).to have_content(translated(promoted_process.title, locale: :dev))
         expect(page).to have_selector("article.card--full", count: 1)
       end
     end
@@ -34,14 +35,14 @@ describe "Participatory Processes", type: :feature do
     it "lists all the processes" do
       within "#processes-grid" do
         expect(page).to have_content("2 processes")
-        expect(page).to have_content(translated(participatory_process.title, locale: :en))
-        expect(page).to have_content(translated(promoted_process.title, locale: :en))
+        expect(page).to have_content(translated(participatory_process.title, locale: :dev))
+        expect(page).to have_content(translated(promoted_process.title, locale: :dev))
         expect(page).to have_selector("article.card", count: 2)
       end
     end
 
     it "links to the individial process page" do
-      click_link(translated(participatory_process.title, locale: :en))
+      click_link(translated(participatory_process.title, locale: :dev))
 
       expect(current_path).to eq decidim.participatory_process_path(participatory_process)
     end
@@ -73,10 +74,10 @@ describe "Participatory Processes", type: :feature do
 
     it "shows the details of the given process" do
       within "main.wrapper" do
-        expect(page).to have_content(translated(participatory_process.title, locale: :en))
-        expect(page).to have_content(translated(participatory_process.subtitle, locale: :en))
-        expect(page).to have_content(translated(participatory_process.description, locale: :en))
-        expect(page).to have_content(translated(participatory_process.short_description, locale: :en))
+        expect(page).to have_content(translated(participatory_process.title, locale: :dev))
+        expect(page).to have_content(translated(participatory_process.subtitle, locale: :dev))
+        expect(page).to have_content(translated(participatory_process.description, locale: :dev))
+        expect(page).to have_content(translated(participatory_process.short_description, locale: :dev))
         expect(page).to have_content(participatory_process.hashtag)
       end
     end

--- a/decidim-dev/lib/decidim/test/i18n_spec.rb
+++ b/decidim-dev/lib/decidim/test/i18n_spec.rb
@@ -2,7 +2,7 @@
 require "i18n/tasks"
 
 RSpec.describe "I18n" do
-  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:i18n) { I18n::Tasks::BaseTask.new(locale: "dev") }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
 

--- a/decidim-dev/lib/decidim/test/rspec_support/i18n.rb
+++ b/decidim-dev/lib/decidim/test/rspec_support/i18n.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
   config.before(:suite) do
+    I18n.available_locales = [:dev, :en]
+    I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
+    I18n.locale = :dev
+    I18n.fallbacks.map("dev" => "en")
     I18n.config.enforce_available_locales = false
   end
 

--- a/decidim-dev/lib/decidim/test/rspec_support/i18n.rb
+++ b/decidim-dev/lib/decidim/test/rspec_support/i18n.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
   config.before(:suite) do
-    I18n.available_locales = [:dev, :en]
     I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
-    I18n.locale = :dev
     I18n.fallbacks.map("dev" => "en")
     I18n.config.enforce_available_locales = false
   end
 
-  config.around(:each) do |example|
-    previous_locale = I18n.locale
-    example.run
-    I18n.locale = previous_locale
+  config.before(:each) do
+    I18n.available_locales = [:dev, :en]
+    I18n.locale = :dev
   end
 end

--- a/decidim-dev/lib/generators/decidim/dummy_generator.rb
+++ b/decidim-dev/lib/generators/decidim/dummy_generator.rb
@@ -45,7 +45,7 @@ module Decidim
 
       def set_locales
         inject_into_file "#{dummy_path}/config/application.rb", after: "class Application < Rails::Application" do
-          "\n    config.i18n.available_locales = %w(dev)\n    config.i18n.default_locale = :dev"
+          "\n    config.i18n.available_locales = %w(dev en)\n    config.i18n.default_locale = :dev"
         end
       end
 

--- a/decidim-dev/lib/generators/decidim/dummy_generator.rb
+++ b/decidim-dev/lib/generators/decidim/dummy_generator.rb
@@ -45,7 +45,7 @@ module Decidim
 
       def set_locales
         inject_into_file "#{dummy_path}/config/application.rb", after: "class Application < Rails::Application" do
-          "\n    config.i18n.available_locales = %w(en ca es)\n    config.i18n.default_locale = :en"
+          "\n    config.i18n.available_locales = %w(dev)\n    config.i18n.default_locale = :dev"
         end
       end
 

--- a/decidim-system/config/i18n-tasks.yml
+++ b/decidim-system/config/i18n-tasks.yml
@@ -1,7 +1,7 @@
 # i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
 
 # The "main" locale.
-base_locale: en
+base_locale: dev
 ## All available locales are inferred from the data by default. Alternatively, specify them explicitly:
 # locales: [es, fr]
 ## Reporting locale, default: en. Available: en, ru.

--- a/decidim-system/config/locales/dev.yml
+++ b/decidim-system/config/locales/dev.yml
@@ -1,5 +1,5 @@
 ---
-en:
+dev:
   decidim:
     system:
       actions:


### PR DESCRIPTION
#### :tophat: What? Why?

Crowding doesn't allow you to rewrite the original project's strings, so we miss the opportunity to proof-read english translations.

This adds a fake `dev` locale which gets used in tests, so we can now use english for the real translations ;)

Bonus points: We won't break tests cause we'll probably never change dev locales! Yay!
#### :ghost: GIF

![](https://media.giphy.com/media/3o6EhWeei7wsp2jc1G/giphy.gif)
