### PR TITLE
Properly truncate HTML text

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ PATH
       roadie-rails (~> 1.0)
       sass-rails (~> 5.0.0)
       sprockets-es6 (~> 0.9.2)
+      truncato (~> 0.7.8)
       turbolinks (~> 5.0.0, >= 5.0.0.1)
 
 PATH
@@ -233,6 +234,7 @@ GEM
     graphql (1.1.0)
     high_voltage (3.0.0)
     highline (1.7.8)
+    htmlentities (4.3.4)
     i18n (0.7.0)
     i18n-tasks (0.9.6)
       activesupport (>= 4.0.2)
@@ -392,6 +394,9 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.5)
     tins (1.12.0)
+    truncato (0.7.8)
+      htmlentities (~> 4.3.1)
+      nokogiri (~> 1.6.1)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)

--- a/decidim-core/app/helpers/decidim/application_helper.rb
+++ b/decidim-core/app/helpers/decidim/application_helper.rb
@@ -1,9 +1,24 @@
+# encoding: utf-8
 # frozen_string_literal: true
 module Decidim
   # Main module to add application-wide helpers.
   module ApplicationHelper
-    def link_to_organization(organization)
-      link_to(organization.name, root_url(host: organization.host))
+    # Truncates a given text respecting its HTML tags.
+    #
+    # text    - The String text to be truncated.
+    # options - A Hash with the options to truncate the text (default: {}):
+    #           :length - An Integer number with the max length of the text.
+    #           :separator - A String to append to the text when it's being
+    #           truncated. See `truncato` gem for more options.
+    #
+    # Returns a String.
+    def html_truncate(text, options = {})
+      options[:max_length] = options.delete(:length) || options[:max_length]
+      options[:tail] = options.delete(:separator) || options[:tail] || "..."
+      options[:count_tags] ||= false
+      options[:count_tail] ||= false
+
+      Truncato.truncate(text, options)
     end
   end
 end

--- a/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
@@ -5,7 +5,7 @@
         <%= link_to participatory_process_path(promoted_process), class: "card__link" do %>
           <h2 class="card__title"><%= translated_attribute promoted_process.title %></h2>
         <% end %>
-        <%= truncate(translated_attribute(promoted_process.description).html_safe, length: 630, separator: ' ') %>
+        <%= html_truncate(translated_attribute(promoted_process.description), length: 630, separator: ' ') %>
         <%= link_to participatory_process_path(promoted_process), class: "button secondary small hollow card__button" do %>
           <%= t(".more_info", scope: "layouts") %>
         <% end %>

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -36,6 +36,8 @@ Gem::Specification.new do |s|
   s.add_dependency "date_validator", "~> 0.9.0"
   s.add_dependency "sprockets-es6", "~> 0.9.2"
   s.add_dependency "cancancan", "~> 1.15.0"
+  s.add_dependency "truncato", "~> 0.7.8"
+
 
   s.add_development_dependency "decidim-dev", Decidim.version
 end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -23,6 +23,7 @@ require "rails-i18n"
 require "date_validator"
 require "sprockets/es6"
 require "cancancan"
+require "truncato"
 
 module Decidim
   module Core

--- a/decidim-core/spec/helpers/decidim/application_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/application_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "spec_helper"
+require_relative "../../../app/helpers/decidim/application_helper"
+
+module Decidim
+  describe ApplicationHelper do
+    describe "#html_truncate" do
+      let(:helper) do
+        Class.new.tap do |v|
+          v.extend(Decidim::ApplicationHelper)
+        end
+      end
+
+      subject { helper.html_truncate(text, length: length) }
+
+      context "truncating HTML text" do
+        let(:text) { "<p>Hello, this is dog</p>" }
+        let(:length) { 5 }
+
+        it { is_expected.to eq("<p>Hello...</p>") }
+      end
+
+      context "truncating regular text" do
+        let(:text) { "Hello, this is dog" }
+        let(:length) { 5 }
+
+        it { is_expected.to eq("Hello...") }
+      end
+
+      context "with a custom separator" do
+        subject { helper.html_truncate(text, length: length, separator: " ...read more") }
+        let(:text) { "Hello, this is dog" }
+        let(:length) { 5 }
+
+        it { is_expected.to eq("Hello ...read more") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Use HTMLTruncator gem so we can truncate text that has HTML.

#### :pushpin: Related Issues
- Fixes #114 

#### :ghost: GIF
![](https://i.imgur.com/Owh4kCR.gif)

