### PR TITLE
Add categories to processes

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/_layout.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/_layout.scss
@@ -18,3 +18,10 @@
 dd {
   margin-bottom: 1rem;
 }
+
+tr.subcategory {
+  td:first-child a:before {
+    content: "•";
+    margin-right: 1rem;
+  }
+}

--- a/decidim-admin/app/commands/decidim/admin/create_category.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_category.rb
@@ -35,6 +35,7 @@ module Decidim
         Category.create!(
           name: form.name,
           description: form.description,
+          parent_id: form.parent_id,
           participatory_process: @participatory_process
         )
       end

--- a/decidim-admin/app/commands/decidim/admin/create_category.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_category.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A command with all the business logic to create a new category in the
+    # system.
+    class CreateCategory < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # form - A form object with the params.
+      # participatory_process - The ParticipatoryProcess that will hold the
+      #   category
+      def initialize(form, participatory_process)
+        @form = form
+        @participatory_process = participatory_process
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        create_category
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :form
+
+      def create_category
+        Category.create!(
+          name: form.name,
+          description: form.description,
+          participatory_process: @participatory_process
+        )
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/destroy_category.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_category.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    class DestroyCategory < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # category - A Category that will be destroyed
+      def initialize(category)
+        @category = category
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the data wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if category.nil? || category.subcategories.any?
+
+        destroy_category
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :category
+
+      def destroy_category
+        category.destroy!
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/destroy_category.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_category.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Decidim
   module Admin
+    # A command with all the business logic to destroy a category in the
+    # system.
     class DestroyCategory < Rectify::Command
       # Public: Initializes the command.
       #

--- a/decidim-admin/app/commands/decidim/admin/update_category.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_category.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A command with all the business logic when updating a category in the
+    # system.
+    class UpdateCategory < Rectify::Command
+      attr_reader :category
+
+      # Public: Initializes the command.
+      #
+      # category - the Category to update
+      # form - A form object with the params.
+      def initialize(category, form)
+        @category = category
+        @form = form
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        update_category
+        broadcast(:ok)
+      end
+
+      private
+
+      attr_reader :form
+
+      def update_category
+        category.update_attributes!(attributes)
+      end
+
+      def attributes
+        {
+          name: form.name,
+          description: form.description
+        }
+      end
+    end
+  end
+end

--- a/decidim-admin/app/commands/decidim/admin/update_category.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_category.rb
@@ -39,6 +39,7 @@ module Decidim
       def attributes
         {
           name: form.name,
+          parent_id: form.parent_id,
           description: form.description
         }
       end

--- a/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
@@ -14,12 +14,12 @@ module Decidim
 
       def new
         authorize! :create, Decidim::Category
-        @form = form(CategoryForm).instance
+        @form = form(CategoryForm).instance(current_process: participatory_process)
       end
 
       def create
         authorize! :create, Decidim::Category
-        @form = form(CategoryForm).from_params(params)
+        @form = form(CategoryForm).from_params(params, current_process: participatory_process)
 
         CreateCategory.call(@form, participatory_process) do
           on(:ok) do
@@ -37,13 +37,13 @@ module Decidim
       def edit
         @category = collection.find(params[:id])
         authorize! :update, @category
-        @form = form(CategoryForm).from_model(@category)
+        @form = form(CategoryForm).from_model(@category, current_process: participatory_process)
       end
 
       def update
         @category = collection.find(params[:id])
         authorize! :update, @category
-        @form = form(CategoryForm).from_params(params)
+        @form = form(CategoryForm).from_params(params, current_process: participatory_process)
 
         UpdateCategory.call(@category, @form) do
           on(:ok) do
@@ -73,7 +73,7 @@ module Decidim
           end
 
           on(:invalid) do
-            flash.now[:alert] = I18n.t("categories.destroy.error", scope: "decidim.admin")
+            flash[:alert] = I18n.t("categories.destroy.error", scope: "decidim.admin")
           end
 
           redirect_back(fallback_location: participatory_process_categories_path(participatory_process))

