### PR TITLE
Precompile assets before running tests on CI

### DIFF
--- a/decidim-admin/Rakefile
+++ b/decidim-admin/Rakefile
@@ -1,27 +1,2 @@
 # frozen_string_literal: true
-
 require "decidim/common_rake"
-require "rdoc/task"
-
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = "rdoc"
-  rdoc.title    = "Decidim::Admin"
-  rdoc.options << "--line-numbers"
-  rdoc.rdoc_files.include("README.md")
-  rdoc.rdoc_files.include("lib/**/*.rb")
-end
-
-load "rails/tasks/statistics.rake"
-
-require "bundler/gem_tasks"
-
-begin
-  require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:spec)
-  ENV["ENGINE_PATH"] = File.dirname(__FILE__)
-
-  task default: :spec
-
-  Rake::Task["spec"].enhance ["common:test_app"]
-rescue LoadError
-end

--- a/decidim-api/Rakefile
+++ b/decidim-api/Rakefile
@@ -1,27 +1,2 @@
 # frozen_string_literal: true
-
 require "decidim/common_rake"
-require "rdoc/task"
-
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = "rdoc"
-  rdoc.title    = "Decidim::Api"
-  rdoc.options << "--line-numbers"
-  rdoc.rdoc_files.include("README.md")
-  rdoc.rdoc_files.include("lib/**/*.rb")
-end
-
-load "rails/tasks/statistics.rake"
-
-require "bundler/gem_tasks"
-
-begin
-  require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:spec)
-  ENV["ENGINE_PATH"] = File.dirname(__FILE__)
-
-  task default: :spec
-
-  Rake::Task["spec"].enhance ["common:test_app"]
-rescue LoadError
-end

--- a/decidim-core/Rakefile
+++ b/decidim-core/Rakefile
@@ -1,27 +1,2 @@
 # frozen_string_literal: true
-
 require "decidim/common_rake"
-require "rdoc/task"
-
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = "rdoc"
-  rdoc.title    = "Decidim::Core"
-  rdoc.options << "--line-numbers"
-  rdoc.rdoc_files.include("README.md")
-  rdoc.rdoc_files.include("lib/**/*.rb")
-end
-
-load "rails/tasks/statistics.rake"
-
-require "bundler/gem_tasks"
-
-begin
-  require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:spec)
-  ENV["ENGINE_PATH"] = File.dirname(__FILE__)
-
-  task default: :spec
-
-  Rake::Task["spec"].enhance ["common:test_app"]
-rescue LoadError
-end

--- a/decidim-dev/lib/decidim/common_rake.rb
+++ b/decidim-dev/lib/decidim/common_rake.rb
@@ -1,23 +1,28 @@
 # frozen_string_literal: true
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 require_relative "../generators/decidim/dummy_generator"
 
+engine_path = Dir.pwd
+engine_name = engine_path.split("/").last
+dummy_app_path = File.expand_path(File.join(engine_path, "spec", "#{engine_name}_dummy_app"))
+
 desc "Generates a dummy app for testing"
-namespace :common do
-  task :test_app do
-    Decidim::Generators::DummyGenerator.start(
-      [
-        "--engine_path=#{ENV["ENGINE_PATH"]}",
-        "--migrate=true",
-        "--quiet"
-      ]
-    )
+task :generate_test_app do
+  Decidim::Generators::DummyGenerator.start(
+    [
+      "--engine_path=#{engine_path}",
+      "--migrate=true",
+      "--quiet"
+    ]
+  )
 
-    dummy_app_path = Dir.glob("./spec/*_dummy_app").first
-    require File.join(dummy_app_path, "config", "application")
-    Rails.application.load_tasks
+  require File.join(dummy_app_path, "config", "application")
+  Rails.application.load_tasks
+  Rake.application["assets:precompile"].invoke
 
-    Rake.application["assets:precompile"].invoke
-
-    FileUtils.cd(ENV["ENGINE_PATH"])
-  end
+  FileUtils.cd(engine_path)
 end
+
+RSpec::Core::RakeTask.new(:spec)
+task default: [:generate_test_app, :spec]

--- a/decidim-dev/lib/decidim/common_rake.rb
+++ b/decidim-dev/lib/decidim/common_rake.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 require_relative "../generators/decidim/dummy_generator"
 
+
+begin
+  require "./spec/#{ENV["ENGINE_NAME"]}_dummy_app/config/application"
+  Rails.application.load_tasks
+rescue LoadError
+  puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
+  puts "Dummy app's rake tasks won't be available."
+  puts "Tried to load it from #{dummy_app_path}"
+end
+
+
 desc "Generates a dummy app for testing"
 namespace :common do
   task :test_app do |_t, _args|

--- a/decidim-dev/lib/decidim/common_rake.rb
+++ b/decidim-dev/lib/decidim/common_rake.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 require_relative "../generators/decidim/dummy_generator"
 
-begin
-rescue LoadError
-  puts "Could not load dummy application. Please ensure you have run `bundle exec rake common:test_app`"
-  puts "Dummy app's rake tasks won't be available."
-  puts "Tried to load it from #{dummy_app_path}"
-end
-
 desc "Generates a dummy app for testing"
 namespace :common do
   task :test_app do
@@ -18,12 +11,13 @@ namespace :common do
         "--quiet"
       ]
     )
