### PR TITLE
Travis already has yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,6 @@ env:
 before_install:
   # Repo for newer Node.js versions
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-  # Repo for Yarn
-  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
   - yarn
   - export BUNDLE_GEMFILE="$TRAVIS_BUILD_DIR/Gemfile"
 


### PR DESCRIPTION
#### :tophat: What? Why?
It looks like `TravisCI` already comes with `yarn` installed, so no need to install it every time.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/26ufmoIppv9yivWXC/giphy.gif)

