### PR TITLE
Locale fixes

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_header.html.erb
@@ -29,7 +29,7 @@
                   <%= link_to t(current_locale, scope: "locales") %>
                   <% if available_locales.length > 1 %>
                     <ul class="menu is-dropdown-submenu">
-                    <% available_locales.each do |locale| %>
+                    <% (available_locales - [I18n.locale.to_s]).each do |locale| %>
                       <li><%= link_to t(locale, scope: "locales"), locale_path(locale: locale), method: :post%></li>
                     <% end %>
                   <% end %>

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -35,4 +35,9 @@ module Decidim
   config_accessor :authorization_handlers do
     []
   end
+
+  # Exposes a configuration option: The application name String.
+  config_accessor :available_locales do
+    %w{en ca es}
+  end
 end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -38,6 +38,6 @@ module Decidim
 
   # Exposes a configuration option: The application name String.
   config_accessor :available_locales do
-    %w{en ca es}
+    %w(en ca es)
   end
 end

--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -65,6 +65,10 @@ module Decidim
           config.abilities << Abilities::Everyone
         end
       end
+
+      initializer "decidim.locales" do |app|
+        app.config.i18n.available_locales = Decidim.config.available_locales
+      end
     end
   end
 end

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -3,4 +3,5 @@ Decidim.configure do |config|
   config.application_name = "My Application Name"
   config.mailer_sender    = "change-me@domain.org"
   config.authorization_handlers = [ExampleAuthorizationHandler]
+  # config.available_locales = %{en ca es}
 end

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -3,5 +3,7 @@ Decidim.configure do |config|
   config.application_name = "My Application Name"
   config.mailer_sender    = "change-me@domain.org"
   config.authorization_handlers = [ExampleAuthorizationHandler]
+
+  # Uncomment this lines to set your preferred locales
   # config.available_locales = %{en ca es}
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This is actually a gardening PR fixing several issues related to locales.

#### :clipboard: Subtasks
- [x] Support a fixed set of locales (overridable by the user) by default. This will make sure we don't ever leak locales set by `devise-i18n` or `rails-i18n` and provides a smoother experience for the implementer.
- [x] Only show the rest of the languages on the switcher.

### :camera: Screenshots (optional)
<img width="261" alt="screen shot 2016-11-08 at 12 28 53 pm" src="https://cloud.githubusercontent.com/assets/111746/20097477/f1fc9120-a5ae-11e6-8705-7e2fbbf784ea.png">

#### :ghost: GIF
![](https://media.giphy.com/media/3o6gEese5luia8rQdy/giphy.gif)
