### PR TITLE
Centralize gemspec properties

### DIFF
--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -6,15 +6,11 @@ require_relative "../decidim-core/lib/decidim/core/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
+  Decidim.add_default_gemspec_properties(s)
+
   s.name        = "decidim-admin"
-  s.version     = Decidim.version
-  s.authors     = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
-  s.email       = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.homepage    = ""
   s.summary     = "Organization administration"
   s.description = "Organization administration to manage a single organization."
-  s.license     = "AGPLv3"
-
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-core", Decidim.version

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -6,14 +6,11 @@ require_relative "../decidim-core/lib/decidim/core/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
+  Decidim.add_default_gemspec_properties(s)
+
   s.name        = "decidim-api"
-  s.version     = Decidim.version
-  s.authors     = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
-  s.email       = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.homepage    = "http://github.com/AjuntamentdeBarcelona/decidim"
   s.summary     = "API engine for decidim"
   s.description = "API engine for decidim"
-  s.license     = "AGPLv3"
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 

--- a/decidim-core/lib/decidim/core/version.rb
+++ b/decidim-core/lib/decidim/core/version.rb
@@ -8,4 +8,13 @@ module Decidim
   def self.rails_version
     ["~> 5.0.0", ">= 5.0.0.1"]
   end
+
+  def self.add_default_gemspec_properties(spec)
+    spec.version = Decidim.version
+    spec.authors = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
+    spec.email = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
+    spec.license = "AGPLv3"
+    spec.homepage = "https://github.com/AjuntamentdeBarcelona/decidim"
+    spec.required_ruby_version = ">= 2.3.1"
+  end
 end

--- a/decidim-dev/decidim-dev.gemspec
+++ b/decidim-dev/decidim-dev.gemspec
@@ -6,14 +6,11 @@ require_relative "../decidim-core/lib/decidim/core/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
+  Decidim.add_default_gemspec_properties(s)
+
   s.name        = "decidim-dev"
-  s.version     = Decidim.version
-  s.authors     = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
-  s.email       = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.homepage    = ""
   s.summary     = "Decidim Dev tools"
   s.description = "Utilities and tools we need to develop Decidim"
-  s.license     = "AGPLv3"
 
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -6,14 +6,11 @@ require_relative "../decidim-core/lib/decidim/core/version"
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|
+  Decidim.add_default_gemspec_properties(s)
+
   s.name        = "decidim-system"
-  s.version     = Decidim.version
-  s.authors     = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
-  s.email       = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
-  s.homepage    = ""
   s.summary     = "System administration"
   s.description = "System administration to create new organization in an installation."
-  s.license     = "AGPLv3"
 
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 

--- a/decidim.gemspec
+++ b/decidim.gemspec
@@ -5,17 +5,12 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require_relative "decidim-core/lib/decidim/core/version"
 
 Gem::Specification.new do |spec|
+  Decidim.add_default_gemspec_properties(spec)
+
   spec.name          = "decidim"
-  spec.version       = Decidim.version
-  spec.authors       = ["Josep Jaume Rey Peroy", "Marc Riera Casals", "Oriol Gual Oliva"]
-  spec.email         = ["josepjaume@gmail.com", "mrc2407@gmail.com", "oriolgual@gmail.com"]
 
   spec.summary       = "Citizen participation framework for Ruby on Rails."
   spec.description   = "Citizen participation framework for Ruby on Rails."
-  spec.homepage      = "https://github.com/AjuntamentdeBarcelona/decidim"
-  spec.license       = "AGPLv3"
-
-  spec.required_ruby_version = ">= 2.3.1"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|decidim-core)/}) }
   spec.bindir        = "bin"


### PR DESCRIPTION
#### :tophat: What? Why?
This centralizes gemspec properties in a single, central point, so we don't have to deal with updating every single gemspec every time we change something.

#### :ghost: GIF
![](https://media.giphy.com/media/pZ9NupUT5JAZy/giphy.gif)
