### PR TITLE
Put settings last in the panels

### DIFF
--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
@@ -8,9 +8,9 @@
 
 <nav class="main-menu">
   <%= active_link_to t("menu.dashboard", scope: "decidim.admin"), root_path, active: :exact %>
-  <%= active_link_to t("menu.settings", scope: "decidim.admin"), organization_path, active: :inclusive if can? :read, current_organization %>
   <%= active_link_to t("menu.participatory_processes", scope: "decidim.admin"), participatory_processes_path, active: :inclusive %>
   <%= active_link_to t("menu.static_pages", scope: "decidim.admin"), static_pages_path, active: :inclusive if can? :read, Decidim::StaticPage %>
+  <%= active_link_to t("menu.settings", scope: "decidim.admin"), organization_path, active: :inclusive if can? :read, current_organization %>
 </nav>
 
 <%= render partial: 'layouts/decidim/admin/login_items' %>

--- a/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
@@ -11,11 +11,6 @@
         <li class="tabs-title is-active">
           <%= aria_selected_link_to t("info", scope: "decidim.admin.menu.participatory_processes_submenu"), participatory_process_path(participatory_process) %>
         </li>
-        <% if can? :update, participatory_process %>
-          <li class="tabs-title">
-            <%= aria_selected_link_to t("settings", scope: "decidim.admin.menu.participatory_processes_submenu"), edit_participatory_process_path(participatory_process) %>
-          </li>
-        <% end %>
         <% if can? :read, Decidim::ParticipatoryProcessStep %>
           <li class="tabs-title">
             <%= aria_selected_link_to t("steps", scope: "decidim.admin.menu.participatory_processes_submenu"), participatory_process_steps_path(participatory_process) %>
@@ -29,6 +24,11 @@
         <% if can? :read, Decidim::ParticipatoryProcessAttachment %>
           <li class="tabs-title">
             <%= aria_selected_link_to t("attachments", scope: "decidim.admin.menu.participatory_processes_submenu"), participatory_process_attachments_path(participatory_process) %>
+          </li>
+        <% end %>
+        <% if can? :update, participatory_process %>
+          <li class="tabs-title">
+            <%= aria_selected_link_to t("settings", scope: "decidim.admin.menu.participatory_processes_submenu"), edit_participatory_process_path(participatory_process) %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
#### :tophat: What? Why?
As a convention, settings should the be last option of a resource in the sidebar.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3o6Zt0IqyfQmz8pnUY/giphy.gif)

