### PR TITLE
Remove label on tabbed editor fields

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -66,7 +66,7 @@ module Decidim
 
       content_tag(:div, class: "editor") do
         template = ""
-        template += label(name) if !options[:label].present? || options[:label]
+        template += label(name) if options[:label] != false
         template += hidden_field(name, options)
         template += content_tag(:div, nil, class: "editor-container", data: {
                                   toolbar: options[:toolbar]

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -95,6 +95,8 @@ module Decidim
 
           expect(parsed.css("li.tabs-title a").count).to eq 3
 
+          expect(parsed.css(".editor label[for='resource_short_description_en']").first).to be_nil
+
           expect(parsed.css(".tabs-panel .editor input[type='hidden'][name='resource[short_description_ca]']").first).to be
           expect(parsed.css(".tabs-panel .editor input[type='hidden'][name='resource[short_description_en]']").first).to be
           expect(parsed.css(".tabs-panel .editor input[type='hidden'][name='resource[short_description_de__CH]']").first).to be


### PR DESCRIPTION
#### :tophat: What? Why?
Editor fields had redundant labels when used on tabbed (translated) inputs. This PR removes the labels in these fields.

#### :pushpin: Related Issues
- Fixes #234 

#### :clipboard: Subtasks
- [x] Remove label
- [x] Fix specs

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/EydiqNQ.png)

#### :ghost: GIF
![](https://media.giphy.com/media/GpAYbMYt0exPO/giphy.gif)

