### PR TITLE
Improve coverage analysis

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -65,10 +65,6 @@ coverage:
 
   ignore:
   - spec
-  - decidim-core/lib/decidim/core/engine.rb
-  - decidim-admin/lib/decidim/admin/engine.rb
-  - decidim-system/lib/decidim/system/engine.rb
-  - decidim-api/lib/decidim/api/engine.rb
 
 comment:
   layout: "header, diff, changes, sunburst, uncovered, tree"


### PR DESCRIPTION
#### :tophat: What? Why?
When running `simplecov` locally, it looks like engines are covered and we have a close-to 100% coverage. Nonetheless, they don't seem to report as covered in `codecov`. This PR tries to palliate that.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3rgXBD5tBiqvFdUi4g/giphy.gif)

