### PR TITLE
Only check slug uniqueness in the same organization

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process.rb
@@ -7,11 +7,8 @@ module Decidim
       # Public: Initializes the command.
       #
       # form - A form object with the params.
-      # organization - The Organization of the user that created the
-      #   participatory process
-      def initialize(form, organization)
+      def initialize(form)
         @form = form
-        @organization = organization
       end
 
       # Executes the command. Braodcasts these events:
@@ -42,7 +39,7 @@ module Decidim
           hero_image: form.hero_image,
           banner_image: form.banner_image,
           promoted: form.promoted,
-          organization: @organization
+          organization: form.organization
         )
       end
     end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
@@ -22,7 +22,7 @@ module Decidim
         authorize! :new, Decidim::ParticipatoryProcess
         @form = ParticipatoryProcessForm.from_params(params, organization: current_organization)
 
-        CreateParticipatoryProcess.call(@form, current_organization) do
+        CreateParticipatoryProcess.call(@form) do
           on(:ok) do
             flash[:notice] = I18n.t("participatory_processes.create.success", scope: "decidim.admin")
             redirect_to participatory_processes_path

--- a/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
@@ -20,7 +20,7 @@ module Decidim
 
       def create
         authorize! :new, Decidim::ParticipatoryProcess
-        @form = ParticipatoryProcessForm.from_params(params)
+        @form = ParticipatoryProcessForm.from_params(params, organization: current_organization)
 
         CreateParticipatoryProcess.call(@form, current_organization) do
           on(:ok) do
@@ -44,7 +44,7 @@ module Decidim
       def update
         @participatory_process = collection.find(params[:id])
         authorize! :update, @participatory_process
-        @form = ParticipatoryProcessForm.from_params(params)
+        @form = ParticipatoryProcessForm.from_params(params, organization: current_organization)
 
         UpdateParticipatoryProcess.call(@participatory_process, @form) do
           on(:ok) do

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -19,7 +19,7 @@ module Decidim
       attribute :promoted, Boolean
       attribute :hero_image
       attribute :banner_image
-      attribute :organization
+      attribute :organization, Decidim::Organization
 
       validates :slug, presence: true
       translatable_validates :title, :subtitle, :description, :short_description, presence: true

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -19,6 +19,7 @@ module Decidim
       attribute :promoted, Boolean
       attribute :hero_image
       attribute :banner_image
+      attribute :organization
 
       validates :slug, presence: true
       translatable_validates :title, :subtitle, :description, :short_description, presence: true
@@ -28,12 +29,9 @@ module Decidim
       private
 
       def slug_uniqueness
-        return unless ParticipatoryProcess.where(slug: slug).where.not(id: id).any?
+        return unless organization.participatory_processes.where(slug: slug).where.not(id: id).any?
 
-        errors.add(
-          :slug,
-          I18n.t("models.participatory_process.validations.slug_uniqueness", scope: "decidim.admin")
-        )
+        errors.add(:slug, :taken)
       end
     end
   end

--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -37,8 +37,6 @@ ca:
             published: Publicat
             title: Títol
           name: Procés participatiu
-          validations:
-            slug_uniqueness: Ja existeix un altre procés participatiu amb el mateix identificador
         participatory_process_step:
           fields:
             active: Active

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -37,8 +37,6 @@ en:
             published: Published
             title: Title
           name: Participatory process
-          validations:
-            slug_uniqueness: Another participatory process with the same slug already exists
         participatory_process_step:
           fields:
             active: Active

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -37,8 +37,6 @@ es:
             published: Publicado
             title: Título
           name: Proceso participativo
-          validations:
-            slug_uniqueness: Ya existe otro proceso participativo con el mismo identificador
         participatory_process_step:
           fields:
             active: Activo

--- a/decidim-admin/spec/commands/create_participatory_process_admin_spec.rb
+++ b/decidim-admin/spec/commands/create_participatory_process_admin_spec.rb
@@ -39,32 +39,4 @@ describe Decidim::Admin::CreateParticipatoryProcessAdmin do
       expect(roles.first.role).to eq "admin"
     end
   end
-
-  # context "when the process is nil" do
-  #   let(:my_process) { nil }
-  #
-  #   it "is not valid" do
-  #     expect { subject.call }.to broadcast(:invalid)
-  #   end
-  # end
-  #
-  # context "when the process is published" do
-  #   let(:my_process) { create :participatory_process }
-  #
-  #   it "is not valid" do
-  #     expect { subject.call }.to broadcast(:invalid)
-  #   end
-  # end
-  #
-  # context "when the process is not published" do
-  #   it "is valid" do
-  #     expect { subject.call }.to broadcast(:ok)
-  #   end
-  #
-  #   it "publishes it" do
-  #     subject.call
-  #     my_process.reload
-  #     expect(my_process).to be_published
-  #   end
-  # end
 end

