### PR TITLE
Fix comments helper

### DIFF
--- a/decidim-comments/app/helpers/decidim/comments/comments_helper.rb
+++ b/decidim-comments/app/helpers/decidim/comments/comments_helper.rb
@@ -29,7 +29,7 @@ module Decidim
       def react_comments_component(node_id, props)
         content_tag("div", "", id: node_id) +
           javascript_tag(%{
-            $.getScript('#{asset_path("decidim/comments/comments")}')
+            $.getScript('#{asset_path("decidim/comments/comments.js")}')
               .then(function () {
                 window.DecidimComments.renderCommentsComponent(
                   '#{node_id}',


### PR DESCRIPTION
#### :tophat: What? Why?
This adds the missing `.js` extension to the comments helper.

#### :pushpin: Related Issues
- Fixes #384

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](http://destinocastillayleon.es/index/wp-content/uploads/2015/08/a2dbfbdc2006faa574d39bdfb725dcb9.jpg)
