### PR TITLE
Don't show `Pages` menu item if don't have permissions

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
@@ -9,7 +9,9 @@
 <nav class="main-menu">
   <%= active_link_to t("menu.dashboard", scope: "decidim.admin"), root_path, active: :exact %>
   <%= active_link_to t("menu.participatory_processes", scope: "decidim.admin"), participatory_processes_path, active: :inclusive %>
-  <%= active_link_to t("menu.static_pages", scope: "decidim.admin"), static_pages_path, active: :inclusive %>
+  <% if can? :read, Decidim::StaticPage %>
+    <%= active_link_to t("menu.static_pages", scope: "decidim.admin"), static_pages_path, active: :inclusive %>
+  <% end %>
 </nav>
 
 <%= render partial: 'layouts/decidim/admin/login_items' %>


### PR DESCRIPTION
#### :tophat: What? Why?
Participatory process admins can see the `Pages` menu item on the admin, but they cannot access it. This PR hides this menu item.

#### :pushpin: Related Issues
- Fixes #232

#### :clipboard: Subtasks
- [x] Hide the item

### :camera: Screenshots (optional)
As a process admin:
![Description](https://i.imgur.com/vRfGjs8.png)

As an organization admin:
![](https://i.imgur.com/HPjPnTu.png)