-    FileUtils.cd(ENV["ENGINE_PATH"])
 
     dummy_app_path = Dir.glob("./spec/*_dummy_app").first
     require File.join(dummy_app_path, "config", "application")
     Rails.application.load_tasks
 
     Rake.application["assets:precompile"].invoke
+
+    FileUtils.cd(ENV["ENGINE_PATH"])
   end
 end

--- a/decidim-dev/lib/decidim/common_rake.rb
+++ b/decidim-dev/lib/decidim/common_rake.rb
@@ -1,25 +1,29 @@
 # frozen_string_literal: true
 require_relative "../generators/decidim/dummy_generator"
 
-
 begin
-  require "./spec/#{ENV["ENGINE_NAME"]}_dummy_app/config/application"
-  Rails.application.load_tasks
 rescue LoadError
-  puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
+  puts "Could not load dummy application. Please ensure you have run `bundle exec rake common:test_app`"
   puts "Dummy app's rake tasks won't be available."
   puts "Tried to load it from #{dummy_app_path}"
 end
 
-
 desc "Generates a dummy app for testing"
 namespace :common do
-  task :test_app do |_t, _args|
-    Decidim::Generators::DummyGenerator.start [
-      "--engine_path=#{ENV["ENGINE_PATH"]}",
-      "--migrate=true",
-      "--quiet"
-    ]
+  task :test_app do
+    Decidim::Generators::DummyGenerator.start(
+      [
+        "--engine_path=#{ENV["ENGINE_PATH"]}",
+        "--migrate=true",
+        "--quiet"
+      ]
+    )
     FileUtils.cd(ENV["ENGINE_PATH"])
+
+    dummy_app_path = Dir.glob("./spec/*_dummy_app").first
+    require File.join(dummy_app_path, "config", "application")
+    Rails.application.load_tasks
+
+    Rake.application["assets:precompile"].invoke
   end
 end

--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 ENV["RAILS_ENV"] ||= "test"
 
+engine_path = Dir.pwd
+engine_name = engine_path.split("/").last
+dummy_app_path = File.expand_path(File.join(engine_path, "spec", "#{engine_name}_dummy_app"))
+
 if ENV["CI"]
   require "simplecov"
   SimpleCov.start
@@ -10,8 +14,7 @@ if ENV["CI"]
 end
 
 begin
-  dummy_app_path = "#{ENV["ENGINE_NAME"]}_dummy_app/config/environment"
-  require dummy_app_path
+  require "#{dummy_app_path}/config/environment"
 rescue LoadError
   puts "Could not load dummy application. Please ensure you have run `bundle exec rake common:test_app`"
   puts "Tried to load it from #{dummy_app_path}"

--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -16,7 +16,7 @@ end
 begin
   require "#{dummy_app_path}/config/environment"
 rescue LoadError
-  puts "Could not load dummy application. Please ensure you have run `bundle exec rake common:test_app`"
+  puts "Could not load dummy application. Please ensure you have run `bundle exec rake generate_test_app`"
   puts "Tried to load it from #{dummy_app_path}"
   exit(-1)
 end

--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -13,7 +13,7 @@ begin
   dummy_app_path = "#{ENV["ENGINE_NAME"]}_dummy_app/config/environment"
   require dummy_app_path
 rescue LoadError
-  puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
+  puts "Could not load dummy application. Please ensure you have run `bundle exec rake common:test_app`"
   puts "Tried to load it from #{dummy_app_path}"
   exit(-1)
 end

--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -15,7 +15,7 @@ begin
 rescue LoadError
   puts "Could not load dummy application. Please ensure you have run `bundle exec rake test_app`"
   puts "Tried to load it from #{dummy_app_path}"
-  exit
+  exit(-1)
 end
 
 require "rspec/rails"

--- a/decidim-system/Rakefile
+++ b/decidim-system/Rakefile
@@ -1,27 +1,2 @@
 # frozen_string_literal: true
-
 require "decidim/common_rake"
-require "rdoc/task"
-
-RDoc::Task.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = "rdoc"
-  rdoc.title    = "Decidim::System"
-  rdoc.options << "--line-numbers"
-  rdoc.rdoc_files.include("README.md")
-  rdoc.rdoc_files.include("lib/**/*.rb")
-end
-
-load "rails/tasks/statistics.rake"
-
-require "bundler/gem_tasks"
-
-begin
-  require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:spec)
-  ENV["ENGINE_PATH"] = File.dirname(__FILE__)
-
-  task default: :spec
-
-  Rake::Task["spec"].enhance ["common:test_app"]
-rescue LoadError
-end

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -4,5 +4,4 @@ if [ "$GEM" == "." ]; then
   docker build --rm=false -t codegram/decidim .
 fi
 
-bundle exec rake assets:precompile
 bundle exec rake

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -4,4 +4,5 @@ if [ "$GEM" == "." ]; then
   docker build --rm=false -t codegram/decidim .
 fi
 
+bundle exec rake assets:precompile
 bundle exec rake


### PR DESCRIPTION
#### :tophat: What? Why?
I've seen timeouts on the first request to `phantomjs` in some tests. After reading through it, it looks like it happens when assets while running in a `phantomjs` session (because it timeouts).

This works around the issue by precompiling assets ahead of time.

#### :pushpin: Related Issues
- Related to https://github.com/teampoltergeist/poltergeist/issues/791#issuecomment-229311349

#### :ghost: GIF
![](https://media.giphy.com/media/jSB2l4zJ82Rvq/giphy.gif)

