### PR TITLE
Bugfix/prevent reloading errors

### DIFF
--- a/decidim-admin/lib/decidim/admin.rb
+++ b/decidim-admin/lib/decidim/admin.rb
@@ -8,5 +8,6 @@ module Decidim
   # eye view of the whole admin.
   #
   module Admin
+    autoload :Features, "decidim/admin/features"
   end
 end

--- a/decidim-admin/lib/decidim/admin/features.rb
+++ b/decidim-admin/lib/decidim/admin/features.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # This module contains all logic related to Features and how they're handled
+    # at the admin panel level.
+    module Features
+      autoload :BaseController, "decidim/admin/features/base_controller"
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -9,6 +9,7 @@ module Decidim
   autoload :AuthorizationFormBuilder, "decidim/authorization_form_builder"
   autoload :DeviseFailureApp, "decidim/devise_failure_app"
   autoload :FeatureManifest, "decidim/feature_manifest"
+  autoload :Features, "decidim/features"
 
   include ActiveSupport::Configurable
 

--- a/decidim-core/lib/decidim/features.rb
+++ b/decidim-core/lib/decidim/features.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Decidim
+  # This module contains all logic related to decidim's Features, the main
+  # building block to extend functionalities in a participatory process.
+  module Features
+    autoload :BaseController, "decidim/features/base_controller"
+  end
+end

--- a/decidim-pages/app/controllers/decidim/pages/admin/application_controller.rb
+++ b/decidim-pages/app/controllers/decidim/pages/admin/application_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency "decidim/admin/features/base_controller"
 
 module Decidim
   module Pages

--- a/decidim-pages/app/controllers/decidim/pages/application_controller.rb
+++ b/decidim-pages/app/controllers/decidim/pages/application_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency "decidim/features/base_controller"
 
 module Decidim
   module Pages


### PR DESCRIPTION
#### :tophat: What? Why?
We've been experiencing reloading errors when working on features. This solves them by leveraging rail's outstanding `autoload` helper :trollface: 

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/dkGhBWE3SyzXW/giphy.gif)
