### PR TITLE
Enhance travis builds running yarn tests once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,9 @@ cache:
   bundler: true
   directories:
     - $HOME/.yarn-cache
+    - $HOME/node_modules
 
 script:
-  - yarn run test:ci
-  - yarn run build
   - cd $GEM;
   - $TRAVIS_BUILD_DIR/run_ci.sh
 

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ev
 if [ "$GEM" == "." ]; then
+  yarn test:ci
   docker build --rm=false -t codegram/decidim .
 elif [ -f "run_ci.sh" ]; then
   sh ./run_ci.sh


### PR DESCRIPTION
#### :tophat: What? Why?

We are running yarn tests for every gem right now so I made a few optimisations:

- We don't need to run `yarn build:prod` since it's supposed to exist in the code base
- Include `node_modules` in travis cache
- Run `yarn test` just when `GEM` is equal to `.`

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
![](https://media.giphy.com/media/yN6TNQhiIxeW4/giphy.gif)

