### PR TITLE
Add settings section to participatory processes

### DIFF
--- a/decidim-admin/app/views/decidim/admin/participatory_processes/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/edit.html.erb
@@ -1,4 +1,16 @@
-<h3><%= t ".title" %></h3>
+<div class="actions">
+  <% if can? :publish, participatory_process %>
+    <% if participatory_process.published? %>
+      <%= link_to t("actions.unpublish", scope: "decidim.admin"), participatory_process_publish_path(participatory_process), method: :delete, class: "small button secondary" %>
+    <% else %>
+      <%= link_to t("actions.publish", scope: "decidim.admin"), participatory_process_publish_path(participatory_process), method: :post, class: "small button secondary" %>
+    <% end %>
+  <% end %>
+
+  <% if can? :destroy, participatory_process %>
+    <%= link_to t("decidim.admin.actions.destroy"), participatory_process, method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } %>
+  <% end %>
+</div>
 
 <%= form_for(@form) do |f| %>
   <%= render partial: 'form', object: f %>

--- a/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
@@ -4,31 +4,18 @@
 <% end %>
 
 <%= render "layouts/decidim/admin/application" do %>
-  <div class="actions">
-    <hr />
-    <% if can? :update, participatory_process %>
-      <%= link_to t("decidim.admin.actions.edit"), ['edit', participatory_process] %>
-    <% end %>
-
-    <% if can? :publish, participatory_process %>
-      <% if participatory_process.published? %>
-        <%= link_to t("actions.unpublish", scope: "decidim.admin"), participatory_process_publish_path(participatory_process), method: :delete, class: "small button secondary" %>
-      <% else %>
-        <%= link_to t("actions.publish", scope: "decidim.admin"), participatory_process_publish_path(participatory_process), method: :post, class: "small button secondary" %>
-      <% end %>
-    <% end %>
-
-    <% if can? :destroy, participatory_process %>
-      <%= link_to t("decidim.admin.actions.destroy"), participatory_process, method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } %>
-    <% end %>
-  </div>
-
+  <hr />
   <div class="row">
     <div class="medium-3 columns">
       <ul class="tabs vertical" id="example-vert-tabs">
         <li class="tabs-title is-active">
           <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.participatory_processes_submenu"), participatory_process_path(participatory_process) %>
         </li>
+        <% if can? :update, participatory_process %>
+          <li class="tabs-title">
+            <%= aria_selected_link_to t("settings", scope: "decidim.admin.menu.participatory_processes_submenu"), edit_participatory_process_path(participatory_process) %>
+          </li>
+        <% end %>
         <% if can? :read, Decidim::ParticipatoryProcessStep %>
           <li class="tabs-title">
             <%= aria_selected_link_to t("steps", scope: "decidim.admin.menu.participatory_processes_submenu"), participatory_process_steps_path(participatory_process) %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
         participatory_processes_submenu:
           info: Info
           process_admins: Process admins
+          settings: Settings
           steps: Steps
         settings: Settings
         static_pages: Pages
@@ -113,7 +114,6 @@ en:
         destroy:
           success: Participatory process destroyed successfully.
         edit:
-          title: Edit participatory process
           update: Update participatory process
         new:
           create: Create participatory process

--- a/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
@@ -96,6 +96,7 @@ describe "Admin manage participatory processes", type: :feature do
 
     it "deletes a participatory_process" do
       click_link translated(participatory_process2.title)
+      click_processes_menu_link "Settings"
       click_link "Destroy"
 
       within ".flash" do

--- a/decidim-admin/spec/shared/manage_processes_examples.rb
+++ b/decidim-admin/spec/shared/manage_processes_examples.rb
@@ -68,7 +68,7 @@ RSpec.shared_examples "manage processes examples" do
 
   it "updates an participatory_process" do
     click_link translated(participatory_process.title)
-    click_link "Edit"
+    click_processes_menu_link "Settings"
 
     within ".edit_participatory_process" do
       fill_in_i18n(
@@ -103,13 +103,14 @@ RSpec.shared_examples "manage processes examples" do
 
     before do
       click_link translated(participatory_process.title)
+      click_processes_menu_link "Settings"
     end
 
     it "publishes the process" do
       click_link "Publish"
       expect(page).to have_content("published successfully")
       expect(page).to have_content("Unpublish")
-      expect(current_path).to eq decidim_admin.participatory_process_path(participatory_process)
+      expect(current_path).to eq decidim_admin.edit_participatory_process_path(participatory_process)
 
       participatory_process.reload
       expect(participatory_process).to be_published
@@ -121,13 +122,14 @@ RSpec.shared_examples "manage processes examples" do
 
     before do
       click_link translated(participatory_process.title)
+      click_processes_menu_link "Settings"
     end
 
     it "unpublishes the process" do
       click_link "Unpublish"
       expect(page).to have_content("unpublished successfully")
       expect(page).to have_content("Publish")
-      expect(current_path).to eq decidim_admin.participatory_process_path(participatory_process)
+      expect(current_path).to eq decidim_admin.edit_participatory_process_path(participatory_process)
 
       participatory_process.reload
       expect(participatory_process).not_to be_published

--- a/decidim-admin/spec/spec_helper.rb
+++ b/decidim-admin/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 ENV["ENGINE_NAME"] = File.dirname(File.dirname(__FILE__)).split("/").last
 require "decidim/test/base_spec_helper"
+
+RSpec.configure do |config|
+  config.include ProcessesMenuLinksHelpers
+end

--- a/decidim-admin/spec/support/processes_menu_links_helpers.rb
+++ b/decidim-admin/spec/support/processes_menu_links_helpers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# A collection of methods to help dealing with processes menu links.
+module ProcessesMenuLinksHelpers
+  # Clicks a link in the submenu of a participatory process navigation.
+  #
+  # text - a String with the name of the link that will be clicked
+  def click_processes_menu_link(text)
+    within ".row .tabs.vertical" do
+      click_link text
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Moves the `edit` and `delete` buttons from participatory processes to a Settings section. 

#### :pushpin: Related Issues
- Fixes #235 

#### :clipboard: Subtasks
- [x] Change layout
- [x] Fix specs

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/GHjufe1.png)

