### PR TITLE
Ignore projectile file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/bundle
 node_modules/
 .vscode
 development_app/
+.projectile

--- a/.projectile
+++ b/.projectile
@@ -1,3 +1,0 @@
-- decidim-*/spec/*_dummy_app
-- development_app
-- docker_development_app

--- a/.projectile
+++ b/.projectile
@@ -1,0 +1,3 @@
+- decidim-*/spec/*_dummy_app
+- development_app
+- docker_development_app


### PR DESCRIPTION
#### :tophat: What? Why?
This adds a `.projectile` file that ignores certain paths from the project search in `emacs` and `spacemacs`.

It doesn't harm to have it, and some of us are using `spacemacs`.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3orieRftQRDJLIlpQc/giphy.gif)

