### PR TITLE
Do not escape description in highlighted processes

### DIFF
--- a/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
@@ -5,7 +5,7 @@
         <%= link_to participatory_process_path(promoted_process), class: "card__link" do %>
           <h2 class="card__title"><%= translated_attribute promoted_process.title %></h2>
         <% end %>
-        <%= html_truncate(translated_attribute(promoted_process.description), length: 630, separator: ' ') %>
+        <%== html_truncate(translated_attribute(promoted_process.description), length: 630, separator: ' ') %>
         <%= link_to participatory_process_path(promoted_process), class: "button secondary small hollow card__button" do %>
           <%= t(".more_info", scope: "layouts") %>
         <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
Highlighted processes show their description with escaped HTML. This PR fixes this.

#### :pushpin: Related Issues
Closes #186

#### :ghost: GIF
![](https://media.giphy.com/media/Ph2EUpM4KAmAM/giphy.gif)