--- a/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require_dependency "decidim/admin/application_controller"
+
+module Decidim
+  module Admin
+    # Controller that allows managing all the Admins.
+    #
+    class CategoriesController < ApplicationController
+      include Concerns::ParticipatoryProcessAdmin
+
+      def index
+        authorize! :read, Decidim::Category
+      end
+
+      def new
+        authorize! :create, Decidim::Category
+        @form = form(CategoryForm).instance
+      end
+
+      def create
+        authorize! :create, Decidim::Category
+        @form = form(CategoryForm).from_params(params)
+
+        CreateCategory.call(@form, participatory_process) do
+          on(:ok) do
+            flash[:notice] = I18n.t("categories.create.success", scope: "decidim.admin")
+            redirect_to participatory_process_categories_path(participatory_process)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("categories.create.error", scope: "decidim.admin")
+            render :new
+          end
+        end
+      end
+
+      def edit
+        @category = collection.find(params[:id])
+        authorize! :update, @category
+        @form = form(CategoryForm).from_model(@category)
+      end
+
+      def update
+        @category = collection.find(params[:id])
+        authorize! :update, @category
+        @form = form(CategoryForm).from_params(params)
+
+        UpdateCategory.call(@category, @form) do
+          on(:ok) do
+            flash[:notice] = I18n.t("categories.update.success", scope: "decidim.admin")
+            redirect_to participatory_process_categories_path(participatory_process)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("categories.update.error", scope: "decidim.admin")
+            render :edit
+          end
+        end
+      end
+
+      def show
+        @category = collection.find(params[:id])
+        authorize! :read, @category
+      end
+
+      def destroy
+        @category = collection.find(params[:id])
+        authorize! :destroy, @category
+
+        DestroyCategory.call(@category) do
+          on(:ok) do
+            flash[:notice] = I18n.t("categories.destroy.success", scope: "decidim.admin")
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("categories.destroy.error", scope: "decidim.admin")
+          end
+
+          redirect_back(fallback_location: participatory_process_categories_path(participatory_process))
+        end
+      end
+
+      private
+
+      def collection
+        @collection ||= participatory_process.categories
+      end
+    end
+  end
+end

--- a/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
@@ -14,7 +14,7 @@ module Decidim
 
       def new
         authorize! :create, Decidim::Category
-        @form = form(CategoryForm).instance(current_process: participatory_process)
+        @form = form(CategoryForm).from_params({}, current_process: participatory_process)
       end
 
       def create

--- a/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/categories_controller.rb
@@ -83,7 +83,7 @@ module Decidim
       private
 
       def collection
-        @collection ||= participatory_process.categories
+        @collection ||= participatory_process.categories.includes(:subcategories)
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/category_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/category_form.rb
@@ -13,6 +13,7 @@ module Decidim
       mimic :category
 
       validates :name, :description, translatable_presence: true
+      validates :current_process, presence: true
       validates :parent_id, inclusion: { in: :parent_categories_ids }, allow_blank: true
 
       attr_reader :current_process

--- a/decidim-admin/app/forms/decidim/admin/category_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/category_form.rb
@@ -24,13 +24,13 @@ module Decidim
       end
 
       def parent_categories
-        current_process.categories.first_class.where.not(id: id)
+        @parent_categories ||= current_process.categories.first_class.where.not(id: id)
       end
 
       private
 
       def parent_categories_ids
-        parent_categories.pluck(:id)
+        @parent_categories_ids ||= parent_categories.pluck(:id)
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/category_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/category_form.rb
@@ -8,10 +8,29 @@ module Decidim
 
       translatable_attribute :name, String
       translatable_attribute :description, String
+      attribute :parent_id, Integer
 
       mimic :category
 
       validates :name, :description, translatable_presence: true
+      validates :parent_id, inclusion: { in: :parent_categories_ids }, allow_blank: true
+
+      attr_reader :current_process
+
+      def initialize(attributes = {})
+        @current_process = attributes.delete("current_process") || attributes.delete(:current_process)
+        super
+      end
+
+      def parent_categories
+        current_process.categories.first_class.where.not(id: id)
+      end
+
+      private
+
+      def parent_categories_ids
+        parent_categories.pluck(:id)
+      end
     end
   end
 end

--- a/decidim-admin/app/forms/decidim/admin/category_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/category_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A form object used to create categories from the admin dashboard.
+    #
+    class CategoryForm < Form
+      include TranslatableAttributes
+
+      translatable_attribute :name, String
+      translatable_attribute :description, String
+
+      mimic :category
+
+      validates :name, :description, translatable_presence: true
+    end
+  end
+end

--- a/decidim-admin/app/helpers/decidim/admin/aria_selected_link_to_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/aria_selected_link_to_helper.rb
@@ -19,7 +19,7 @@ module Decidim
           text,
           link,
           options.merge(
-            "aria-selected": is_active_link?(link, :exclusive)
+            "aria-selected": is_active_link?(link, options[:aria_link_type] || :inclusive)
           )
         )
       end

--- a/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
@@ -13,6 +13,7 @@ module Decidim
 
           can :manage, ParticipatoryProcess
           can :manage, ParticipatoryProcessStep
+          can :manage, Category
           can :manage, ParticipatoryProcessUserRole
           can [:create, :update, :index, :new, :read], StaticPage
           can [:update_slug, :destroy], [StaticPage, StaticPageForm] do |page|

--- a/decidim-admin/app/models/decidim/admin/abilities/participatory_process_admin.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/participatory_process_admin.rb
@@ -40,6 +40,10 @@ module Decidim
           can :manage, Component do |component|
             participatory_processes.include?(component.participatory_process)
           end
+
+          can :manage, Category do |category|
+            participatory_processes.include?(category.participatory_process)
+          end
         end
       end
     end

--- a/decidim-admin/app/views/decidim/admin/categories/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/_form.html.erb
@@ -1,0 +1,7 @@
+<div class="field">
+  <%= form.translated :text_field, :name, autofocus: true %>
+</div>
+
+<div class="field">
+  <%= form.translated :editor, :description %>
+</div>

