### PR TITLE
Remove Organization' extra fields from system panel

### DIFF
--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -14,7 +14,7 @@ module Decidim
     mount_uploader :homepage_image, Decidim::HomepageImageUploader
 
     def homepage_big_url
-      homepage_image&.big&.url
+      homepage_image.big.url
     end
   end
 end

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -9,13 +9,12 @@ module Decidim
     has_many :scopes, foreign_key: "decidim_organization_id", class_name: Decidim::Scope, inverse_of: :organization
 
     validates :name, :host, uniqueness: true
-    validates :homepage_image, presence: true, on: :create
     validates :homepage_image, file_size: { less_than_or_equal_to: 10.megabytes }, on: :create
 
     mount_uploader :homepage_image, Decidim::HomepageImageUploader
 
     def homepage_big_url
-      homepage_image.big.url
+      homepage_image&.big&.url
     end
   end
 end

--- a/decidim-core/db/migrate/20161209134715_make_organization_description_optional.rb
+++ b/decidim-core/db/migrate/20161209134715_make_organization_description_optional.rb
@@ -1,0 +1,5 @@
+class MakeOrganizationDescriptionOptional < ActiveRecord::Migration[5.0]
+  def change
+    change_column :decidim_organizations, :welcome_text, :jsonb, null: true
+  end
+end

--- a/decidim-core/spec/models/decidim/organization_spec.rb
+++ b/decidim-core/spec/models/decidim/organization_spec.rb
@@ -22,7 +22,7 @@ module Decidim
           )
         end
 
-        it { is_expected.not_to be_valid }
+        it { is_expected.to be_valid }
       end
 
       context "when the homepage image is too big" do

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -40,9 +40,6 @@ module Decidim
         Decidim::Organization.create!(
           name: form.name,
           host: form.host,
-          description: form.description,
-          welcome_text: form.welcome_text,
-          homepage_image: form.homepage_image,
           available_locales: form.available_locales,
           default_locale: form.default_locale
         )

--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -42,8 +42,6 @@ module Decidim
       def save_organization
         organization.name = form.name
         organization.host = form.host
-        organization.description = form.description
-        organization.welcome_text = form.welcome_text
 
         organization.save!
       end

--- a/decidim-system/app/forms/decidim/system/register_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/register_organization_form.rb
@@ -6,19 +6,13 @@ module Decidim
     # A form object used to create organizations from the system dashboard.
     #
     class RegisterOrganizationForm < UpdateOrganizationForm
-      include TranslatableAttributes
-
       mimic :organization
 
       attribute :organization_admin_email, String
       attribute :organization_admin_name, String
       attribute :available_locales, Array
       attribute :default_locale, String
-      attribute :homepage_image
-      translatable_attribute :description, String
-      translatable_attribute :welcome_text, String
 
-      validates :welcome_text, presence: true
       validates :organization_admin_email, :organization_admin_name, :name, :host, presence: true
       validates :available_locales, presence: true
       validates :default_locale, presence: true

--- a/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -13,10 +13,6 @@ module Decidim
       attribute :name, String
       attribute :host, String
 
-      translatable_attribute :description, String
-      translatable_attribute :welcome_text, String
-
-      validates :welcome_text, presence: true
       validate :validate_organization_uniqueness
 
       private

--- a/decidim-system/app/views/decidim/system/organizations/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/edit.html.erb
@@ -7,14 +7,6 @@
     <%= f.text_field :host %>
   </div>
 
-  <div class="field">
-    <%= f.translated :text_area, :description %>
-  </div>
-
-  <div class="field">
-    <%= f.translated :editor, :welcome_text %>
-  </div>
-
   <div class="actions">
     <%= f.submit t("decidim.system.actions.save") %>
   </div>

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -12,23 +12,11 @@
   </div>
 
   <div class="field">
-    <%= f.translated :editor, :description %>
-  </div>
-
-  <div class="field">
-    <%= f.translated :editor, :welcome_text %>
-  </div>
-
-  <div class="field">
     <%= f.text_field :organization_admin_name %>
   </div>
 
   <div class="field">
     <%= f.email_field :organization_admin_email %>
-  </div>
-
-  <div class="field">
-    <%= f.file_field :homepage_image %>
   </div>
 
   <%= f.fields_for :locales do |fields| %>

--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -16,9 +16,6 @@ module Decidim
             {
               name: "Gotham City",
               host: "decide.gotham.gov",
-              description_en: "Fictional city appearing in American comic books.",
-              welcome_text_en: "Welcome! Join in!",
-              homepage_image: Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "..", "..", "..", "decidim-dev", "spec", "support", "city.jpeg"), "image/jpg"),
               organization_admin_name: "Fiorello Henry La Guardia",
               organization_admin_email: "f.laguardia@gotham.gov",
               available_locales: ["en"],
@@ -44,7 +41,6 @@ module Decidim
 
             expect(admin.email).to eq("f.laguardia@gotham.gov")
             expect(admin.organization.name).to eq("Gotham City")
-            expect(admin.organization.description).to include("en" => "Fictional city appearing in American comic books.")
             expect(admin.roles).to include("admin")
             expect(admin).to be_created_by_invite
           end

--- a/decidim-system/spec/features/organizations_spec.rb
+++ b/decidim-system/spec/features/organizations_spec.rb
@@ -24,7 +24,6 @@ describe "Organizations", type: :feature do
         fill_in "Organization admin email", with: "mayor@citizen.corp"
         check "organization_available_locales_en"
         choose "organization_default_locale_en"
-        attach_file "Homepage image", File.join(File.dirname(__FILE__), "..", "..", "..", "decidim-dev", "spec", "support", "city.jpeg")
         click_button "Create organization & invite admin"
 
         expect(page).to have_css("div.flash.success")
@@ -55,7 +54,6 @@ describe "Organizations", type: :feature do
       it "edits the data" do
         fill_in "Name", with: "Citizens Rule!"
         fill_in "Host", with: "www.foo.org"
-        fill_in_i18n :organization_description, "#description-tabs", en: "Organization description."
         click_button "Save"
 
         expect(page).to have_css("div.flash.success")


### PR DESCRIPTION
#### :tophat: What? Why?
This removes `description`, `welcome_text` and `image` from system's admin panel.

#### :pushpin: Related Issues
- Fixes #324

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/26BRIaGqykNr0XKlG/giphy.gif)

