### PR TITLE
Add comments to proposals

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ PATH
       rails (~> 5.0.0, >= 5.0.0.1)
       rails-i18n (~> 5.0.0, >= 5.0.0.1)
     decidim-proposals (0.0.1.alpha9)
+      decidim-comments (= 0.0.1.alpha9)
       decidim-core (= 0.0.1.alpha9)
       kaminari (~> 1.0.0.rc1)
       rectify (~> 0.8.0)

--- a/decidim-api/lib/decidim/api/test/type_context.rb
+++ b/decidim-api/lib/decidim/api/test/type_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.shared_context "graphql type" do
   let!(:current_organization) { create(:organization) }
-  let!(:current_user) { create(:user) }
+  let!(:current_user) { create(:user, organization: current_organization) }
   let(:model) { OpenStruct.new({}) }
 
   let(:schema) do

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -21,8 +21,11 @@ module Decidim
       validate :commentable_can_have_replies
       validates :depth, numericality: { greater_than_or_equal_to: 0 }
       validates :alignment, inclusion: { in: [0, 1, -1] }
+      validate :same_organization
 
       before_save :compute_depth
+
+      delegate :organization, to: :commentable
 
       # Public: Define if a comment can have replies or not
       #
@@ -42,6 +45,10 @@ module Decidim
       # Private: Compute comment depth inside the current comment tree
       def compute_depth
         self.depth = commentable.depth + 1 if commentable.respond_to?(:depth)
+      end
+
+      def same_organization
+        errors.add(:commentable, :invalid) unless author.organization == organization
       end
     end
   end

--- a/decidim-comments/spec/factories.rb
+++ b/decidim-comments/spec/factories.rb
@@ -2,7 +2,7 @@ require_relative "../../decidim-core/spec/factories"
 
 FactoryGirl.define do
   factory :comment, class: Decidim::Comments::Comment do
-    author { build(:user) }
+    author { build(:user, organization: commentable.organization) }
     commentable { build(:participatory_process) }
     body { Faker::Lorem.paragraph }
   end

--- a/decidim-comments/spec/models/comment_spec.rb
+++ b/decidim-comments/spec/models/comment_spec.rb
@@ -36,6 +36,13 @@ module Decidim
         end
       end
 
+      it "is not valid if the author organization is different" do
+        foreign_user = build(:user)
+        comment = build(:comment, author: foreign_user)
+
+        expect(comment).to_not be_valid
+      end
+
       describe "#can_have_replies?" do
         it "should return true if the comment's depth is below MAX_DEPTH" do
           comment.depth = Comment::MAX_DEPTH - 1

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -6,6 +6,7 @@ module Decidim
     class Page < Pages::ApplicationRecord
       validates :title, :feature, presence: true
       belongs_to :feature, foreign_key: "decidim_feature_id", class_name: Decidim::Feature
+      has_one :organization, through: :feature
     end
   end
 end

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    # Custom helpers, scoped to the pages engine.
+    #
+    module ApplicationHelper
+      include Decidim::Comments::CommentsHelper
+    end
+  end
+end

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -7,6 +7,7 @@ module Decidim
       belongs_to :author, foreign_key: "decidim_author_id", class_name: Decidim::User
       belongs_to :category, foreign_key: "decidim_category_id", class_name: Decidim::Category
       belongs_to :scope, foreign_key: "decidim_scope_id", class_name: Decidim::Scope
+      has_one :organization, through: :feature
 
       validates :title, :feature, :body, presence: true
       validate :category_belongs_to_feature
@@ -19,6 +20,16 @@ module Decidim
 
       def author_avatar_url
         author&.avatar&.url || ActionController::Base.helpers.asset_path("decidim/default-avatar.svg")
+      end
+
+      # Public: Canpeople comment on this proposal?
+      #
+      # Until we have a way to store options fore features and its resources we
+      # assume all proposals can be commented.
+      #
+      # Returns Boolean
+      def commentable?
+        true
       end
 
       private

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -28,3 +28,10 @@
     </div>
   </div>
 </div>
+
+
+<%= content_for :expanded do %>
+  <% if @proposal.commentable? %>
+    <%= comments_for @proposal, arguable: true %>
+  <% end %>
+<% end %>

--- a/decidim-proposals/decidim-proposals.gemspec
+++ b/decidim-proposals/decidim-proposals.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "Rakefile", "README.md"]
 
   s.add_dependency "decidim-core", Decidim.version
+  s.add_dependency "decidim-comments", Decidim.version
   s.add_dependency "rectify", "~> 0.8.0"
   s.add_dependency "kaminari", "~> 1.0.0.rc1"
 

--- a/decidim-proposals/spec/factories.rb
+++ b/decidim-proposals/spec/factories.rb
@@ -1,5 +1,6 @@
 require_relative "../../decidim-core/spec/factories"
 require_relative "../../decidim-admin/spec/factories"
+require_relative "../../decidim-comments/spec/factories"
 
 FactoryGirl.define do
   factory :proposal_feature, class: Decidim::Feature do

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -58,6 +58,26 @@ describe "Proposals", type: :feature do
     end
   end
 
+  context "when a proposal has comments" do
+    let(:proposal) { create(:proposal, feature: feature)}
+    let(:author) { create(:user, :confirmed, organization: feature.organization)}
+    let!(:comments) { create_list(:comment, 3, commentable: proposal) }
+
+    before do
+      click_link "Processes"
+      click_link participatory_process.title["en"]
+      click_link "Proposals"
+    end
+
+    it "shows the comments" do
+      click_link proposal.title
+
+      comments.each do |comment| 
+        expect(page).to have_content(comment.body)
+      end
+    end
+  end
+
   context "listing proposals in a participatory process" do
     before do
       click_link "Processes"


### PR DESCRIPTION
#### :tophat: What? Why?

- Implements #377

Until we have an option to configure when to enable comments, all proposals can be commented.

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/dhxfKie.png)

#### :ghost: GIF
![](https://i.imgur.com/aRQDfLs.gif)
