### PR TITLE
Add a demo generator to use DummyAuthorizationHandler

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/activate_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/activate_participatory_process_step.rb
@@ -11,7 +11,7 @@ module Decidim
         @step = step
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the data wasn't valid and we couldn't proceed.

--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process.rb
@@ -11,7 +11,7 @@ module Decidim
         @form = form
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the form wasn't valid and we couldn't proceed.

--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process_admin.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process_admin.rb
@@ -14,7 +14,7 @@ module Decidim
         @participatory_process = participatory_process
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the form wasn't valid and we couldn't proceed.

--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
@@ -14,7 +14,7 @@ module Decidim
         @participatory_process = participatory_process
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the form wasn't valid and we couldn't proceed.

--- a/decidim-admin/app/commands/decidim/admin/publish_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/publish_participatory_process.rb
@@ -10,7 +10,7 @@ module Decidim
         @process = process
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the data wasn't valid and we couldn't proceed.

--- a/decidim-admin/app/commands/decidim/admin/reorder_participatory_process_steps.rb
+++ b/decidim-admin/app/commands/decidim/admin/reorder_participatory_process_steps.rb
@@ -12,7 +12,7 @@ module Decidim
         @order = order
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the data wasn't valid and we couldn't proceed.

--- a/decidim-admin/app/commands/decidim/admin/unpublish_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/unpublish_participatory_process.rb
@@ -10,7 +10,7 @@ module Decidim
         @process = process
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the data wasn't valid and we couldn't proceed.

--- a/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
@@ -13,7 +13,7 @@ module Decidim
         @form = form
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the form wasn't valid and we couldn't proceed.

--- a/decidim-admin/app/commands/decidim/admin/update_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_participatory_process_step.rb
@@ -14,7 +14,7 @@ module Decidim
         @form = form
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the form wasn't valid and we couldn't proceed.

--- a/decidim-core/app/commands/decidim/authorize_user.rb
+++ b/decidim-core/app/commands/decidim/authorize_user.rb
@@ -9,14 +9,14 @@ module Decidim
       @handler = handler
     end
 
-    # Executes the command. Braodcasts these events:
+    # Executes the command. Broadcasts these events:
     #
     # - :ok when everything is valid.
     # - :invalid if the handler wasn't valid and we couldn't proceed.
     #
     # Returns nothing.
     def call
-      return broadcast(:invalid) unless handler.valid?
+      return broadcast(:invalid) unless handler.authorized?
 
       create_authorization
       broadcast(:ok)

--- a/decidim-core/spec/commands/decidim/authorize_user_spec.rb
+++ b/decidim-core/spec/commands/decidim/authorize_user_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+module Decidim
+  describe AuthorizeUser do
+    let(:user) { create(:user) }
+    let(:handler) do
+      DummyAuthorizationHandler.new(
+        document_number: "12345678X",
+        user: user
+      )
+    end
+
+    before do
+      expect(handler).to receive(:authorized?).and_return(authorized)
+    end
+
+    subject { described_class.new(handler) }
+
+    context "when the form is not authorized" do
+      let(:authorized) { false }
+
+      it "is not valid" do
+        expect { subject.call }.to broadcast(:invalid)
+      end
+    end
+
+    context "when everything is ok" do
+      let(:authorized) { true }
+
+      it "creates an authorization for the user" do
+        expect { subject.call }.to change { user.authorizations.count }.by(1)
+      end
+
+      it "stores the metadata" do
+        subject.call
+
+        expect(user.authorizations.first.metadata["document_number"]).to eq("12345678X")
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dummy_authorization_handler.rb
+++ b/decidim-dev/lib/decidim/dummy_authorization_handler.rb
@@ -1,18 +1,25 @@
 # frozen_string_literal: true
 module Decidim
-  # A n example implementation of an AuthorizationHandler to be used in tests.
+  # An example implementation of an AuthorizationHandler to be used in tests.
   class DummyAuthorizationHandler < AuthorizationHandler
     attribute :document_number, String
     attribute :birthday, Date
 
     validates :document_number, presence: true
+    validate :valid_document_number
 
     def authorized?
-      valid? && document_number.end_with?("X")
+      valid?
     end
 
     def metadata
       super.merge(document_number: document_number)
+    end
+
+    private
+
+    def valid_document_number
+      errors.add(:document_number, :invalid) unless document_number.to_s.end_with?("X")
     end
   end
 end

--- a/decidim-system/app/commands/decidim/system/create_admin.rb
+++ b/decidim-system/app/commands/decidim/system/create_admin.rb
@@ -11,7 +11,7 @@ module Decidim
         @form = form
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the form wasn't valid and we couldn't proceed.

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -12,7 +12,7 @@ module Decidim
         @form = form
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the form wasn't valid and we couldn't proceed.

--- a/decidim-system/app/commands/decidim/system/update_admin.rb
+++ b/decidim-system/app/commands/decidim/system/update_admin.rb
@@ -12,7 +12,7 @@ module Decidim
         @form = form
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the form wasn't valid and we couldn't proceed.

--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -13,7 +13,7 @@ module Decidim
         @form = form
       end
 
-      # Executes the command. Braodcasts these events:
+      # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the form wasn't valid and we couldn't proceed.

--- a/lib/generators/decidim/app_builder.rb
+++ b/lib/generators/decidim/app_builder.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "decidim/core"
+
 module Decidim
   module Generators
     # Custom app builder to inject own Gemfile.

--- a/lib/generators/decidim/demo_generator.rb
+++ b/lib/generators/decidim/demo_generator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require "rails/generators"
+require "rails/generators/rails/app/app_generator"
+require "decidim/core/version"
+require_relative "app_builder"
+require_relative "install_generator"
+
+module Decidim
+  module Generators
+    # Generates a Rails app and installs decidim to it. Uses the default Rails
+    # generator for most of the work.
+    #
+    # Remember that, for how generators work, actions are executed based on the
+    # definition order of the public methods.
+    class DemoGenerator < Rails::Generators::Base
+      def authorization_handlers
+        remove_file "app/services/example_authorization_handler.rb"
+        inject_into_file "config/initializers/decidim.rb", before: "Decidim" do
+          "require \"decidim/dummy_authorization_handler\" \n"
+        end
+        gsub_file "config/initializers/decidim.rb",
+                  /ExampleAuthorizationHandler/,
+                  "Decidim::DummyAuthorizationHandler"
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Adds a generator named `decidim:demo` that set the `DummyAuthorizationHandler` as the one to use instead fo the example. This way we can use it locally or in a staging environment, we just need to set a document number that ends with "X".

I've also realized there was a bug in `AuthorizeUser` and I fixed it and fiex all the `Braodcast` typos.

#### :pushpin: Related Issues
- Related to #214 

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/mpqsPij.png)

#### :ghost: GIF
![](https://i.imgur.com/ZAaYDAk.gif)
