### PR TITLE
Let engines mount themselves

### DIFF
--- a/decidim-admin/README.md
+++ b/decidim-admin/README.md
@@ -4,13 +4,6 @@ This library adds and administration dashboard so users can manage their
 organization, participatory processes and all other entities.
 
 ## Usage
-Include this library in your Decidim' flavoured Rails app by:
-
-```ruby
-# config/routes.rb
-mount Decidim::Admin::Engine => '/admin'
-```
-
 This will add an admin dashboard to manage an organization an all its entities.
 It's included by default with Decidim.
 

--- a/decidim-admin/lib/decidim/admin/engine.rb
+++ b/decidim-admin/lib/decidim/admin/engine.rb
@@ -21,6 +21,12 @@ module Decidim
     class Engine < ::Rails::Engine
       isolate_namespace Decidim::Admin
 
+      initializer "decidim_admin.mount_routes" do |_app|
+        Decidim::Core::Engine.routes do
+          mount Decidim::Admin::Engine => "/admin"
+        end
+      end
+
       initializer "decidim_admin.assets" do |app|
         app.config.assets.precompile += %w(decidim_admin_manifest.js)
       end

--- a/decidim-admin/spec/features/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "spec_helper"
@@ -14,10 +15,12 @@ describe "Admin manages ogranization", type: :feature do
 
   describe "show" do
     it "lists the details from the organization" do
-      expect(page).to have_content(organization.name)
-      expect(page).to have_content(translated(organization.description))
-      expect(page).to have_content(translated(organization.description, locale: :es))
-      expect(page).to have_content(translated(organization.description, locale: :ca))
+      within ".main-content" do
+        expect(page).to have_content(organization.name)
+        expect(page.body).to include(translated(organization.description))
+        expect(page.body).to include(translated(organization.description, locale: :es))
+        expect(page.body).to include(translated(organization.description, locale: :ca))
+      end
     end
   end
 

--- a/decidim-api/README.md
+++ b/decidim-api/README.md
@@ -3,14 +3,7 @@
 This library exposes a [GraphQL](https://facebook.github.io/graphql/) API to programatically interact with the Decidim platform via HTTP.
 
 ## Usage
-Include this library in your Decidim' flavoured Rails app by:
-
-```ruby
-# config/routes.rb
-mount Decidim::Api::Engine => '/api'
-```
-
-This will expose two nice endpoints:
+Including `decidim-api` will get expose two nice endpoints:
 
 * `/api`: The main GraphQL endpoint that holds the actual API.
 * `/api/docs`: Nicely-written docs of the entities of the API.

--- a/decidim-api/lib/decidim/api/engine.rb
+++ b/decidim-api/lib/decidim/api/engine.rb
@@ -14,6 +14,12 @@ module Decidim
         app.config.assets.precompile += %w(decidim_api_manifest.js)
       end
 
+      initializer "decidim_api.mount_routes" do |_app|
+        Decidim::Core::Engine.routes do
+          mount Decidim::Api::Engine => "/api"
+        end
+      end
+
       initializer "decidim-api.middleware" do |app|
         app.config.middleware.insert_before 0, Rack::Cors do
           allow do

--- a/decidim-system/lib/decidim/system/engine.rb
+++ b/decidim-system/lib/decidim/system/engine.rb
@@ -19,6 +19,12 @@ module Decidim
     class Engine < ::Rails::Engine
       isolate_namespace Decidim::System
 
+      initializer "decidim_system.mount_routes" do |_app|
+        Decidim::Core::Engine.routes do
+          mount Decidim::System::Engine => "/system"
+        end
+      end
+
       initializer "decidim_system.assets" do |app|
         app.config.assets.precompile += %w(decidim_system_manifest.js)
       end

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -21,9 +21,6 @@ module Decidim
                                  desc: "Run migrations after installing decidim"
 
       def install
-        route "mount Decidim::System::Engine => '/system'"
-        route "mount Decidim::Admin::Engine => '/admin'"
-        route "mount Decidim::Api::Engine => '/api'"
         route "mount Decidim::Core::Engine => '/'"
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
We've all felt the pain of our development apps becoming outdated as we keep adding more engines - normally because you might need to add a new mount point in your `routes.rb`. This PR deals with it letting the engines mount themselves against `Decidim::Core::Engine` and making `Decidim::Core::Engine` the only mount point of the app.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/l3vR9cgQTcYSQNRpC/giphy.gif)

