### PR TITLE
Move decidim config to core

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -7,4 +7,25 @@ module Decidim
   autoload :TranslatableAttributes, "decidim/translatable_attributes"
   autoload :FormBuilder, "decidim/form_builder"
   autoload :DeviseFailureApp, "decidim/devise_failure_app"
+  include ActiveSupport::Configurable
+
+  # Loads seeds from all engines.
+  def self.seed!
+    Rails.application.railties.select do |railtie|
+      railtie.respond_to?(:load_seed) && railtie.class.name.include?("Decidim::")
+    end.each(&:load_seed)
+  end
+
+  # Exposes a configuration option: The application name String.
+  config_accessor :application_name
+
+  # Exposes a configuration option: The email String to use as sender in all
+  # the mails.
+  config_accessor :mailer_sender
+
+  # Exposes a configuration option: an Array of `cancancan`'s Ability classes
+  # that will be automatically included to the base `Decidim::Ability` class.
+  config_accessor :abilities do
+    []
+  end
 end

--- a/lib/decidim.rb
+++ b/lib/decidim.rb
@@ -5,25 +5,4 @@ require "decidim/admin"
 
 # Module declaration.
 module Decidim
-  include ActiveSupport::Configurable
-
-  # Loads seeds from all engines.
-  def self.seed!
-    Rails.application.railties.select do |railtie|
-      railtie.respond_to?(:load_seed) && railtie.class.name.include?("Decidim::")
-    end.each(&:load_seed)
-  end
-
-  # Exposes a configuration option: The application name String.
-  config_accessor :application_name
-
-  # Exposes a configuration option: The email String to use as sender in all
-  # the mails.
-  config_accessor :mailer_sender
-
-  # Exposes a configuration option: an Array of `cancancan`'s Ability classes
-  # that will be automatically included to the base `Decidim::Ability` class.
-  config_accessor :abilities do
-    []
-  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Decidim's configuration should be ultimately held at `core` instead of the meta-gem - this way, we allow unplugging components that are considered optional, even though if they reside in the main repo. Think of `decidim-system` - you could have a deployment where you'd only want to have `decidim-core` and `decidim-admin` deployed.

#### :ghost: GIF
![](https://media.giphy.com/media/14aUO0Mf7dWDXW/giphy.gif)

