### PR TITLE
Improve error display on tabbed form fields

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/_forms.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/_forms.scss
@@ -1,4 +1,9 @@
 form {
+  ul.tabs {
+    a.alert {
+      color: map-get($foundation-palette, alert);
+    }
+  }
   .tabs-content {
     margin-bottom: 1rem;
   }


### PR DESCRIPTION
#### :tophat: What? Why?
PR #191 added tabs on translated form fields, but errors were hidden inside each tab and there was no way to clearly see them without accessing each tab of each field. This PR addresses this (see screenshot)

#### :pushpin: Related Issues
- Related to #191, #127 

### :camera: Screenshots (optional)
![Errors in tabs](https://i.imgur.com/efp0AMj.png)

Explanation: `Title` has errors in some of its locales, so the label is red. Also, each locale with errors (English, in this case) is red too. Locales without errors are shown in normal color.

`Subtitle` has no errors in any of its locales, so the label and the tabs titles are shown OK.

`Slug` and `Hashtag` are shown in order to prove that non-i18n fields are not affected by this PR.

#### :ghost: GIF
![](https://media.giphy.com/media/xTiTnAWsCOrpoyyat2/giphy.gif)