--- a/decidim-admin/app/views/decidim/admin/categories/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/_form.html.erb
@@ -5,3 +5,8 @@
 <div class="field">
   <%= form.translated :editor, :description %>
 </div>
+
+<div class="field">
+  <%= form.label :parent_id %>
+  <%= select :category, :parent_id, @form.parent_categories.collect { |c| [c.name[current_organization.default_locale], c.id] }, include_blank: true %>
+</div>

--- a/decidim-admin/app/views/decidim/admin/categories/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/edit.html.erb
@@ -1,0 +1,9 @@
+<h3><%= t ".title" %></h3>
+
+<%= form_for(@form, url: participatory_process_category_path(@category.participatory_process, @category)) do |f| %>
+  <%= render partial: 'form', object: f %>
+
+  <div class="actions">
+    <%= f.submit t(".update") %>
+  </div>
+<% end %>

--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -1,0 +1,33 @@
+<section id="categories">
+  <h4><%= t(".categories_title", scope: "decidim.admin") %></h4>
+
+  <% if can? :create, Decidim::Category %>
+    <div class="actions title">
+      <%= link_to t("actions.new", scope: "decidim.admin", name: t("models.category.name", scope: "decidim.admin")), new_participatory_process_category_path(participatory_process), class: 'new' %>
+    </div>
+  <% end %>
+
+  <% if participatory_process.categories.any? %>
+    <table class="stack">
+      <thead>
+        <tr>
+          <th><%= t("models.category.fields.name", scope: "decidim.admin") %></th>
+          <th class="actions"><%= t("actions.title", scope: "decidim.admin") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% participatory_process.categories.each do |category| %>
+          <tr data-id="<%= category.id %>">
+            <td>
+              <%= link_to translated_attribute(category.name), participatory_process_category_path(participatory_process, category) %><br />
+            </td>
+            <td class="actions">
+              <%= link_to t("actions.edit", scope: "decidim.admin"), edit_participatory_process_category_path(participatory_process, category) if can? :update, category %>
+              <%= link_to t("actions.destroy", scope: "decidim.admin"), participatory_process_category_path(participatory_process, category), method: :delete, class: "small alert button", data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } if can? :destroy, category %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>

--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -16,8 +16,8 @@
         </tr>
       </thead>
       <tbody>
-        <% participatory_process.categories.each do |category| %>
-          <tr data-id="<%= category.id %>">
+        <% participatory_process.categories.first_class.each do |category| %>
+          <tr>
             <td>
               <%= link_to translated_attribute(category.name), participatory_process_category_path(participatory_process, category) %><br />
             </td>
@@ -26,6 +26,17 @@
               <%= link_to t("actions.destroy", scope: "decidim.admin"), participatory_process_category_path(participatory_process, category), method: :delete, class: "small alert button", data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } if can? :destroy, category %>
             </td>
           </tr>
+          <% category.subcategories.each do |subcategory| %>
+            <tr class="subcategory">
+              <td>
+                <%= link_to translated_attribute(subcategory.name), participatory_process_category_path(participatory_process, subcategory) %><br />
+              </td>
+              <td class="actions">
+                <%= link_to t("actions.edit", scope: "decidim.admin"), edit_participatory_process_category_path(participatory_process, subcategory) if can? :update, subcategory %>
+                <%= link_to t("actions.destroy", scope: "decidim.admin"), participatory_process_category_path(participatory_process, subcategory), method: :delete, class: "small alert button", data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } if can? :destroy, subcategory %>
+              </td>
+            </tr>
+          <% end %>
         <% end %>
       </tbody>
     </table>

--- a/decidim-admin/app/views/decidim/admin/categories/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/new.html.erb
@@ -1,6 +1,6 @@
 <h3><%= t ".title" %></h3>
 
-<%= form_for(@form) do |f| %>
+<%= form_for(@form, url: participatory_process_categories_path(participatory_process)) do |f| %>
   <%= render partial: 'form', object: f %>
 
   <div class="actions">

--- a/decidim-admin/app/views/decidim/admin/categories/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/new.html.erb
@@ -1,0 +1,9 @@
+<h3><%= t ".title" %></h3>
+
+<%= form_for(@form) do |f| %>
+  <%= render partial: 'form', object: f %>
+
+  <div class="actions">
+    <%= f.submit t(".create") %>
+  </div>
+<% end %>

--- a/decidim-admin/app/views/decidim/admin/categories/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/show.html.erb
@@ -1,0 +1,14 @@
+<h3><%= translated_attribute(@category.name) %></h3>
+
+<div class="actions">
+  <hr />
+  <%= link_to t("decidim.admin.actions.edit"), ['edit', participatory_process, @category] if can? :update, @category %>
+  <%= link_to t("decidim.admin.actions.destroy"), [participatory_process, @category], method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } if can? :destroy, @category %>
+</div>
+
+<dl>
+  <%= display_for @category,
+    :name,
+    :description
+    %>
+</dl>

