### PR TITLE
Increase mass_threshold for code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,8 +8,9 @@ engines:
     enabled: true
     config:
       languages:
-      - ruby
-      - javascript
+        javascript: true
+        ruby:
+          mass_threshold: 50
     exclude_fingerprints:
     - 645ddab80611224e15d61c8426285296
     - 82b4059b3b55d7b7f06d8aba6cb7b81a


### PR DESCRIPTION
#### :tophat: What? Why?
This adjusts the `mass_threshold` so "similar code" code climate issues are less frequent.

#### :ghost: GIF
![](https://media.giphy.com/media/uGjzzKY4BhtKw/giphy.gif)

