### PR TITLE
Add fake avatars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 cache:
   bundler: true
   directories:
-  - $HOME/.yarn-cache
+    - $HOME/.yarn-cache
 
 script:
   - yarn run eslint $GEM/app/**/*.js.es6 $GEM/app/**/*.js

--- a/decidim-core/app/assets/images/decidim/default-avatar.svg
+++ b/decidim-core/app/assets/images/decidim/default-avatar.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="200px" height="200px" viewBox="0 0 200 200" enable-background="new 0 0 200 200" xml:space="preserve">
+<g>
+	<path fill="#C5C5C5" d="M200-0.5H0v200h26.099c2.885-35.293,24.07-64.381,52.419-74.319C64.372,117.596,54.75,102.674,54.75,85.5
+		c0-24.853,20.146-45,45-45c24.853,0,45,20.147,45,45c0,17.095-9.533,31.963-23.572,39.58c28.5,9.837,49.828,39.002,52.724,74.42
+		H200V-0.5z"/>
+	<path fill="#FFFFFF" d="M121.178,125.08c14.039-7.617,23.572-22.485,23.572-39.58c0-24.853-20.147-45-45-45
+		c-24.854,0-45,20.147-45,45c0,17.174,9.622,32.096,23.768,39.681c-28.349,9.938-49.534,39.026-52.419,74.319h147.803
+		C171.006,164.082,149.678,134.917,121.178,125.08z"/>
+</g>
+</svg>

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -16,6 +16,8 @@ module Decidim
     validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
     validate :all_roles_are_valid
+    validates :avatar, file_size: { less_than_or_equal_to: 5.megabytes }
+    mount_uploader :avatar, Decidim::AvatarUploader
 
     # Public: Allows customizing the invitation instruction email content when
     # inviting a user.

--- a/decidim-core/app/uploaders/decidim/avatar_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/avatar_uploader.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Decidim
+  # This class deals with uploading avatars to a User.
+  class AvatarUploader < ApplicationUploader
+    include CarrierWave::MiniMagick
+
+    process :validate_dimensions
+
+    protected
+
+    # CarrierWave automatically calls this method and validates the content
+    # type fo the temp file to match against any of these options.
+    def content_type_whitelist
+      [
+        %r{image\/}
+      ]
+    end
+
+    # A simple check to avoid DoS with maliciously crafted images, or just to
+    # avoid reckless users that upload gigapixels images.
+    #
+    # See https://hackerone.com/reports/390
+    def validate_dimensions
+      manipulate! do |image|
+        raise CarrierWave::IntegrityError, I18n.t("carrierwave.errors.image_too_big") if image.dimensions.any? { |dimension| dimension > max_image_height_or_width }
+        image
+      end
+    end
+
+    def max_image_height_or_width
+      8000
+    end
+
+    def default_url(*)
+      ActionController::Base.helpers.asset_path("decidim/default-avatar.svg")
+    end
+  end
+end

--- a/decidim-core/db/migrate/20161213094244_add_avatar_to_users.rb
+++ b/decidim-core/db/migrate/20161213094244_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_users, :avatar, :string
+  end
+end

--- a/decidim-core/spec/factories.rb
+++ b/decidim-core/spec/factories.rb
@@ -71,6 +71,7 @@ FactoryGirl.define do
     organization
     locale                "en"
     tos_agreement         "1"
+    avatar                { test_file("avatar.svg", "image/svg+xml") }
 
     trait :confirmed do
       confirmed_at { Time.current }

--- a/decidim-dev/spec/support/avatar.svg
+++ b/decidim-dev/spec/support/avatar.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="200px" height="200px" viewBox="0 0 200 200" enable-background="new 0 0 200 200" xml:space="preserve">
+<g>
+	<path fill="#C5C5C5" d="M200-0.5H0v200h26.099c2.885-35.293,24.07-64.381,52.419-74.319C64.372,117.596,54.75,102.674,54.75,85.5
+		c0-24.853,20.146-45,45-45c24.853,0,45,20.147,45,45c0,17.095-9.533,31.963-23.572,39.58c28.5,9.837,49.828,39.002,52.724,74.42
+		H200V-0.5z"/>
+	<path fill="#FFFFFF" d="M121.178,125.08c14.039-7.617,23.572-22.485,23.572-39.58c0-24.853-20.147-45-45-45
+		c-24.854,0-45,20.147-45,45c0,17.174,9.622,32.096,23.768,39.681c-28.349,9.938-49.534,39.026-52.419,74.319h147.803
+		C171.006,164.082,149.678,134.917,121.178,125.08z"/>
+</g>
+</svg>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds avatars to users, and sets a default avatar to:

![](http://smallbusinessbc.ca/wp-content/themes/sbbcmain/images/default-avatar.svg)

#### :pushpin: Related Issues
There's no issue for this, but a discussion for this arose in #250. I needed this too in #309.

#### :clipboard: Subtasks
- [x] Add code
- [x] Add tests

### :camera: Screenshots (optional)
*None*