--- a/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
@@ -23,7 +23,7 @@
         <% end %>
         <% if can? :read, Decidim::Category %>
           <li class="tabs-title">
-            <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.participatory_processes_submenu"), participatory_process_categories_path(participatory_process) %>
+            <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin.participatory_process_categories_path(participatory_process) %>
           </li>
         <% end %>
         <% if can? :read, Decidim::Admin::ParticipatoryProcessUserRole %>

--- a/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
@@ -9,7 +9,7 @@
     <div class="medium-3 columns">
       <ul class="tabs vertical" id="example-vert-tabs">
         <li class="tabs-title is-active">
-          <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin.participatory_process_path(participatory_process) %>
+          <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin.participatory_process_path(participatory_process), aria_link_type: :exclusive %>
         </li>
         <% if can? :read, Decidim::ParticipatoryProcessStep %>
           <li class="tabs-title">
@@ -19,6 +19,11 @@
         <% if can? :read, Decidim::Feature %>
           <li class="tabs-title">
             <%= aria_selected_link_to t("features", scope: "decidim.admin.menu.participatory_processes_submenu"), decidim_admin.participatory_process_features_path(participatory_process) %>
+          </li>
+        <% end %>
+        <% if can? :read, Decidim::Category %>
+          <li class="tabs-title">
+            <%= aria_selected_link_to t("categories", scope: "decidim.admin.menu.participatory_processes_submenu"), participatory_process_categories_path(participatory_process) %>
           </li>
         <% end %>
         <% if can? :read, Decidim::Admin::ParticipatoryProcessUserRole %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -24,7 +24,7 @@ en:
           error: There was an error creating this category.
           success: Category created successfully.
         destroy:
-          error: There was an error deleting this category.
+          error: There was an error deleting this category. Please delete any subcategory first, make sure no other entity belongs to this category and try again.
           success: Category deleted successfully.
         edit:
           title: Edit category

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -19,6 +19,22 @@ en:
         publish: Publish
         title: Actions
         unpublish: Unpublish
+      categories:
+        create:
+          error: There was an error creating this category.
+          success: Category created successfully.
+        destroy:
+          error: There was an error deleting this category.
+          success: Category deleted successfully.
+        edit:
+          title: Edit category
+          update: Update category
+        new:
+          create: Create category
+          title: New category
+        update:
+          error: There was an error updating this category.
+          success: Category updated successfully.
       components:
         create:
           error: There was an error creating this component.
@@ -54,6 +70,9 @@ en:
         title: Features
       decidim:
         admin:
+          categories:
+            index:
+              categories_title: Categories
           participatory_process_attachments:
             index:
               attachments_title: Attachments
@@ -69,6 +88,7 @@ en:
         participatory_processes: Participatory processes
         participatory_processes_submenu:
           attachments: Attachments
+          categories: Categories
           features: Features
           info: Info
           process_admins: Process admins
@@ -77,6 +97,10 @@ en:
         settings: Settings
         static_pages: Pages
       models:
+        category:
+          fields:
+            name: Name
+          name: Category
         participatory_process:
           fields:
             created_at: Created at

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -7,6 +7,8 @@ Decidim::Admin::Engine.routes.draw do
     resources :participatory_processes do
       resource :publish, controller: "participatory_process_publications", only: [:create, :destroy]
 
+      resources :categories
+
       resources :steps, controller: "participatory_process_steps" do
         resource :activate, controller: "participatory_process_step_activations", only: [:create, :destroy]
         collection do

--- a/decidim-admin/spec/commands/create_category_spec.rb
+++ b/decidim-admin/spec/commands/create_category_spec.rb
@@ -10,12 +10,12 @@ module Decidim
         let(:form_params) do
           {
             "category" => {
-              "name_en" => "Title",
-              "name_es" => "Title",
-              "name_ca" => "Title",
-              "description_en" => "Description",
-              "description_es" => "Description",
-              "description_ca" => "Description"
+              "name_en" => Decidim::Faker::Localized.paragraph(3),
+              "name_es" => Decidim::Faker::Localized.paragraph(3),
+              "name_ca" => Decidim::Faker::Localized.paragraph(3),
+              "description_en" => Decidim::Faker::Localized.paragraph(3),
+              "description_es" => Decidim::Faker::Localized.paragraph(3),
+              "description_ca" => Decidim::Faker::Localized.paragraph(3)
             }
           }
         end

