### PR TITLE
Let admins manage organization settings

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 module Decidim
   module Admin
-    # A command with all the business logic updating the current organization.
+    # A command with all the business logic for updating the current
+    # organization.
     class UpdateOrganization < Rectify::Command
-
       # Public: Initializes the command.
       #
       # organization - The Organization that will be updated.

--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A command with all the business logic updating the current organization.
+    class UpdateOrganization < Rectify::Command
+
+      # Public: Initializes the command.
+      #
+      # organization - The Organization that will be updated.
+      # form - A form object with the params.
+      def initialize(organization, form)
+        @organization = organization
+        @form = form
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        update_organization
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :form, :organization
+
+      def update_organization
+        organization.update_attributes!(attributes)
+      end
+
+      def attributes
+        {
+          name: form.name,
+          description: form.description
+        }
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require_dependency "decidim/admin/application_controller"
+
+module Decidim
+  module Admin
+    # Controller that allows managing the user organization.
+    #
+    class OrganizationController < ApplicationController
+      def edit
+        authorize! :update, current_organization
+        @form = OrganizationForm.from_model(current_organization)
+      end
+
+      def update
+        authorize! :update, current_organization
+        @form = OrganizationForm.from_params(params)
+
+        UpdateOrganization.call(current_organization, @form) do
+          on(:ok) do
+            flash[:notice] = I18n.t("organization.update.success", scope: "decidim.admin")
+            redirect_to organization_path
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("organization.update.error", scope: "decidim.admin")
+            render :edit
+          end
+        end
+      end
+
+      def show
+        authorize! :read, current_organization
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
@@ -13,7 +13,7 @@ module Decidim
 
       def update
         authorize! :update, current_organization
-        @form = OrganizationForm.from_params(params)
+        @form = OrganizationForm.from_params(form_params)
 
         UpdateOrganization.call(current_organization, @form) do
           on(:ok) do
@@ -30,6 +30,14 @@ module Decidim
 
       def show
         authorize! :read, current_organization
+      end
+
+      private
+
+      def form_params
+        params[:organization] ||= {}
+        params[:organization][:id] ||= current_organization.id
+        params
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 module Decidim
   module Admin
-    # A form object used to create or update the current organization from the
-    # admin dashboard.
+    # A form object used to update the current organization from the admin
+    # dashboard.
     #
     class OrganizationForm < Rectify::Form
       include TranslatableAttributes
@@ -14,6 +14,7 @@ module Decidim
       attribute :name, String
 
       validates :name, presence: true
+      translatable_validates :description, presence: true
     end
   end
 end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A form object used to create or update the current organization from the
+    # admin dashboard.
+    #
+    class OrganizationForm < Rectify::Form
+      include TranslatableAttributes
+
+      translatable_attribute :description, String
+
+      mimic :organization
+
+      attribute :name, String
+
+      validates :name, presence: true
+    end
+  end
+end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -7,11 +7,10 @@ module Decidim
     class OrganizationForm < Rectify::Form
       include TranslatableAttributes
 
-      translatable_attribute :description, String
-
       mimic :organization
 
       attribute :name, String
+      translatable_attribute :description, String
 
       validates :name, presence: true
       translatable_validates :description, presence: true

--- a/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
@@ -18,7 +18,7 @@ module Decidim
           can [:update_slug, :destroy], [StaticPage, StaticPageForm] do |page|
             !StaticPage.default?(page.slug)
           end
-          can :manage, Decidim::Organization do |organization|
+          can [:read, :update], Decidim::Organization do |organization|
             organization == user.organization
           end
           can :read, :admin_dashboard

--- a/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
@@ -18,6 +18,9 @@ module Decidim
           can [:update_slug, :destroy], [StaticPage, StaticPageForm] do |page|
             !StaticPage.default?(page.slug)
           end
+          can :manage, Decidim::Organization do |organization|
+            organization == user.organization
+          end
           can :read, :admin_dashboard
         end
       end

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -1,0 +1,7 @@
+<div class="field">
+  <%= form.text_field :name %>
+</div>
+
+<div class="field">
+  <%= form.translated :editor, :description %>
+</div>

--- a/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
@@ -1,6 +1,8 @@
-<h3><%= t ".title" %></h3>
+<% content_for :title do %>
+  <h2><%= t ".title" %></h2>
+<% end %>
 
-<%= form_for(@form) do |f| %>
+<%= form_for(@form, url: organization_path, format: :put) do |f| %>
   <%= render partial: 'form', object: f %>
 
   <div class="actions">

--- a/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
@@ -2,7 +2,7 @@
   <h2><%= t ".title" %></h2>
 <% end %>
 
-<%= form_for(@form, url: organization_path, format: :put) do |f| %>
+<%= form_for(@form, url: organization_path) do |f| %>
   <%= render partial: 'form', object: f %>
 
   <div class="actions">

