### PR TITLE
Welcome text and description as string

### DIFF
--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -7,7 +7,7 @@
 </div>
 
 <div class="field">
-  <%= form.translated :editor, :welcome_text %>
+  <%= form.translated :text_area, :welcome_text %>
 </div>
 
 <div class="field">

--- a/decidim-admin/spec/features/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_spec.rb
@@ -17,10 +17,17 @@ describe "Admin manages ogranization", type: :feature do
       visit decidim_admin.edit_organization_path
 
       fill_in "Name", with: "My super-uber organization"
+
       fill_in_i18n_editor :organization_description, "#description-tabs", {
         en: "My own super description",
         es: "Mi gran descripción",
         ca: "La meva gran descripció"
+      }
+
+      fill_in_i18n :organization_welcome_text, "#welcome_text-tabs", {
+        en: "My super welcome text",
+        es: "Mi super texto de bienvenida",
+        ca: "El meu súper text de benvinguda"
       }
 
       click_button "Update organization"

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -4,7 +4,7 @@
       <div class="columns small-centered large-10">
         <h1 class="text-highlight heading1 hero-heading">
           <% if current_organization.welcome_text.present? %>
-            <%== translated_attribute current_organization.welcome_text %>
+            <%= translated_attribute current_organization.welcome_text %>
           <% else %>
             <%= t('.welcome', organization: current_organization.name) %>
           <% end %>

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -5,9 +5,7 @@ if !Rails.env.production? || ENV["SEED"]
   staging_organization = Decidim::Organization.create!(
     name: Faker::Company.name,
     host: ENV["DECIDIM_HOST"] || "localhost",
-    welcome_text: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-      Decidim::Faker::Localized.sentence(5)
-    end,
+    welcome_text: Decidim::Faker::Localized.sentence(5),
     description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
       Decidim::Faker::Localized.sentence(15)
     end,


### PR DESCRIPTION
#### :tophat: What? Why?
Next chapter in my `description` text obsession. This turns the welcome text into a string field instead of a rich editor.

#### :pushpin: Related Issues
- Related to #345 
- Related to #346

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/26FL0yMyKyZUhmipa/giphy.gif)

