### PR TITLE
Update to Ruby 2.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - $TRAVIS_BUILD_DIR/run_ci.sh
 
 rvm:
-  - 2.3.1
+  - 2.3.3
 
 notifications:
     email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.3.3
 MAINTAINER david.morcillo@codegram
 
 ENV APP_HOME /code

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-ruby "2.3.1"
+ruby "2.3.3"
 
 gemspec path: "."
 gemspec path: "decidim-core"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,7 +463,7 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3p222
 
 BUNDLED WITH
    1.13.6

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Also you can run it as a standalone container like this:
 In order to develop on decidim, you'll need:
 
 * **PostgreSQL** 9.4+
-* **Ruby** 2.3.1
+* **Ruby** 2.3.3
 * **NodeJS** with **yarn** (JavaScript dependency manager, can be installed with `npm install yarn`)
 * **ImageMagick**
 


### PR DESCRIPTION
#### :tophat: What? Why?

We should always try to use the latest version of Ruby.

#### :ghost: GIF
![](https://i.imgur.com/aeqniC8.gif)

