### PR TITLE
Lock rails version to a higher one

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,8 +18,8 @@ PATH
       decidim-api (= 0.0.1.alpha9)
       decidim-core (= 0.0.1.alpha9)
       decidim-system (= 0.0.1.alpha9)
-      rails (~> 5.0.0)
-      rails-i18n (~> 5.0.0)
+      rails (~> 5.0.0, >= 5.0.0.1)
+      rails-i18n (~> 5.0.0, >= 5.0.0.1)
 
 PATH
   remote: decidim-admin
@@ -36,10 +36,10 @@ PATH
       foundation_rails_helper (~> 2.0.0)
       jbuilder (~> 2.5)
       jquery-rails (~> 4.0)
-      rails (~> 5.0.0)
+      rails (~> 5.0.0, >= 5.0.0.1)
       rectify (~> 0.7.1)
       sass-rails (~> 5.0.0)
-      turbolinks (~> 5.0.0)
+      turbolinks (~> 5.0.0, >= 5.0.0.1)
 
 PATH
   remote: decidim-api
@@ -49,7 +49,7 @@ PATH
       graphiql-rails (~> 1.3.0)
       graphql (~> 0.19.4)
       rack-cors (~> 0.4.0)
-      rails (~> 5.0.0)
+      rails (~> 5.0.0, >= 5.0.0.1)
 
 PATH
   remote: decidim-core
@@ -67,13 +67,13 @@ PATH
       jbuilder (~> 2.5)
       jquery-rails (~> 4.0)
       pg (~> 0.19.0)
-      rails (~> 5.0.0)
+      rails (~> 5.0.0, >= 5.0.0.1)
       rectify (~> 0.7.1)
       redis (~> 3.3.0)
       roadie-rails (~> 1.0)
       sass-rails (~> 5.0.0)
       sprockets-es6 (~> 0.9.2)
-      turbolinks (~> 5.0.0)
+      turbolinks (~> 5.0.0, >= 5.0.0.1)
 
 PATH
   remote: decidim-dev
@@ -104,10 +104,10 @@ PATH
       foundation_rails_helper (~> 2.0.0)
       jbuilder (~> 2.5)
       jquery-rails (~> 4.0)
-      rails (~> 5.0.0)
+      rails (~> 5.0.0, >= 5.0.0.1)
       rectify (~> 0.7.1)
       sass-rails (~> 5.0.0)
-      turbolinks (~> 5.0.0)
+      turbolinks (~> 5.0.0, >= 5.0.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-core", Decidim.version
-  s.add_dependency "rails", Decidim.rails_version
+  s.add_dependency "rails", *Decidim.rails_version
   s.add_dependency "devise", "~> 4.2"
   s.add_dependency "devise-i18n", "~> 1.1.0"
   s.add_dependency "rectify", "~> 0.7.1"
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "foundation-rails", "~> 6.2.4.0"
   s.add_dependency "sass-rails", "~> 5.0.0"
   s.add_dependency "jquery-rails", "~> 4.0"
-  s.add_dependency "turbolinks", Decidim.rails_version
+  s.add_dependency "turbolinks", *Decidim.rails_version
   s.add_dependency "jbuilder", "~> 2.5"
   s.add_dependency "foundation_rails_helper", "~> 2.0.0"
   s.add_dependency "active_link_to", "~> 1.0.0"

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-core", Decidim.version
-  s.add_dependency "rails", Decidim.rails_version
+  s.add_dependency "rails", *Decidim.rails_version
   s.add_dependency "graphql", "~> 0.19.4"
   s.add_dependency "graphiql-rails", "~> 1.3.0"
   s.add_dependency "rack-cors", "~> 0.4.0"

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -17,14 +17,14 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", Decidim.rails_version
+  s.add_dependency "rails", *Decidim.rails_version
   s.add_dependency "devise", "~> 4.2"
   s.add_dependency "devise-i18n", "~> 1.1.0"
   s.add_dependency "rectify", "~> 0.7.1"
   s.add_dependency "foundation-rails", "~> 6.2.4.0"
   s.add_dependency "sass-rails", "~> 5.0.0"
   s.add_dependency "jquery-rails", "~> 4.0"
-  s.add_dependency "turbolinks", Decidim.rails_version
+  s.add_dependency "turbolinks", *Decidim.rails_version
   s.add_dependency "carrierwave", "~> 1.0.0.rc"
   s.add_dependency "jbuilder", "~> 2.5"
   s.add_dependency "foundation_rails_helper", "~> 2.0.0"

--- a/decidim-core/lib/decidim/core/version.rb
+++ b/decidim-core/lib/decidim/core/version.rb
@@ -6,6 +6,6 @@ module Decidim
   end
 
   def self.rails_version
-    "~> 5.0.0"
+    ["~> 5.0.0", ">= 5.0.0.1"]
   end
 end

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-core", Decidim.version
-  s.add_dependency "rails", Decidim.rails_version
+  s.add_dependency "rails", *Decidim.rails_version
   s.add_dependency "devise", "~> 4.2"
   s.add_dependency "devise-i18n", "~> 1.1.0"
   s.add_dependency "rectify", "~> 0.7.1"
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "foundation-rails", "~> 6.2.4.0"
   s.add_dependency "sass-rails", "~> 5.0.0"
   s.add_dependency "jquery-rails", "~> 4.0"
-  s.add_dependency "turbolinks", Decidim.rails_version
+  s.add_dependency "turbolinks", *Decidim.rails_version
   s.add_dependency "jbuilder", "~> 2.5"
   s.add_dependency "foundation_rails_helper", "~> 2.0.0"
   s.add_dependency "active_link_to", "~> 1.0.0"


### PR DESCRIPTION
#### :tophat: What? Why?
In order to be more restrictive in which Rails version to use, let's turn `rails_version` into an array - this allows us more freedom in version restrictions.

#### :ghost: GIF
![](https://media.giphy.com/media/1zngj0du8qG4M/giphy.gif)

