### PR TITLE
Show welcome text in the front page

### DIFF
--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -3,7 +3,11 @@
     <div class="row">
       <div class="columns small-centered large-10">
         <h1 class="text-highlight heading1 hero-heading">
-          <%= t('.welcome', organization: current_organization.name) %>
+          <% if current_organization.welcome_text.present? %>
+            <%== translated_attribute current_organization.welcome_text %>
+          <% else %>
+            <%= t('.welcome', organization: current_organization.name) %>
+          <% end %>
         </h1>
       </div>
     </div>
@@ -14,17 +18,21 @@
     </div>
   </div>
 </section>
-<section class="extended subhero home-section">
-  <div class="row">
-    <div class="columns small-centered large-10">
-      <h2 class="heading3"><%== translated_attribute current_organization.welcome_text %></h2>
-      <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
-        <%= t(".register") %>
-        <%= icon "chevron-right", aria_hidden: true %>
-      <% end %>
+
+<% if current_organization.description.present? %>
+  <section class="extended subhero home-section">
+    <div class="row">
+      <div class="columns small-centered large-10">
+        <h2 class="heading3"><%== translated_attribute current_organization.description %></h2>
+        <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
+          <%= t(".register") %>
+          <%= icon "chevron-right", aria_hidden: true %>
+        <% end %>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
+<% end %>
+
 <section class="wrapper-home">
   <div class="row">
     <h3 class="section-heading"><%= t(".highlighted_processes") %></h3>

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -6,7 +6,10 @@ if !Rails.env.production? || ENV["SEED"]
     name: Faker::Company.name,
     host: ENV["DECIDIM_HOST"] || "localhost",
     welcome_text: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-      Decidim::Faker::Localized.sentence(3)
+      Decidim::Faker::Localized.sentence(5)
+    end,
+    description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
+      Decidim::Faker::Localized.sentence(15)
     end,
     homepage_image: File.new(File.join(File.dirname(__FILE__), "seeds", "homepage_image.jpg")),
     default_locale: I18n.default_locale,

--- a/decidim-core/spec/features/locales_spec.rb
+++ b/decidim-core/spec/features/locales_spec.rb
@@ -16,7 +16,7 @@ describe "Locales", type: :feature do
         click_link "Català"
       end
 
-      expect(page).to have_content("Benvingut/da a #{organization.name}")
+      expect(page).to have_content("Inici")
     end
 
     it "keeps the locale between pages" do
@@ -26,7 +26,7 @@ describe "Locales", type: :feature do
 
       click_link "Inici"
 
-      expect(page).to have_content("Benvingut/da a #{organization.name}")
+      expect(page).to have_content("Inici")
     end
 
     context "with a signed in user" do
@@ -38,7 +38,7 @@ describe "Locales", type: :feature do
       end
 
       it "uses the user's locale" do
-        expect(page).to have_content("Benvingut/da a #{organization.name}")
+        expect(page).to have_content("Inici")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This conditionally shows the welcome text on the front page if available, resorts to a default one otherwise.

The description field shows the same behavior, resorting to not rendering it if not present.

#### :pushpin: Related Issues
- Fixes #329

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/5FZSLpb0eoz4s/giphy.gif)

