### PR TITLE
Remove vendored files from codecov

### DIFF
--- a/.#codecov.yml
+++ b/.#codecov.yml
@@ -1,0 +1,1 @@
+josepjaumegmail.com@Joseps-MacBook-Pro.local.2553

--- a/.#codecov.yml
+++ b/.#codecov.yml
@@ -1,1 +1,0 @@
-josepjaumegmail.com@Joseps-MacBook-Pro.local.2553

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   - yarn
   - export BUNDLE_GEMFILE="$TRAVIS_BUILD_DIR/Gemfile"
+  - export BUNDLE_PATH="$HOME/.bundle"
 
 cache:
   bundler: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -70,7 +70,7 @@ coverage:
         branches: null
 
   ignore:
-  - "decidim-*/spec"
+  - "decidim-*/spec/*"
   - "spec/*"
   - "decidim-*/lib/**/*/test/*"
   - "lib/**/*/test/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -75,6 +75,8 @@ coverage:
   - "decidim-*/lib/**/*/test"
   - "lib/**/*/test"
   - "bundle.js"
+  - "vendor"
+  - "node_modules"
 
 comment:
   layout: "header, diff, changes, sunburst, uncovered, tree"

--- a/codecov.yml
+++ b/codecov.yml
@@ -71,12 +71,12 @@ coverage:
 
   ignore:
   - "decidim-*/spec"
-  - "spec"
-  - "decidim-*/lib/**/*/test"
-  - "lib/**/*/test"
+  - "spec/*"
+  - "decidim-*/lib/**/*/test/*"
+  - "lib/**/*/test/*"
   - "bundle.js"
-  - "vendor"
-  - "node_modules"
+  - "vendor/*"
+  - "node_modules/*"
 
 comment:
   layout: "header, diff, changes, sunburst, uncovered, tree"

--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -11,13 +11,10 @@ if ENV["CI"]
     add_filter "/test/"
     add_filter "/spec/"
     add_filter "bundle.js"
+    add_filter "/vendor/"
 
     add_filter do |src|
-      src.filename =~ /vendor/ unless src.filename =~ %r{/decidim(-[A-z]+)?/}
-    end
-
-    add_filter do |src|
-      !(src.filename =~ /^#{SimpleCov.root}/) unless src.filename =~ %r{/decidim(-[A-z]+)?/}
+      !(src.filename =~ /^#{ENV["TRAVIS_BUILD_DIR"]}/)
     end
   end
 

--- a/decidim-dev/lib/decidim/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/test/base_spec_helper.rb
@@ -8,6 +8,14 @@ if ENV["CI"]
   require "simplecov"
   SimpleCov.start do
     filters.clear
+    add_filter "/test/"
+    add_filter "/spec/"
+    add_filter "bundle.js"
+
+    add_filter do |src|
+      src.filename =~ /vendor/ unless src.filename =~ %r{/decidim(-[A-z]+)?/}
+    end
+
     add_filter do |src|
       !(src.filename =~ /^#{SimpleCov.root}/) unless src.filename =~ %r{/decidim(-[A-z]+)?/}
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Codecov has been importing `vendor` on the latest builds, therefore breaking coverage. This restores it.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3oEjHCWdU7F4hkcudy/giphy.gif)

