### PR TITLE
Fix constant lookup

### DIFF
--- a/decidim-api/app/controllers/decidim/api/documentation_controller.rb
+++ b/decidim-api/app/controllers/decidim/api/documentation_controller.rb
@@ -3,7 +3,7 @@ module Decidim
   module Api
     # This controller takes queries from an HTTP endpoint and sends them out to
     # the Schema to be executed, later returning the response as JSON.
-    class DocumentationController < ApplicationController
+    class DocumentationController < Api::ApplicationController
       layout "decidim/api/documentation"
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Rails' constant reloading causes errors in some cases. one of them is:

1. Restart the server
1. Visit the root path of the app
1. Visit `localhost:3000/api/docs` and watch the server fail

This PR ensures the constant is correctly loaded.

#### :pushpin: Related Issues
- Fixes #248

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*