--- a/decidim-admin/spec/commands/create_category_spec.rb
+++ b/decidim-admin/spec/commands/create_category_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe CreateCategory, :db do
+      describe "call" do
+        let(:organization) { create(:organization) }
+        let(:participatory_process) { create :participatory_process, organization: organization }
+        let(:form_params) do
+          {
+            "category" => {
+              "name_en" => "Title",
+              "name_es" => "Title",
+              "name_ca" => "Title",
+              "description_en" => "Description",
+              "description_es" => "Description",
+              "description_ca" => "Description"
+            }
+          }
+        end
+        let(:form) do
+          CategoryForm.from_params(
+            form_params,
+            current_organization: organization,
+            current_process: participatory_process
+          )
+        end
+        let(:command) { described_class.new(form, participatory_process) }
+
+        describe "when the form is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't create a category" do
+            expect do
+              command.call
+            end.to_not change { Category.count }
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "creates a new category" do
+            expect do
+              command.call
+            end.to change { participatory_process.categories.count }.by(1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/commands/destroy_category_spec.rb
+++ b/decidim-admin/spec/commands/destroy_category_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe DestroyCategory, :db do
+      describe "call" do
+        let(:organization) { create(:organization) }
+        let(:participatory_process) { create :participatory_process, organization: organization }
+        let(:category) { create(:category, participatory_process: participatory_process) }
+        let(:command) { described_class.new(category) }
+
+        describe "when the category is not present" do
+          let(:category) { nil }
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when the category is not empty" do
+          let!(:subcategory) { create :subcategory, parent: category }
+
+          it "doesn't destroy the category" do
+            expect do
+              command.call
+            end.to_not change { Category.count }
+          end
+        end
+
+        describe "when the data is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "destroys the category in the organization" do
+            category
+            expect do
+              command.call
+            end.to change { Category.count }.by(-1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/commands/destroy_category_spec.rb
+++ b/decidim-admin/spec/commands/destroy_category_spec.rb
@@ -33,7 +33,7 @@ module Decidim
             expect { command.call }.to broadcast(:ok)
           end
 
-          it "destroys the category in the organization" do
+          it "destroys the category in the process" do
             category
             expect do
               command.call

--- a/decidim-admin/spec/commands/update_category_spec.rb
+++ b/decidim-admin/spec/commands/update_category_spec.rb
@@ -51,7 +51,7 @@ module Decidim
             expect { command.call }.to broadcast(:ok)
           end
 
-          it "updates the category in the organization" do
+          it "updates the category in the process" do
             command.call
             category.reload
 

--- a/decidim-admin/spec/commands/update_category_spec.rb
+++ b/decidim-admin/spec/commands/update_category_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe UpdateCategory, :db do
+      describe "call" do
+        let(:organization) { create(:organization) }
+        let(:participatory_process) { create :participatory_process, organization: organization }
+        let(:category) { create(:category, participatory_process: participatory_process) }
+        let(:form_params) do
+          {
+            "category" => {
+              "name_en" => "New title",
+              "name_es" => "Title",
+              "name_ca" => "Title",
+              "description_en" => "Description",
+              "description_es" => "Description",
+              "description_ca" => "Description"
+            }
+          }
+        end
+        let(:form) do
+          CategoryForm.from_params(
+            form_params,
+            current_organization: organization,
+            current_process: participatory_process
+          )
+        end
+        let(:command) { described_class.new(category, form) }
+
+        describe "when the form is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't update the category" do
+            command.call
+            category.reload
+
+            expect(translated(category.name)).to_not eq("New title")
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "updates the category in the organization" do
+            command.call
+            category.reload
+
+            expect(translated(category.name)).to eq("New title")
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/features/admin_manages_participatory_process_categories_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_process_categories_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../shared/manage_process_categories_examples"
+
+describe "Admin manages participatory process categories", type: :feature do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:participatory_process) do
+    create(
+      :participatory_process,
+      organization: organization,
+      description: { en: "Description", ca: "Descripció", es: "Descripción" },
+      short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
+    )
+  end
+  let!(:category) do
+    create(
+      :category,
+      participatory_process: participatory_process
+    )
+  end
+
+  it_behaves_like "manage process categories examples"
+end

--- a/decidim-admin/spec/features/process_admin_manages_participatory_process_categories_spec.rb
+++ b/decidim-admin/spec/features/process_admin_manages_participatory_process_categories_spec.rb
@@ -7,6 +7,8 @@ require_relative "../shared/manage_process_categories_examples"
 describe "Admin manages participatory process categories", type: :feature do
   include_context "participatory process admin"
 
+  let(:user) { process_admin }
+
   let!(:category) do
     create(
       :category,

--- a/decidim-admin/spec/forms/category_form_spec.rb
+++ b/decidim-admin/spec/forms/category_form_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe CategoryForm do
+      let(:name) do
+        {
+          en: "Name",
+          es: "Nombre",
+          ca: "Nom"
+        }
+      end
+      let(:description) do
+        {
+          en: "Description",
+          es: "Descripción",
+          ca: "Descripció"
+        }
+      end
+      let(:parent_id) { nil }
+      let(:attributes) do
+        {
+          "category" => {
+            "name_en" => name[:en],
+            "name_es" => name[:es],
+            "name_ca" => name[:ca],
+            "parent_id" => parent_id,
+            "description_en" => description[:en],
+            "description_es" => description[:es],
+            "description_ca" => description[:ca]
+          }
+        }
+      end
+      let(:organization) { create :organization }
+      let(:participatory_process) { create :participatory_process, organization: organization }
+
+      subject do
+        described_class.from_params(
+          attributes,
+          current_process: participatory_process,
+          current_organization: organization
+        )
+      end
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when participatory process is not set" do
+        let(:participatory_process) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when some language in name is missing" do
+        let(:name) do
+          {
+            en: "Name",
+            ca: "Nombre"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when some language in description is missing" do
+        let(:description) do
+          {
+            ca: "Descripció"
+          }
+        end
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when the parent_id is set" do
+        context "to the ID of a first-class category" do
+          let!(:category) { create :category, participatory_process: participatory_process }
+          let(:parent_id) { category.id }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "to the ID of a subcategory" do
+          let!(:subcategory) { create :subcategory }
+          let(:parent_id) { subcategory.id }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/shared/manage_process_categories_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_categories_examples.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+RSpec.shared_examples "manage process categories examples" do
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin.participatory_process_path(participatory_process)
+    click_link "Categories"
+  end
+
+  it "displays all fields from a single category" do
+    within "#categories table" do
+      click_link translated(category.name)
+    end
+
+    within "dl" do
+      expect(page).to have_i18n_content(category.name, locale: :en)
+      expect(page).to have_i18n_content(category.name, locale: :es)
+      expect(page).to have_i18n_content(category.name, locale: :ca)
+      expect(page).to have_i18n_content(category.description, locale: :en)
+      expect(page).to have_i18n_content(category.description, locale: :es)
+      expect(page).to have_i18n_content(category.description, locale: :ca)
+    end
+  end
+
+  it "creates a new category" do
+    find("#categories .actions .new").click
+
+    within ".new_category" do
+      fill_in_i18n(
+        :category_name,
+        "#name-tabs",
+        en: "My category",
+        es: "Mi categoría",
+        ca: "La meva categoria"
+      )
+      fill_in_i18n_editor(
+        :category_description,
+        "#short_description-tabs",
+        en: "Short description",
+        es: "Descripción corta",
+        ca: "Descripció curta"
+      )
+
+      find("*[type=submit]").click
+    end
+
+    within ".flash" do
+      expect(page).to have_content("successfully")
+    end
+
+    within "#categories table" do
+      expect(page).to have_content("My category")
+    end
+  end
+
+  it "updates a category" do
+    within "#categories" do
+      within find("tr", text: translated(category.name)) do
+        click_link "Edit"
+      end
+    end
+
+    within ".edit_category" do
+      fill_in_i18n(
+        :category_name,
+        "#name-tabs",
+        en: "My new name",
+        es: "Mi nuevo nombre",
+        ca: "El meu nou nom"
+      )
+
+      find("*[type=submit]").click
+    end
+
+    within ".flash" do
+      expect(page).to have_content("successfully")
+    end
+
+    within "#categories table" do
+      expect(page).to have_content("My new name")
+    end
+  end
+
+  context "deleting a category" do
+    let!(:category2) { create(:category, participatory_process: participatory_process) }
+
+    before do
+      visit current_path
+    end
+
+    context "when the category has no subcategories" do
+      it "deletes a category" do
+        within find("tr", text: translated(category2.name)) do
+          click_link "Destroy"
+        end
+
+        within ".flash" do
+          expect(page).to have_content("successfully")
+        end
+
+        within "#categories table" do
+          expect(page).to_not have_content(translated(category2.name))
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/shared/manage_process_categories_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_categories_examples.rb
@@ -84,11 +84,11 @@ RSpec.shared_examples "manage process categories examples" do
   context "deleting a category" do
     let!(:category2) { create(:category, participatory_process: participatory_process) }
 
-    before do
-      visit current_path
-    end
-
     context "when the category has no subcategories" do
+      before do
+        visit current_path
+      end
+
       it "deletes a category" do
         within find("tr", text: translated(category2.name)) do
           click_link "Destroy"
@@ -100,6 +100,28 @@ RSpec.shared_examples "manage process categories examples" do
 
         within "#categories table" do
           expect(page).to_not have_content(translated(category2.name))
+        end
+      end
+    end
+
+    context "when the category has some subcategories" do
+      let!(:subcategory) { create(:subcategory, parent: category2) }
+
+      before do
+        visit current_path
+      end
+
+      it "deletes a category" do
+        within find("tr", text: translated(category2.name)) do
+          click_link "Destroy"
+        end
+
+        within ".flash" do
+          expect(page).to have_content("error deleting")
+        end
+
+        within "#categories table" do
+          expect(page).to have_content(translated(category2.name))
         end
       end
     end

--- a/decidim-admin/spec/shared/manage_process_categories_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_categories_examples.rb
@@ -35,10 +35,10 @@ RSpec.shared_examples "manage process categories examples" do
       )
       fill_in_i18n_editor(
         :category_description,
-        "#short_description-tabs",
-        en: "Short description",
-        es: "Descripción corta",
-        ca: "Descripció curta"
+        "#description-tabs",
+        en: "Description",
+        es: "Descripción",
+        ca: "Descripció"
       )
 
       find("*[type=submit]").click

--- a/decidim-core/app/forms/decidim/form.rb
+++ b/decidim-core/app/forms/decidim/form.rb
@@ -6,8 +6,8 @@ module Decidim
     attr_reader :current_organization, :current_user
 
     def initialize(attributes = {})
-      @current_organization = attributes.delete("current_organization")
-      @current_user = attributes.delete("current_user")
+      @current_organization = attributes.delete("current_organization") || attributes.delete(:current_organization)
+      @current_user = attributes.delete("current_user") || attributes.delete(:current_user)
       super
     end
   end

--- a/decidim-core/app/models/decidim/category.rb
+++ b/decidim-core/app/models/decidim/category.rb
@@ -5,7 +5,7 @@ module Decidim
   class Category < ApplicationRecord
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess, inverse_of: :categories
     has_many :subcategories, ->(object) { where(parent_id: object.id) }, foreign_key: "parent_id", class_name: Decidim::Category, dependent: :destroy
-    has_one :parent, class_name: Decidim::Category, foreign_key: "parent_id"
+    belongs_to :parent, class_name: Decidim::Category, foreign_key: "parent_id"
 
     validate :forbid_deep_nesting
     before_save :subcategories_have_same_process

--- a/decidim-core/app/models/decidim/category.rb
+++ b/decidim-core/app/models/decidim/category.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Decidim
+  # Categories serve as a taxonomy for components to use for while in the
+  # context of a participatory process.
+  class Category < ApplicationRecord
+    belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess, inverse_of: :categories
+    has_many :subcategories, -> (object) { where(parent_id: object.id) }, foreign_key: "parent_id", class_name: Decidim::Category, dependent: :destroy
+    has_one :parent, class_name: Decidim::Category, foreign_key: "parent_id"
+
+    validate :forbid_deep_nesting
+    before_save :subcategories_have_same_process
+
+    # Scope to return only the first-class categories, that is, those that are
+    # not subcategories.
+    #
+    # Returns an ActiveRecord::Relation.
+    def self.first_class
+      where(parent_id: nil)
+    end
+
+    private
+
+    def forbid_deep_nesting
+      return unless parent
+      if parent.parent.present?
+        self.errors.add(:parent_id, :nesting_too_deep)
+      end
+    end
+
+    def subcategories_have_same_process
+      return unless parent
+      self.participatory_process = parent.participatory_process
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/category.rb
+++ b/decidim-core/app/models/decidim/category.rb
@@ -4,7 +4,7 @@ module Decidim
   # context of a participatory process.
   class Category < ApplicationRecord
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess, inverse_of: :categories
-    has_many :subcategories, -> (object) { where(parent_id: object.id) }, foreign_key: "parent_id", class_name: Decidim::Category, dependent: :destroy
+    has_many :subcategories, ->(object) { where(parent_id: object.id) }, foreign_key: "parent_id", class_name: Decidim::Category, dependent: :destroy
     has_one :parent, class_name: Decidim::Category, foreign_key: "parent_id"
 
     validate :forbid_deep_nesting
@@ -22,9 +22,9 @@ module Decidim
 
     def forbid_deep_nesting
       return unless parent
-      if parent.parent.present?
-        self.errors.add(:parent_id, :nesting_too_deep)
-      end
+      return unless parent.parent.present?
+
+      errors.add(:parent_id, :nesting_too_deep)
     end
 
     def subcategories_have_same_process

--- a/decidim-core/app/models/decidim/category.rb
+++ b/decidim-core/app/models/decidim/category.rb
@@ -4,8 +4,8 @@ module Decidim
   # context of a participatory process.
   class Category < ApplicationRecord
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess, inverse_of: :categories
-    has_many :subcategories, ->(object) { where(parent_id: object.id) }, foreign_key: "parent_id", class_name: Decidim::Category, dependent: :destroy
-    belongs_to :parent, class_name: Decidim::Category, foreign_key: "parent_id"
+    has_many :subcategories, foreign_key: "parent_id", class_name: Decidim::Category, dependent: :destroy, inverse_of: :parent
+    belongs_to :parent, class_name: Decidim::Category, foreign_key: "parent_id", inverse_of: :subcategories
 
     validate :forbid_deep_nesting
     before_save :subcategories_have_same_process

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -27,6 +27,11 @@ module Decidim
              class_name: Decidim::ParticipatoryProcessAttachment,
              dependent: :destroy,
              inverse_of: :participatory_process
+    has_many :categories,
+             foreign_key: "decidim_participatory_process_id",
+             class_name: Decidim::Category,
+             dependent: :destroy,
+             inverse_of: :participatory_process
 
     has_many :features, foreign_key: "decidim_participatory_process_id"
     has_many :components, through: :features

--- a/decidim-core/config/i18n-tasks.yml
+++ b/decidim-core/config/i18n-tasks.yml
@@ -94,6 +94,7 @@ ignore_unused:
   - activerecord.models.decidim/user
   - booleans.*
   - errors.messages.file_size_is_less_than_or_equal_to
+  - errors.messages.nesting_too_deep
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
       file_size_is_less_than_or_equal_to: file size must be less than or equal to %{count}
       invalid_manifest: "Invalid manifest"
       invalid_participatory_process: "Invalid participatory process"
+      nesting_too_deep: can't be inside of a subcategory
   layouts:
     decidim:
       footer:

--- a/decidim-core/db/migrate/20161123085134_add_categories.rb
+++ b/decidim-core/db/migrate/20161123085134_add_categories.rb
@@ -1,0 +1,10 @@
+class AddCategories < ActiveRecord::Migration[5.0]
+  def change
+    create_table :decidim_categories do |t|
+      t.jsonb :name, null: false
+      t.jsonb :description, null: false
+      t.integer :parent_id, index: true
+      t.integer :decidim_participatory_process_id, index: true
+    end
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -110,7 +110,7 @@ if !Rails.env.production? || ENV["SEED"]
     participatory_process: participatory_process1
   )
 
-  Decidim::ParticipatoryProcess.all.each do |process|
+  Decidim::ParticipatoryProcess.find_each do |process|
     Decidim::ParticipatoryProcessAttachment.create!(
       title: Decidim::Faker::Localized.sentence(2),
       description: Decidim::Faker::Localized.sentence(5),
@@ -123,5 +123,14 @@ if !Rails.env.production? || ENV["SEED"]
       file: File.new(File.join(File.dirname(__FILE__), "seeds", "Exampledocument.pdf")),
       participatory_process: process
     )
+    2.times do
+      Decidim::Category.create!(
+        name: Decidim::Faker::Localized.sentence(5),
+        description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+          Decidim::Faker::Localized.paragraph(3)
+        end,
+        participatory_process: process
+      )
+    end
   end
 end

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -1,6 +1,20 @@
 require "decidim/faker/localized"
 
 FactoryGirl.define do
+  factory :category, class: Decidim::Category do
+    name { Decidim::Faker::Localized.sentence(3) }
+    description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
+    participatory_process
+  end
+
+  factory :subcategory, parent: :category do
+    parent { build(:category) }
+
+    before(:create) do |object|
+      object.parent.save unless object.parent.persisted?
+    end
+  end
+
   factory :organization, class: Decidim::Organization do
     name { Faker::Company.name }
     sequence(:host) { |n| "#{n}.lvh.me" }

--- a/decidim-core/spec/models/decidim/category_spec.rb
+++ b/decidim-core/spec/models/decidim/category_spec.rb
@@ -19,6 +19,11 @@ module Decidim
       let(:category) { build(:category, parent: subcategory) }
 
       it { is_expected.not_to be_valid }
+
+      it "adds an error" do
+        subject.valid?
+        expect(subject.errors[:parent_id]).to eq ["can't be inside of a subcategory"]
+      end
     end
 
     context "before saving a subcategory" do

--- a/decidim-core/spec/models/decidim/category_spec.rb
+++ b/decidim-core/spec/models/decidim/category_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe Category do
+    let(:category) { build(:category) }
+    subject { category }
+
+    it { is_expected.to be_valid }
+
+    context "when it has a parent" do
+      let(:category) { create(:subcategory) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when its parent has a parent" do
+      let(:subcategory) { create(:subcategory) }
+      let(:category) { build(:category, parent: subcategory) }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "before saving a subcategory" do
+      let(:parent) { create(:category) }
+      let(:category) { create(:subcategory, parent: parent, participatory_process: nil) }
+
+      it "sets its process to its parent's" do
+        subject.save
+        expect(subject.participatory_process).to eq parent.participatory_process
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/test/rspec_support/helpers.rb
+++ b/decidim-dev/lib/decidim/test/rspec_support/helpers.rb
@@ -33,6 +33,10 @@ module Decidim::FeatureTestHelpers
   end
 end
 
+def stripped(text)
+  Nokogiri::HTML(text).text
+end
+
 RSpec.configure do |config|
   config.include Decidim::FeatureTestHelpers, type: :feature
 end

--- a/decidim-dev/lib/decidim/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/test/rspec_support/translation_helpers.rb
@@ -10,6 +10,15 @@ module TranslationHelpers
     field.try(:[], locale.to_s)
   end
 
+  # Checks that the current page has some translated content. It strips the
+  # HTML tags from the field (in case there are any).
+  #
+  # field - the field that holds the translations
+  # locale - the ID of the locale to check
+  def have_i18n_content(field, locale: I18n.locale)
+    have_content(stripped(translated(field, locale: locale)))
+  end
+
   # Handles how to fill in i18n form fields.
   #
   # field - the name of the field that should be filled, without the


### PR DESCRIPTION
#### :tophat: What? Why?
Adds categories to a participatory process. These categories can have one level of subcategories, but not two.

#### :pushpin: Related Issues
- Fixes #264 

#### :clipboard: Subtasks
- [x] Add categories
- [x] Add feature specs
- [x] Add unit tests
- [x] Add i18n for subcategories errors

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/Gi6GCAU.png)
