### PR TITLE
Fix code climate issues

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -16,6 +16,8 @@ engines:
     - 82b4059b3b55d7b7f06d8aba6cb7b81a
     - b0c92f6cd3876fc88891cbd4ff26faea
     - 2804eaecd03c1e9786c9a6f7007dd61e
+    - 8ee853f81f2b3bc5a136db89ada0575b
+    - bbf4868601b2ff72220fde128f9a9bac
   eslint:
     enabled: false
   fixme:


### PR DESCRIPTION
#### :tophat: What? Why?
This ignores two code climate issues that are actually incorrect:
* `decidim_validatable` is actually copying all the code from `devise` due to its limitations. We want to mimic that behavior and so we should leave the codebase untouched.
* `block too big`: It's using `ActiveSupport::Concern` and it's the idiomatic way to do that.

#### :ghost: GIF
![](https://media.giphy.com/media/14kkd3gt5FJt3a/giphy.gif)

