### PR TITLE
Deprecate hstore in favor of jsonb

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/attributes_display_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/attributes_display_helper.rb
@@ -31,7 +31,7 @@ module Decidim
       # attrs - a list of N attributes of the `record`.
       def display_for(record, *attrs)
         attrs.map do |attr|
-          if record.column_for_attribute(attr).type == :hstore
+          if record.column_for_attribute(attr).type == :jsonb
             I18n.available_locales.map do |locale|
               display_label(record, attr, locale) + display_value(record, attr, locale)
             end.reduce(:+)

--- a/decidim-core/db/migrate/20161005153007_add_description_to_organizations.rb
+++ b/decidim-core/db/migrate/20161005153007_add_description_to_organizations.rb
@@ -1,9 +1,7 @@
 class AddDescriptionToOrganizations < ActiveRecord::Migration[5.0]
   def change
-    enable_extension :hstore
-
     change_table :decidim_organizations do |t|
-      t.hstore :description
+      t.jsonb :description
     end
   end
 end

--- a/decidim-core/db/migrate/20161010102356_translate_processes.rb
+++ b/decidim-core/db/migrate/20161010102356_translate_processes.rb
@@ -6,10 +6,10 @@ class TranslateProcesses < ActiveRecord::Migration[5.0]
     remove_column :decidim_participatory_processes, :short_description
 
     change_table :decidim_participatory_processes do |t|
-      t.hstore :title, null: false
-      t.hstore :subtitle, null: false
-      t.hstore :short_description, null: false
-      t.hstore :description, null: false
+      t.jsonb :title, null: false
+      t.jsonb :subtitle, null: false
+      t.jsonb :short_description, null: false
+      t.jsonb :description, null: false
     end
   end
 end

--- a/decidim-core/db/migrate/20161017085822_add_participatory_process_steps.rb
+++ b/decidim-core/db/migrate/20161017085822_add_participatory_process_steps.rb
@@ -1,9 +1,9 @@
 class AddParticipatoryProcessSteps < ActiveRecord::Migration[5.0]
   def change
     create_table :decidim_participatory_process_steps do |t|
-      t.hstore :title, null: false
-      t.hstore :short_description, null: false
-      t.hstore :description, null: false
+      t.jsonb :title, null: false
+      t.jsonb :short_description, null: false
+      t.jsonb :description, null: false
       t.datetime :start_date
       t.datetime :end_date
       t.references :decidim_participatory_process,

--- a/decidim-core/db/migrate/20161108093802_create_decidim_static_pages.rb
+++ b/decidim-core/db/migrate/20161108093802_create_decidim_static_pages.rb
@@ -1,9 +1,9 @@
 class CreateDecidimStaticPages < ActiveRecord::Migration[5.0]
   def change
     create_table :decidim_static_pages do |t|
-      t.hstore :title, null: false
+      t.jsonb :title, null: false
       t.string :slug, null: false
-      t.hstore :content, null: false
+      t.jsonb :content, null: false
       t.references :decidim_organization, foreign_key: true, index: true
       t.timestamps
     end

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   factory :organization, class: Decidim::Organization do
     name { Faker::Company.name }
     sequence(:host) { |n| "#{n}.lvh.me" }
-    description     "Description"
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
   end
 
   factory :participatory_process, class: Decidim::ParticipatoryProcess do


### PR DESCRIPTION
#### :tophat: What? Why?
Replaces all uses of `hstore` for `jsonb` which is more flexible and allows multiple levels of nesting.

#### :pushpin: Related Issues
- Fixes #228

#### :clipboard: Subtasks
- [x] Fun
- [x] Profit

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/Hz6WKZkKkLOE0/giphy.gif)