--- a/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
@@ -1,0 +1,9 @@
+<h3><%= t ".title" %></h3>
+
+<%= form_for(@form) do |f| %>
+  <%= render partial: 'form', object: f %>
+
+  <div class="actions">
+    <%= f.submit t(".update") %>
+  </div>
+<% end %>

--- a/decidim-admin/app/views/decidim/admin/organization/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/show.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title do %>
+  <h2><%= link_to current_organization.name, current_organization %></h2>
+<% end %>
+
+<div class="actions">
+  <hr />
+  <% if can? :update, current_organization %>
+    <%= link_to t("decidim.admin.actions.edit"), edit_organization_path %>
+  <% end %>
+</div>
+
+<dl>
+  <%= display_for current_organization,
+    :name,
+    :description
+  %>
+  <dt><%= display_label(current_organization, :created_at) %></dt>
+  <dd><%= l current_organization.created_at, format: :long %></dd>
+</dl>

--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
@@ -9,7 +9,7 @@
 <nav class="main-menu">
   <%= active_link_to t("menu.dashboard", scope: "decidim.admin"), root_path, active: :exact %>
   <% if can? :read, current_organization %>
-    <%= active_link_to t("menu.organization", scope: "decidim.admin"), organization_path, active: :inclusive %>
+    <%= active_link_to t("menu.settings", scope: "decidim.admin"), organization_path, active: :inclusive %>
   <% end %>
   <%= active_link_to t("menu.participatory_processes", scope: "decidim.admin"), participatory_processes_path, active: :inclusive %>
   <%= active_link_to t("menu.static_pages", scope: "decidim.admin"), static_pages_path, active: :inclusive %>

--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
@@ -8,9 +8,7 @@
 
 <nav class="main-menu">
   <%= active_link_to t("menu.dashboard", scope: "decidim.admin"), root_path, active: :exact %>
-  <% if can? :read, current_organization %>
-    <%= active_link_to t("menu.settings", scope: "decidim.admin"), organization_path, active: :inclusive %>
-  <% end %>
+  <%= active_link_to t("menu.settings", scope: "decidim.admin"), organization_path, active: :inclusive if can? :read, current_organization %>
   <%= active_link_to t("menu.participatory_processes", scope: "decidim.admin"), participatory_processes_path, active: :inclusive %>
   <%= active_link_to t("menu.static_pages", scope: "decidim.admin"), static_pages_path, active: :inclusive %>
 </nav>

--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
@@ -8,6 +8,9 @@
 
 <nav class="main-menu">
   <%= active_link_to t("menu.dashboard", scope: "decidim.admin"), root_path, active: :exact %>
+  <% if can? :manage, current_organization %>
+    <%= active_link_to t("menu.organization", scope: "decidim.admin"), organization_path, active: :inclusive %>
+  <% end %>
   <%= active_link_to t("menu.participatory_processes", scope: "decidim.admin"), participatory_processes_path, active: :inclusive %>
   <%= active_link_to t("menu.static_pages", scope: "decidim.admin"), static_pages_path, active: :inclusive %>
 </nav>

--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
@@ -8,7 +8,7 @@
 
 <nav class="main-menu">
   <%= active_link_to t("menu.dashboard", scope: "decidim.admin"), root_path, active: :exact %>
-  <% if can? :manage, current_organization %>
+  <% if can? :read, current_organization %>
     <%= active_link_to t("menu.organization", scope: "decidim.admin"), organization_path, active: :inclusive %>
   <% end %>
   <%= active_link_to t("menu.participatory_processes", scope: "decidim.admin"), participatory_processes_path, active: :inclusive %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -30,6 +30,7 @@ en:
               process_admins_title: Participatory process admins
       menu:
         dashboard: Dashboard
+        organization: Organization
         participatory_processes: Participatory processes
         participatory_processes_submenu:
           info: Info
@@ -59,6 +60,13 @@ en:
             created_at: Created at
             title: Title
           name: Page
+      organization:
+        edit:
+          title: Edit organization
+          update: Update organization
+        update:
+          error: There was an error when updating this organization.
+          success: Organization updated successfully.
       participatory_process_publications:
         create:
           error: There was an error publishing this participatory process.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -30,12 +30,12 @@ en:
               process_admins_title: Participatory process admins
       menu:
         dashboard: Dashboard
-        organization: Organization
         participatory_processes: Participatory processes
         participatory_processes_submenu:
           info: Info
           process_admins: Process admins
           steps: Steps
+        settings: Settings
         static_pages: Pages
       models:
         participatory_process:

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 Decidim::Admin::Engine.routes.draw do
   constraints(->(request) { Decidim::Admin::OrganizationDashboardConstraint.new(request).matches? }) do
