### PR TITLE
Codeclimate coverage reporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,5 @@ gemspec path: "decidim-dev"
 
 gem "rubocop", "~> 0.45"
 gem "rspec_junit_formatter", "0.2.3"
-gem "simplecov", "~> 0.12"
-gem "codecov", "~> 0.1.6"
 
 eval(File.read(File.join(File.dirname(__FILE__), "Gemfile.common")))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ PATH
       bullet (~> 5)
       byebug
       capybara (~> 2.10.0)
+      codeclimate-test-reporter (~> 1.0.0.pre.rc2)
       database_cleaner (~> 1.5.0)
       factory_girl_rails
       i18n-tasks (~> 0.9.6)
@@ -168,10 +169,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
-    codecov (0.1.6)
-      json
-      simplecov
-      url
+    codeclimate-test-reporter (1.0.0.pre.rc2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.2)
@@ -194,7 +192,6 @@ GEM
       actionmailer (>= 4.0.0)
       devise (>= 4.0.0)
     diff-lcs (1.2.5)
-    docile (1.1.5)
     easy_translate (0.5.0)
       json
       thread
@@ -349,11 +346,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    simplecov (0.12.0)
-      docile (~> 1.1.0)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -381,7 +373,6 @@ GEM
       thread_safe (~> 0.1)
     unicode-display_width (1.1.1)
     uniform_notifier (1.10.0)
-    url (0.3.2)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -402,7 +393,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.12)
-  codecov (~> 0.1.6)
   decidim!
   decidim-admin!
   decidim-core!
@@ -413,7 +403,6 @@ DEPENDENCIES
   rspec (~> 3.0)
   rspec_junit_formatter (= 0.2.3)
   rubocop (~> 0.45)
-  simplecov (~> 0.12)
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://img.shields.io/travis/AjuntamentdeBarcelona/decidim.svg)](https://travis-ci.org/AjuntamentdeBarcelona/decidim)
 [![Code Climate](https://img.shields.io/codeclimate/github/AjuntamentdeBarcelona/decidim.svg)](https://codeclimate.com/github/AjuntamentdeBarcelona/decidim/trends)
 [![Issue Count](https://img.shields.io/codeclimate/issues/github/AjuntamentdeBarcelona/decidim.svg)](https://codeclimate.com/github/AjuntamentdeBarcelona/decidim/issues)
-[![codecov](https://img.shields.io/codecov/c/github/AjuntamentdeBarcelona/decidim.svg)](https://codecov.io/gh/AjuntamentdeBarcelona/decidim)
+[![Code Climate Coverage](https://img.shields.io/codeclimate/coverage/github/AjuntamentdeBarcelona/decidim.svg)](https://codeclimate.com/github/AjuntamentdeBarcelona/decidim)
 [![Dependency Status](https://img.shields.io/gemnasium/AjuntamentdeBarcelona/decidim.svg)](https://gemnasium.com/github.com/AjuntamentdeBarcelona/decidim)
 
 ### Project management

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "capybara", "~> 2.10.0"
   s.add_dependency "rspec-rails", "~> 3.5"
   s.add_dependency "byebug"
+  s.add_dependency "codeclimate-test-reporter", "~> 1.0.0.pre.rc2"
   s.add_dependency "wisper-rspec"
   s.add_dependency "listen", "~> 3.1.0"
   s.add_dependency "launchy"

--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -2,11 +2,8 @@
 ENV["RAILS_ENV"] ||= "test"
 
 if ENV["CI"]
-  require "simplecov"
-  SimpleCov.start
-
-  require "codecov"
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  require "codeclimate-test-reporter"
+  CodeClimate::TestReporter.start
 end
 
 begin


### PR DESCRIPTION
#### :tophat: What? Why?
Instead of `codecov`, which seems to be performing very poorly, let's switch to code climate's coverage reporting.

#### :ghost: GIF
![](https://media.giphy.com/media/bcXoQSO8lx7tm/giphy.gif)
