### PR TITLE
Fix active link class in Home section

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_header.html.erb
@@ -74,7 +74,7 @@
             <div class="row">
               <ul class="main-nav">
                 <li>
-                  <%= active_link_to t("menu.home", scope: "decidim"), root_path, active: :exact, class: "main-nav__link", class_active: "main-nav__link-active" %>
+                  <%= active_link_to t("menu.home", scope: "decidim"), root_path, active: :exact, class: "main-nav__link", class_active: "main-nav__link--active" %>
                 </li>
                 <li>
                   <%= active_link_to t("menu.processes", scope: "decidim"), participatory_processes_path, active: :inclusive, class: "main-nav__link", class_active: "main-nav__link--active" %>


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes a bug in the public pages where the Home section was not being properly highlighted in the menu.

#### :pushpin: Related Issues
- Fixes #199

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/CeI60MY.png)

#### :ghost: GIF
![](https://media.giphy.com/media/vFKqnCdLPNOKc/giphy.gif)

