### PR TITLE
Fix steps reordering

### DIFF
--- a/decidim-admin/app/assets/javascripts/decidim/admin/sort_steps.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/sort_steps.js.es6
@@ -8,14 +8,20 @@
 $(() => {
   const sortableElement = $('#steps tbody');
 
-  if (sortableElement) {
+  if (sortableElement[0]) {
     const sortUrl = sortableElement.data('sort-url');
 
     sortable('#steps tbody', {
       placeholder: $('<tr style="border-style: dashed; border-color: #000"><td colspan="4">&nbsp;</td></tr>')[0],
     })[0].addEventListener('sortupdate', (e) => {
-      const order = $(e.target).children().map(() => $(this).data('id')).toArray();
-      $.ajax({ method: 'POST', url: sortUrl, data: { items_ids: order } });
+      const order = $(e.target).children().map((index, child) => $(child).data('id')).toArray();
+
+      $.ajax({
+        method: 'POST',
+        url: sortUrl,
+        contentType: 'application/json',
+        data: JSON.stringify({ items_ids: order }) }
+      );
     });
   }
 });

--- a/decidim-admin/app/commands/decidim/admin/reorder_participatory_process_steps.rb
+++ b/decidim-admin/app/commands/decidim/admin/reorder_participatory_process_steps.rb
@@ -34,7 +34,10 @@ module Decidim
           hash.update(id => { position: index })
         end
 
-        collection.update(data.keys, data.values)
+        ParticipatoryProcessStep.transaction do
+          collection.update_all(position: nil)
+          collection.update(data.keys, data.values)
+        end
       end
 
       def order

--- a/decidim-core/db/migrate/20161107152228_remove_not_null_on_step_position.rb
+++ b/decidim-core/db/migrate/20161107152228_remove_not_null_on_step_position.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullOnStepPosition < ActiveRecord::Migration[5.0]
+  def change
+    change_column :decidim_participatory_process_steps, :position, :integer, null: true
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
A couple of things:

1. Steps reordering was broken when no steps were found. This broke JS and stopped all other JS form working.
1. The actual reordering in the server side was also broken sometimes when setting the new position to the steps. I had to remove the `NOT NULL` constraint on the `position` column in order to make the reordering work.

#### :ghost: GIF
![](https://media.giphy.com/media/WzH5B9UvjACju/giphy.gif)