+    resource :organization, only: [:show, :edit, :update], controller: "organization"
     resources :participatory_processes do
       resource :publish, controller: "participatory_process_publications", only: [:create, :destroy]
 

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -8,7 +8,12 @@ module Decidim
         let(:organization) { create(:organization) }
         let(:form) do
           OrganizationForm.from_params(
-            organization: organization.attributes.merge(name: "My super organization"),
+            organization: {
+              name: "My super organization",
+              description_en: "My description",
+              description_es: "Mi descripción",
+              description_ca: "La meva descripció"
+            }
           )
         end
         let(:command) { described_class.new(organization, form) }

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe UpdateOrganization, :db do
+      describe "call" do
+        let(:organization) { create(:organization) }
+        let(:form) do
+          OrganizationForm.from_params(
+            organization: organization.attributes.merge(name: "My super organization"),
+          )
+        end
+        let(:command) { described_class.new(organization, form) }
+
+        describe "when the form is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't update the organization" do
+            command.call
+            organization.reload
+
+            expect(organization.name).to_not eq("My super organization")
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "updates the organization in the organization" do
+            command.call
+            organization.reload
+
+            expect(organization.name).to eq("My super organization")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/features/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages ogranization", type: :feature do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin.organization_path
+  end
+
+  describe "show" do
+    it "lists the details from the organization" do
+      expect(page).to have_content(organization.name)
+      expect(page).to have_content(translated(organization.description))
+      expect(page).to have_content(translated(organization.description, locale: :es))
+      expect(page).to have_content(translated(organization.description, locale: :ca))
+    end
+  end
+
+  describe "edit" do
+    it "updates the values from the form" do
+      click_link "Edit"
+
+      fill_in "Name", with: "My super-uber organization"
+      fill_in_i18n_editor :organization_description, "#description-tabs", {
+        en: "My own super description",
+        es: "Mi gran descripción",
+        ca: "La meva gran descripció"
+      }
+
+      click_button "Update organization"
+
+      expect(page).to have_content("updated successfully")
+
+      expect(page).to have_content("My super-uber organization")
+      expect(page).to have_content("My own super description")
+      expect(page).to have_content("Mi gran descripción")
+      expect(page).to have_content("La meva gran descripció")
+    end
+  end
+end

--- a/decidim-admin/spec/forms/organization_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_form_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe OrganizationForm do
+      let(:name) { "My super organization" }
+      let(:description) do
+        {
+          en: "Description, awesome description",
+          es: "Descripción",
+          ca: "Descripció"
+        }
+      end
+      let(:organization) { create(:organization) }
+      let(:attributes) do
+        {
+          "organization" => {
+            "name" => name,
+            "description_en" => description[:en],
+            "description_es" => description[:es],
+            "description_ca" => description[:ca]
+          }
+        }
+      end
+
+      subject { described_class.from_params(attributes) }
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when name is missing" do
+        let(:name) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when some language in description is missing" do
+        let(:description) do
+          {
+            ca: "Descripció"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/models/abilities/admin_user_spec.rb
+++ b/decidim-admin/spec/models/abilities/admin_user_spec.rb
@@ -43,4 +43,18 @@ describe Decidim::Admin::Abilities::AdminUser do
     it { is_expected.to be_able_to(:destroy, page) }
     it { is_expected.to be_able_to(:destroy, form) }
   end
+
+  context "when the organization is the one they belong to" do
+    let(:organization) { user.organization }
+
+    it { is_expected.to be_able_to(:update, organization) }
+    it { is_expected.to be_able_to(:read, organization) }
+  end
+
+  context "when the organization is different form the one they belong to" do
+    let(:organization) { build(:organization) }
+
+    it { is_expected.not_to be_able_to(:update, organization) }
+    it { is_expected.not_to be_able_to(:read, organization) }
+  end
 end

--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -33,7 +33,7 @@ $(document).on('turbolinks:load', () => {
 
       quill.on('text-change', () => {
         const text = quill.getText();
-        if (text === '') {
+        if (text === '\n') {
           $input.val('');
         } else {
           $input.val(quill.root.innerHTML);


### PR DESCRIPTION
#### :tophat: What? Why?
We want to let admins change organization details as name and description. This PR lets them do this.

#### :pushpin: Related Issues
- Fixes #203 

#### :clipboard: Subtasks
- [x] Add feature
- [x] Add feature spec
- [x] Add specs
- [x] Add docs

### :camera: Screenshots (optional)
Show:
![Description](https://i.imgur.com/OwgMEmn.png)

Edit: 
![](https://i.imgur.com/EnoFk25.png)

Updated show:
![](https://i.imgur.com/wciHkQT.png)

#### :ghost: GIF
![](https://media.giphy.com/media/INFNFHifeweUU/giphy.gif)

