### PR TITLE
Make locale mandatory in LocalizedString

### DIFF
--- a/decidim-api/app/types/decidim/api/translated_field_type.rb
+++ b/decidim-api/app/types/decidim/api/translated_field_type.rb
@@ -32,7 +32,7 @@ module Decidim
       field :translation do
         type types.String
         description "Returns a single translation given a locale."
-        argument :locale, types.String, "A locale to search for"
+        argument :locale, !types.String, "A locale to search for"
 
         resolve ->(obj, args, _ctx) {
           translations = obj.stringify_keys


### PR DESCRIPTION
#### :tophat: What? Why?
Make locale argument mandatory in `TranslatedFieldType`.

#### :ghost: GIF
![](https://media.giphy.com/media/l3vQYI6VJBgORn74k/giphy.gif)

