### PR TITLE
Disable migrations on secondary engines

### DIFF
--- a/decidim-pages/lib/decidim/pages/admin_engine.rb
+++ b/decidim-pages/lib/decidim/pages/admin_engine.rb
@@ -6,6 +6,8 @@ module Decidim
     class AdminEngine < ::Rails::Engine
       isolate_namespace Decidim::Pages::Admin
 
+      paths["db/migrate"] = nil
+
       routes do
         post "/", to: "pages#update", as: :page
         root to: "pages#edit"


### PR DESCRIPTION
#### :tophat: What? Why?

Secondary engines (admin engines and such) don't need to have migrations (otherwise rails will complain because they're duplicated). This disables them. It looks tricky, but AFAIK there's no other way to do it.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3o6ZthUtLIJQc1qAKc/giphy.gif)

