### PR TITLE
Remove `to_hash` warning

### DIFF
--- a/decidim-core/app/services/decidim/authorization_handler.rb
+++ b/decidim-core/app/services/decidim/authorization_handler.rb
@@ -86,7 +86,7 @@ module Decidim
 
       return unless Decidim.authorization_handlers.include?(handler_klass)
 
-      handler_klass.new(params || {})
+      handler_klass.from_params(params || {})
     rescue NameError
       nil
     end


### PR DESCRIPTION
#### :tophat: What? Why?
We had some weird deprecation warnings for Rails 5.1. This PR fixes those deprecation warnings.

#### :pushpin: Related Issues
- Fixes #236

#### :ghost: GIF
![](https://media.giphy.com/media/IT6kBZ1k5oEeI/giphy.gif)

