### PR TITLE
Check for translated attribute

### DIFF
--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -3,10 +3,10 @@
     <div class="row">
       <div class="columns small-centered large-10">
         <h1 class="text-highlight heading1 hero-heading">
-          <% if current_organization.welcome_text.present? %>
-            <%== translated_attribute current_organization.welcome_text %>
-          <% else %>
+          <% if translated_attribute(current_organization.welcome_text).blank? %>
             <%= t('.welcome', organization: current_organization.name) %>
+          <% else %>
+            <%== translated_attribute current_organization.welcome_text %>
           <% end %>
         </h1>
       </div>

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -19,7 +19,7 @@
   </div>
 </section>
 
-<% if current_organization.description.present? %>
+<% if !translated_attribute(current_organization.description).blank? %>
   <section class="extended subhero home-section">
     <div class="row">
       <div class="columns small-centered large-10">


### PR DESCRIPTION
#### :tophat: What? Why?
This checks if the welcome text is available on the current locale before showing the default message. The bug is due to an interaction between #345 and #346.

#### :pushpin: Related Issues
- Related to #345 and #346

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3oriO9ia2ZJhWVVjXy/giphy.gif)