--- a/decidim-admin/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-admin/spec/commands/create_participatory_process_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe Decidim::Admin::CreateParticipatoryProcess do
+  let(:organization) { create :organization }
+  let(:form) do
+    double(
+      :invalid? => invalid,
+      title: {en: "title"},
+      subtitle: {en: "subtitle"},
+      slug: "slug",
+      hashtag: "hashtag",
+      hero_image: nil,
+      banner_image: nil,
+      promoted: nil,
+      description: {en: "description"},
+      short_description: {en: "short_description"},
+      organization: organization
+    )
+  end
+  let(:invalid) { false }
+
+  subject { described_class.new(form) }
+
+  context "when the form is not valid" do
+    let(:invalid) { true }
+
+    it "is not valid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when everything is ok" do
+    it "creates the user role" do
+      expect { subject.call }.to change { Decidim::ParticipatoryProcess.count }.by(1)
+    end
+  end
+end

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 module Decidim
   module Admin
     describe ParticipatoryProcessForm do
+      let(:organization) { create :organization }
       let(:title) do
         {
           en: "Title",
@@ -53,7 +54,7 @@ module Decidim
         }
       end
 
-      subject { described_class.from_params(attributes) }
+      subject { described_class.from_params(attributes, organization: organization) }
 
       context "when everything is OK" do
         it { is_expected.to be_valid }
@@ -108,13 +109,25 @@ module Decidim
       end
 
       context "when slug is not unique" do
-        before do
-          create(:participatory_process, slug: slug)
+        context "in the same organization" do
+          before do
+            create(:participatory_process, slug: slug, organization: organization)
+          end
+
+          it "is not valid" do
+            expect(subject).to_not be_valid
+            expect(subject.errors[:slug]).to_not be_empty
+          end
         end
 
-        it "is not valid" do
-          expect(subject).to_not be_valid
-          expect(subject.errors[:slug]).to_not be_empty
+        context "in another organization" do
+          before do
+            create(:participatory_process, slug: slug)
+          end
+
+          it "is valid" do
+            expect(subject).to be_valid
+          end
         end
       end
     end

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -13,7 +13,7 @@ module Decidim
     attr_readonly :active_step
 
     validates :slug, presence: true
-    validate :slug_uniqueness
+    validates :slug, uniqueness: { scope: :organization }
 
     mount_uploader :hero_image, Decidim::HeroImageUploader
     mount_uploader :banner_image, Decidim::BannerImageUploader
@@ -37,16 +37,6 @@ module Decidim
     # Returns a boolean.
     def published?
       published_at.present?
-    end
-
-    private
-
-    def slug_uniqueness
-      others = ParticipatoryProcess
-        .where(organization: organization, slug: slug)
-        .where.not(id: id)
-
-      errors.add(:slug, :taken) if others.any?
     end
   end
 end

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -13,7 +13,7 @@ module Decidim
     attr_readonly :active_step
 
     validates :slug, presence: true
-    validates :slug, uniqueness: true
+    validate :slug_uniqueness
 
     mount_uploader :hero_image, Decidim::HeroImageUploader
     mount_uploader :banner_image, Decidim::BannerImageUploader
@@ -37,6 +37,16 @@ module Decidim
     # Returns a boolean.
     def published?
       published_at.present?
+    end
+
+    private
+
+    def slug_uniqueness
+      others = ParticipatoryProcess
+        .where(organization: organization, slug: slug)
+        .where.not(id: id)
+
+      errors.add(:slug, :taken) if others.any?
     end
   end
 end

--- a/decidim-core/db/migrate/20161110092735_add_index_for_process_slug_organization.rb
+++ b/decidim-core/db/migrate/20161110092735_add_index_for_process_slug_organization.rb
@@ -1,0 +1,8 @@
+class AddIndexForProcessSlugOrganization < ActiveRecord::Migration[5.0]
+  def change
+    add_index :decidim_participatory_processes,
+      [:decidim_organization_id, :slug],
+      unique: true,
+      name: "index_unique_process_slug_and_organization"
+  end
+end

--- a/decidim-core/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_process_spec.rb
@@ -3,10 +3,24 @@ require "spec_helper"
 
 module Decidim
   describe ParticipatoryProcess do
-    let(:participatory_process) { build(:participatory_process) }
+    let(:participatory_process) { build(:participatory_process, slug: "my-slug") }
+    subject { participatory_process }
 
-    it "is valid" do
-      expect(participatory_process).to be_valid
+    it { is_expected.to be_valid }
+
+    context "when there's a process with the same slug in the same organization" do
+      let!(:external_process) { create :participatory_process, organization: participatory_process.organization, slug: "my-slug" }
+
+      it "is not valid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:slug]).to eq ["has already been taken"]
+      end
+    end
+
+    context "when there's a process with the same slug in another organization" do
+      let!(:external_process) { create :participatory_process, slug: "my-slug" }
+
+      it { is_expected.to be_valid }
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Only checks for slug uniqueness in the same organization. 

#### :pushpin: Related Issues
- Fixes #189 

#### :clipboard: Subtasks
- [x] Fix model validation
- [x] Check if the same validation is done in the form object of the  `admin` engine (and fix it)

#### :ghost: GIF
![](https://media.giphy.com/media/lma5aujULEkKs/giphy.gif)

