### PR TITLE
Use heroku secret generator to generate SECRET_KEY_BASE env variable

### DIFF
--- a/lib/generators/decidim/templates/app.json.erb
+++ b/lib/generators/decidim/templates/app.json.erb
@@ -8,6 +8,9 @@
     "sendgrid:starter"
   ],
   "env": {
-    "SECRET_KEY_BASE": "<%= secret_token %>"
+    "SECRET_KEY_BASE": {
+      "description": "A secret used by Rails to identify sessions",
+      "generator": "secret"
+    }
   }
 }


### PR DESCRIPTION
#### :tophat: What? Why?

In order to not include secrets into the version control system we are using heroku's secret generator to handle the `SECRET_KEY_BASE` env variable.

#### :pushpin: Related Issues
- Fixes #321 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
![](https://media.giphy.com/media/eGsBGj0PisO3u/giphy.gif)

