### PR TITLE
Fix login redirect

### DIFF
--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -8,13 +8,23 @@ module Decidim
       layout "application"
 
       def after_sign_in_path_for(user)
-        if user.role?(:admin)
-          decidim_admin.root_path
-        elsif user.is_a?(User) && user.sign_in_count == 1 && Decidim.authorization_handlers.any?
+        if !pending_redirect?(user) && first_login_and_not_authorized?(user)
           authorizations_path
         else
           super
         end
+      end
+
+      # Calling the `stored_location_for` method removes the key, so in order
+      # to check if there's any pending redirect after login I need to call
+      # this method and use the value to set a pending redirect. This is the
+      # only way to do this without checking the session directly.
+      def pending_redirect?(user)
+        store_location_for(user, stored_location_for(user))
+      end
+
+      def first_login_and_not_authorized?(user)
+        user.is_a?(User) && user.sign_in_count == 1 && Decidim.authorization_handlers.any?
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -8,7 +8,9 @@ module Decidim
       layout "application"
 
       def after_sign_in_path_for(user)
-        if user.is_a?(User) && user.sign_in_count == 1 && Decidim.authorization_handlers.any?
+        if user.role?(:admin)
+          decidim_admin.root_path
+        elsif user.is_a?(User) && user.sign_in_count == 1 && Decidim.authorization_handlers.any?
           authorizations_path
         else
           super

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -11,7 +11,11 @@ module Decidim
           context "and is an admin" do
             let(:user) { build(:user, :admin, sign_in_count: 1) }
 
-            it { is_expected.to eq("/admin/") }
+            before do
+              controller.session[:"user_return_to"] = account_path
+            end
+
+            it { is_expected.to eq account_path }
           end
 
           context "and is not an admin" do

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -8,30 +8,38 @@ module Decidim
         subject { controller.after_sign_in_path_for(user) }
 
         context "when the given resource is a user" do
-          context "when it is the first time to log in" do
-            let(:user) { build(:user, sign_in_count: 1) }
+          context "and is an admin" do
+            let(:user) { build(:user, :admin, sign_in_count: 1) }
 
-            context "when there are authorization handlers" do
-              before do
-                Decidim.authorization_handlers = [Decidim::DummyAuthorizationHandler]
+            it { is_expected.to eq("/admin/") }
+          end
+
+          context "and is not an admin" do
+            context "when it is the first time to log in" do
+              let(:user) { build(:user, sign_in_count: 1) }
+
+              context "when there are authorization handlers" do
+                before do
+                  Decidim.authorization_handlers = [Decidim::DummyAuthorizationHandler]
+                end
+
+                it { is_expected.to eq("/authorizations") }
               end
 
-              it { is_expected.to eq("/authorizations") }
+              context "otherwise" do
+                before do
+                  Decidim.authorization_handlers = []
+                end
+
+                it { is_expected.to eq("/") }
+              end
             end
 
-            context "otherwise" do
-              before do
-                Decidim.authorization_handlers = []
-              end
+            context "and it's not the first time to log in" do
+              let(:user) { build(:user, sign_in_count: 2) }
 
               it { is_expected.to eq("/") }
             end
-          end
-
-          context "otherwise" do
-            let(:user) { build(:user, sign_in_count: 2) }
-
-            it { is_expected.to eq("/") }
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes login path for admins so they always get redirected to the `admin` section.

#### :pushpin: Related Issues
- Fixes #282 

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/l0HlU58VINoTOW6Fa/giphy.gif)

