### PR TITLE
Pages are commentable by default on seeds

### DIFF
--- a/decidim-pages/lib/decidim/pages/feature.rb
+++ b/decidim-pages/lib/decidim/pages/feature.rb
@@ -33,7 +33,8 @@ Decidim.register_feature(:pages) do |feature|
         title: Decidim::Faker::Localized.sentence(2),
         body: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
           Decidim::Faker::Localized.paragraph(3)
-        end
+        end,
+        commentable: true
       )
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
This makes pages commentable by default on seeds for demonstration purposes.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/l2JhGFkAMQDRPjTTq/giphy.gif)
