### PR TITLE
Filter meetings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ PATH
       date_validator (~> 0.9)
       decidim-core (= 0.0.1)
       rectify (~> 0.8)
+      searchlight (~> 4.1.0)
 
 PATH
   remote: decidim-pages
@@ -441,6 +442,7 @@ GEM
       sprockets (> 2.11)
       sprockets-rails
       tilt
+    searchlight (4.1.0)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ PATH
     decidim-meetings (0.0.1)
       date_validator (~> 0.9)
       decidim-core (= 0.0.1)
+      kaminari (~> 1.0.0.rc1)
       rectify (~> 0.8)
       searchlight (~> 4.1.0)
 

--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -2,13 +2,16 @@
 module Decidim
   # Helper to paginate collections.
   module PaginateHelper
-    # Displays booleans in a human way (yes/no, supporting i18n). Supports
-    # `nil` values as `false`.
+    # Displays pagination links for the given collection, setting the correct
+    # theme. This mostly acts as a proxy for the underlying pagination engine.
     #
-    # boolean - a Boolean that will be displayed in a human way.
+    # collection - a collection of elements that need to be paginated
+    # paginate_params - a Hash with options to delegate to the pagination helper.
     def decidim_paginate(collection, paginate_params)
       # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
       # and unless we remove these params they are added again as query string :(
+      # Please do not mix `params` with `paginate_params`. We're removing elements from the
+      # global `params` object.
       params.delete("participatory_process_id")
       params.delete("feature_id")
 

--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -6,13 +6,13 @@ module Decidim
     # `nil` values as `false`.
     #
     # boolean - a Boolean that will be displayed in a human way.
-    def decidim_paginate(collection, params)
+    def decidim_paginate(collection, paginate_params)
       # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
       # and unless we remove these params they are added again as query string :(
       params.delete("participatory_process_id")
       params.delete("feature_id")
 
-      paginate collection, theme: "decidim", params: { order_start_time: params[:order_start_time], scope_id: params[:scope_id] }
+      paginate collection, theme: "decidim", params: paginate_params
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -10,12 +10,12 @@ module Decidim
     def decidim_paginate(collection, paginate_params)
       # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
       # and unless we remove these params they are added again as query string :(
-      # Please do not mix `params` with `paginate_params`. We're removing elements from the
-      # global `params` object.
-      params.delete("participatory_process_id")
-      params.delete("feature_id")
+      default_params = {
+        participatory_process_id: nil,
+        feature_id: nil
+      }
 
-      paginate collection, theme: "decidim", params: paginate_params
+      paginate collection, theme: "decidim", params: paginate_params.merge(default_params)
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/paginate_helper.rb
+++ b/decidim-core/app/helpers/decidim/paginate_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Decidim
+  # Helper to paginate collections.
+  module PaginateHelper
+    # Displays booleans in a human way (yes/no, supporting i18n). Supports
+    # `nil` values as `false`.
+    #
+    # boolean - a Boolean that will be displayed in a human way.
+    def decidim_paginate(collection, params)
+      # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
+      # and unless we remove these params they are added again as query string :(
+      params.delete("participatory_process_id")
+      params.delete("feature_id")
+
+      paginate collection, theme: "decidim", params: { order_start_time: params[:order_start_time], scope_id: params[:scope_id] }
+    end
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -14,6 +14,13 @@ if !Rails.env.production? || ENV["SEED"]
     available_locales: Decidim.available_locales
   )
 
+  3.times do
+    Decidim::Scope.create!(
+      name: Faker::Lorem.word,
+      organization: staging_organization
+    )
+  end
+
   Decidim::User.create!(
     name: Faker::Name.name,
     email: "admin@decidim.org",

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -87,23 +87,20 @@ module Decidim
     # Returns a String.
     def categories_select(name, collection, options = {})
       options = {
-        prompt: nil,
         disable_parents: true
       }.merge(options)
 
-      prompt = options[:prompt]
       disable_parents = options[:disable_parents]
 
       selected = object.send(name)
       categories = categories_for_select(collection)
-      categories = [[prompt]] + categories if prompt
       disabled = if disable_parents
                    disabled_categories_for(collection)
                  else
                    []
                  end
 
-      select(name, @template.options_for_select(categories, selected: selected, disabled: disabled))
+      select(name, @template.options_for_select(categories, selected: selected, disabled: disabled), options)
     end
 
     private

--- a/decidim-meetings/Gemfile
+++ b/decidim-meetings/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'decidim', path: '..'
+gemspec
+
+eval(File.read(File.join(File.dirname(__FILE__), "..", "Gemfile.common")))

--- a/decidim-meetings/app/assets/config/decidim_meetings_manifest.js
+++ b/decidim-meetings/app/assets/config/decidim_meetings_manifest.js
@@ -1,0 +1,1 @@
+//= link decidim/meetings/meetings_filters.js.es6

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
@@ -1,0 +1,46 @@
+// = require_self
+$(document).ready(() => {
+  const $form = $('form#filter_form');
+  const $scopes = $form.find('input[type=checkbox]');
+  const $sort = $form.find('input[type=radio]');
+  $form.on('change', 'input', (event) => {
+    $form.submit();
+
+    let newUrl;
+    const formAction = $form.attr('action');
+    const params = $form.serialize();
+
+    if (formAction.indexOf('?') < 0) {
+      newUrl = `${formAction}?${params}`;
+    } else {
+      newUrl = `${formAction}&${params}`;
+    }
+
+    window.history.pushState(null, null, newUrl);
+  });
+
+  window.onpopstate = function(event) {
+    const location = decodeURIComponent(document.location);
+
+    $scopes.attr('checked', false);
+    $sort.attr('checked', false)
+
+    try {
+      const [, sortValue] = location.match(/order_start_time=([^&]*)/);
+      $form.find(`input[type=radio][value=${sortValue}]`)[0].checked = true;
+    } catch(e) {
+      $form.find('input[type=radio][value=asc]')[0].checked = true;
+    }
+
+    let scopeValues = location.match(/scope_id\[\]=([^&]*)/g);
+
+    if (scopeValues) {
+      scopeValues = scopeValues.map(val => val.match(/scope_id\[\]=(.*)/)[1]);
+      scopeValues.forEach(value => {
+        $form.find(`input[type=checkbox][value=${value}]`)[0].checked = true;
+      })
+    }
+
+    $form.submit();
+  };
+});

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
@@ -1,9 +1,9 @@
 // = require_self
 $(document).ready(() => {
-  const $form = $('form#filter_form');
+  const $form = $('form#new_filter');
   const $scopes = $form.find('input[type=checkbox]');
   const $sort = $form.find('input[type=radio]');
-  $form.on('change', 'input', (event) => {
+  $form.on('change', 'input, select', (event) => {
     $form.submit();
 
     let newUrl;
@@ -33,12 +33,17 @@ $(document).ready(() => {
     }
 
     let scopeValues = location.match(/scope_id\[\]=([^&]*)/g);
-
     if (scopeValues) {
       scopeValues = scopeValues.map(val => val.match(/scope_id\[\]=(.*)/)[1]);
       scopeValues.forEach(value => {
         $form.find(`input[type=checkbox][value=${value}]`)[0].checked = true;
       })
+    }
+
+    let categoryIdValues = location.match(/filter\[category_id\]=([^&]*)/g);
+    if (categoryIdValues) {
+      categoryIdValues = categoryIdValues[0].match(/=(.*)/)[1];
+      $form.find(`select#filter_category_id`).first().val(categoryIdValues);
     }
 
     $form.submit();

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
@@ -1,6 +1,9 @@
 // = require ./meetings_form_filter.component
 // = require_self
 
+// Initializes the meetings filter. We're unmounting the component before
+// changing the page so that we stop listening to events and we don't bind
+// multiple times when re-visiting the page.
 ((exports) => {
   const { DecidimMeetings: { MeetingsFormFilterComponent } } = exports;
   const meetingsFormFilter = new MeetingsFormFilterComponent('form#new_filter');

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
@@ -3,6 +3,7 @@ $(document).ready(() => {
   const $form = $('form#new_filter');
   const $scopes = $form.find('input[type=checkbox]');
   const $sort = $form.find('input[type=radio]');
+
   $form.on('change', 'input, select', (event) => {
     $form.submit();
 
@@ -20,32 +21,30 @@ $(document).ready(() => {
   });
 
   window.onpopstate = function(event) {
-    const location = decodeURIComponent(document.location);
-
     $scopes.attr('checked', false);
     $sort.attr('checked', false)
 
-    try {
-      const [, sortValue] = location.match(/order_start_time=([^&]*)/);
-      $form.find(`input[type=radio][value=${sortValue}]`)[0].checked = true;
-    } catch(e) {
-      $form.find('input[type=radio][value=asc]')[0].checked = true;
-    }
+    let [sortValue] = getLocationParams(/order_start_time=([^&]*)/g) || ["asc"];
+    $form.find(`input[type=radio][value=${sortValue}]`)[0].checked = true;
 
-    let scopeValues = location.match(/scope_id\[\]=([^&]*)/g);
-    if (scopeValues) {
-      scopeValues = scopeValues.map(val => val.match(/scope_id\[\]=(.*)/)[1]);
-      scopeValues.forEach(value => {
-        $form.find(`input[type=checkbox][value=${value}]`)[0].checked = true;
-      })
-    }
+    let scopeValues = getLocationParams(/scope_id\[\]=([^&]*)/g) || [];
+    console.log(scopeValues)
+    scopeValues.forEach(value => {
+      $form.find(`input[type=checkbox][value=${value}]`)[0].checked = true;
+    })
 
-    let categoryIdValues = location.match(/filter\[category_id\]=([^&]*)/g);
-    if (categoryIdValues) {
-      categoryIdValues = categoryIdValues[0].match(/=(.*)/)[1];
-      $form.find(`select#filter_category_id`).first().val(categoryIdValues);
-    }
+    let [categoryIdValue] = getLocationParams(/filter\[category_id\]=([^&]*)/g) || [];
+    $form.find(`select#filter_category_id`).first().val(categoryIdValue);
 
     $form.submit();
+  };
+
+  const getLocationParams = (regex) => {
+    const location = decodeURIComponent(document.location);
+    let values = location.match(regex);
+    if (values) {
+      values = values.map(val => val.match(/=(.*)/)[1]);
+    }
+    return values;
   };
 });

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_filters.js.es6
@@ -1,50 +1,19 @@
+// = require ./meetings_form_filter.component
 // = require_self
-$(document).ready(() => {
-  const $form = $('form#new_filter');
-  const $scopes = $form.find('input[type=checkbox]');
-  const $sort = $form.find('input[type=radio]');
 
-  $form.on('change', 'input, select', (event) => {
-    $form.submit();
+((exports) => {
+  const { DecidimMeetings: { MeetingsFormFilterComponent } } = exports;
+  const meetingsFormFilter = new MeetingsFormFilterComponent('form#new_filter');
 
-    let newUrl;
-    const formAction = $form.attr('action');
-    const params = $form.serialize();
-
-    if (formAction.indexOf('?') < 0) {
-      newUrl = `${formAction}?${params}`;
-    } else {
-      newUrl = `${formAction}&${params}`;
-    }
-
-    window.history.pushState(null, null, newUrl);
-  });
-
-  window.onpopstate = function(event) {
-    $scopes.attr('checked', false);
-    $sort.attr('checked', false)
-
-    let [sortValue] = getLocationParams(/order_start_time=([^&]*)/g) || ["asc"];
-    $form.find(`input[type=radio][value=${sortValue}]`)[0].checked = true;
-
-    let scopeValues = getLocationParams(/scope_id\[\]=([^&]*)/g) || [];
-    console.log(scopeValues)
-    scopeValues.forEach(value => {
-      $form.find(`input[type=checkbox][value=${value}]`)[0].checked = true;
-    })
-
-    let [categoryIdValue] = getLocationParams(/filter\[category_id\]=([^&]*)/g) || [];
-    $form.find(`select#filter_category_id`).first().val(categoryIdValue);
-
-    $form.submit();
+  const onDocumentReady = () => {
+    meetingsFormFilter.mountComponent();
   };
 
-  const getLocationParams = (regex) => {
-    const location = decodeURIComponent(document.location);
-    let values = location.match(regex);
-    if (values) {
-      values = values.map(val => val.match(/=(.*)/)[1]);
-    }
-    return values;
+  const onTurboLinksBeforeVisit = () => {
+    meetingsFormFilter.unmountComponent();
+    $(document).off('turbolinks:before-visit', onTurboLinksBeforeVisit);
   };
-});
+
+  $(document).ready(onDocumentReady);
+  $(document).on('turbolinks:before-visit', onTurboLinksBeforeVisit);
+})(window);

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form_filter.component.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form_filter.component.js.es6
@@ -1,4 +1,10 @@
 /* eslint-disable no-div-regex, no-useless-escape, no-param-reassign */
+
+/**
+ * A component that handles the meetings filter form.
+ * @class
+ * @augments Component
+ */
 ((exports) => {
   class MeetingsFormFilterComponent {
     constructor(selector) {
@@ -9,6 +15,11 @@
       this._onPopState = this._onPopState.bind(this);
     }
 
+    /**
+     * Handles the logic for unmounting the component
+     * @public
+     * @returns {Void} - Returns nothing
+     */
     unmountComponent() {
       if (this.mounted) {
         this.mounted = false;
@@ -18,6 +29,11 @@
       }
     }
 
+    /**
+     * Handles the logic for mounting the component
+     * @public
+     * @returns {Void} - Returns nothing
+     */
     mountComponent() {
       if (this.$form.length > 0 && !this.mounted) {
         this.mounted = true;
@@ -27,10 +43,21 @@
       }
     }
 
+    /**
+     * Finds the current location.
+     * @private
+     * @returns {String} - Returns the current location.
+     */
     _getLocation() {
       return exports.location;
     }
 
+    /**
+     * Finds the values of the location prams that match the given regexp.
+     * @private
+     * @param {Regexp} regex - a Regexp to match the params.
+     * @returns {String[]} - An array of values of the params that match the regexp.
+     */
     _getLocationParams(regex) {
       const location = decodeURIComponent(this._getLocation());
       let values = location.match(regex);
@@ -40,11 +67,21 @@
       return values;
     }
 
+    /**
+     * Clears the form to start with a clean state.
+     * @private
+     * @returns {Void} - Returns nothing.
+     */
     _clearForm() {
       this.$form.find('input[type=checkbox]').attr('checked', false);
       this.$form.find('input[type=radio]').attr('checked', false);
     }
 
+    /**
+     * Handles the logic when going back to a previous state in the filter form.
+     * @private
+     * @returns {Void} - Returns nothing.
+     */
     _onPopState() {
       this._clearForm();
 
@@ -62,6 +99,11 @@
       this.$form.submit();
     }
 
+    /**
+     * Handles the logic to update the current location after a form change event.
+     * @private
+     * @returns {Void} - Returns nothing.
+     */
     _onFormChange() {
       let newUrl = '';
       const formAction = this.$form.attr('action');

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form_filter.component.js.es6
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form_filter.component.js.es6
@@ -1,0 +1,82 @@
+((exports) => {
+  class MeetingsFormFilterComponent {
+    constructor(selector) {
+      this.$form = $(selector);
+      this.mounted = false;
+    }
+
+    getLocationParams(regex) {
+      const location = decodeURIComponent(exports.location);
+      let values = location.match(regex);
+      if (values) {
+        values = values.map(val => val.match(/=(.*)/)[1]);
+      }
+      return values;
+    }
+
+    clearForm() {
+      this.$form.find('input[type=checkbox]').attr('checked', false);
+      this.$form.find('input[type=radio]').attr('checked', false);
+    }
+
+    onPopState(event) {
+      this.clearForm();
+
+      let [sortValue] = this.getLocationParams(/order_start_time=([^&]*)/g) || ["asc"];
+      this.$form.find(`input[type=radio][value=${sortValue}]`)[0].checked = true;
+
+      let scopeValues = this.getLocationParams(/scope_id\[\]=([^&]*)/g) || [];
+      scopeValues.forEach(value => {
+        this.$form.find(`input[type=checkbox][value=${value}]`)[0].checked = true;
+      })
+
+      let [categoryIdValue] = this.getLocationParams(/filter\[category_id\]=([^&]*)/g) || [];
+      this.$form.find(`select#filter_category_id`).first().val(categoryIdValue);
+
+      this.$form.submit();
+    }
+
+    onFormChange() {
+      let newUrl;
+      const formAction = this.$form.attr('action');
+      const params = this.$form.serialize();
+
+      this.$form.submit();
+
+      if (formAction.indexOf('?') < 0) {
+        newUrl = `${formAction}?${params}`;
+      } else {
+        newUrl = `${formAction}&${params}`;
+      }
+
+      exports.history.pushState(null, null, newUrl);
+    }
+
+    unmountComponent() {
+      if (this.mounted) {
+        console.log("unmount")
+        this.mounted = false;
+        this.$form.off('change', 'input, select', () => {
+          this.onFormChange();
+        });
+
+        exports.onpopstate = null;
+      }
+    }
+
+    mountComponent() {
+      if (this.$form.length > 0 && !this.mounted) {
+        console.log("mount")
+        this.mounted = true;
+        this.$form.on('change', 'input, select', () => {
+          this.onFormChange();
+        });
+
+        exports.onpopstate = (event) => this.onPopState(event);
+      }
+    }
+  }
+
+  exports.DecidimMeetings = exports.DecidimMeetings || {};
+  exports.DecidimMeetings.MeetingsFormFilterComponent = MeetingsFormFilterComponent;
+})(window);

--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form_filter.component.test.js
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/meetings_form_filter.component.test.js
@@ -1,0 +1,145 @@
+/* eslint-disable no-unused-expressions */
+require('jquery');
+require('./meetings_form_filter.component.js.es6');
+
+const { DecidimMeetings: { MeetingsFormFilterComponent } } = window;
+
+describe('MeetingsFormFilterComponent', () => {
+  const selector = 'form#new_filter';
+  let subject = null;
+
+  beforeEach(() => {
+    let form = `
+      <form id="new_filter" action="/filters" method="get">
+        <input value="asc" type="radio" name="order_start_time" checked />
+        <input value="desc" type="radio" name="order_start_time" />
+
+        <input value="1" type="checkbox" name="scope_id[]" />
+        <input value="2" type="checkbox" name="scope_id[]" />
+        <input value="3" type="checkbox" name="scope_id[]" />
+
+        <select id="filter_category_id" name="filter[category_id]">
+          <option value="1">Category 1</option>
+          <option value="2">Category 2</option>
+        </select>
+      </form>
+    `;
+    $('body').append(form);
+    window.history = {
+      pushState: sinon.stub()
+    };
+    subject = new MeetingsFormFilterComponent(selector);
+  });
+
+  it('exists', () => {
+    expect(MeetingsFormFilterComponent).to.exist;
+  });
+
+  it('initializes unmounted', () => {
+    expect(subject.mounted).to.be.falsey;
+  });
+
+  it('initializes the formSelector with the given selector', () => {
+    expect(subject.$form).to.deep.equal($(selector));
+  });
+
+  describe('when mounted', () => {
+    beforeEach(() => {
+      sinon.spy(subject.$form, 'on');
+      subject.mountComponent();
+    });
+
+    afterEach(() => {
+      subject.$form.on.restore();
+      subject.unmountComponent();
+    });
+
+    it('mounts the component', () => {
+      expect(subject.mounted).to.be.truthy;
+    });
+
+    it('mounts the component', () => {
+      expect(window.onpopstate).to.equal(subject._onPopState);
+    });
+
+    it('binds the form change event', () => {
+      expect(subject.$form.on).to.have.been.calledWith('change', 'input, select', subject._onFormChange);
+    });
+
+    describe('on form change event', () => {
+      let stub = null;
+
+      beforeEach(() => {
+        stub = sinon.stub(subject.$form, 'submit');
+      });
+
+      it('form is submitted', () => {
+        $(selector).find('input[name=order_start_time][value=desc]').trigger('change');
+
+        expect(stub).to.have.been.calledOnce;
+      })
+
+      it('sets the onpopostate callback', () => {
+        sinon.stub(subject.$form, 'serialize').returns('order_start_time=desc')
+        $(selector).find('input[name=order_start_time][value=desc]').trigger('change');
+
+        expect(window.history.pushState).to.have.been.calledWith(null, null, '/filters?order_start_time=desc');
+      });
+    });
+
+    describe('onpopstate event', () => {
+      beforeEach(() => {
+        sinon.stub(subject.$form, 'submit');
+      });
+
+      it('clears the form data', () => {
+        let clearFormSpy = sinon.spy(subject, '_clearForm');
+
+        window.onpopstate();
+
+        expect(clearFormSpy).to.have.been.called;
+      });
+
+      it('sets the correct form fields based on the current location', () => {
+        sinon.stub(subject, '_getLocation').returns('/filters?order_start_time=desc&scope_id[]=1&scope_id[]=2&filter[category_id]=2')
+
+        window.onpopstate();
+
+        expect($(selector).find('select').val()).to.equal('2');
+        expect($(selector).find('input[name=order_start_time][value=desc]').attr('checked')).to.be.truthy;
+        expect($(selector).find('input[name=order_start_time][value=asc]').attr('checked')).to.be.falsey;
+        expect($(selector).find('input[name=scope_id][value=1]').attr('checked')).to.be.truthy;
+        expect($(selector).find('input[name=scope_id][value=2]').attr('checked')).to.be.truthy;
+        expect($(selector).find('input[name=scope_id][value=3]').attr('checked')).to.be.falsey;
+      });
+    });
+  });
+
+  describe('when unmounted', () => {
+    beforeEach(() => {
+      sinon.spy(subject.$form, 'off');
+      subject.mountComponent();
+      subject.unmountComponent();
+    });
+
+    afterEach(() => {
+      subject.$form.off.restore();
+    })
+
+    it('mounts the component', () => {
+      expect(subject.mounted).to.be.falsey;
+    });
+
+    it('unbinds the form change event', () => {
+      expect(subject.$form.off).to.have.been.calledWith('change', 'input, select', subject._onFormChange);
+    });
+
+    it('removes the onpopostate callback', () => {
+      expect(window.onpopstate).not.to.exist;
+    });
+  });
+
+  afterEach(() => {
+    $(selector).remove();
+  })
+});

--- a/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
@@ -23,6 +23,7 @@ module Decidim
 
         def create_meeting
           Meeting.create!(
+            decidim_scope_id: @form.decidim_scope_id,
             title: @form.title,
             short_description: @form.short_description,
             description: @form.description,

--- a/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
@@ -23,8 +23,8 @@ module Decidim
 
         def create_meeting
           Meeting.create!(
-            decidim_scope_id: @form.decidim_scope_id,
-            decidim_category_id: @form.decidim_category_id,
+            scope: @form.scope,
+            category: @form.category,
             title: @form.title,
             short_description: @form.short_description,
             description: @form.description,

--- a/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/create_meeting.rb
@@ -24,6 +24,7 @@ module Decidim
         def create_meeting
           Meeting.create!(
             decidim_scope_id: @form.decidim_scope_id,
+            decidim_category_id: @form.decidim_category_id,
             title: @form.title,
             short_description: @form.short_description,
             description: @form.description,

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -28,6 +28,7 @@ module Decidim
 
         def update_meeting
           @meeting.update_attributes!(
+            decidim_scope_id: @form.decidim_scope_id,
             title: @form.title,
             short_description: @form.short_description,
             description: @form.description,

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -29,6 +29,7 @@ module Decidim
         def update_meeting
           @meeting.update_attributes!(
             decidim_scope_id: @form.decidim_scope_id,
+            decidim_category_id: @form.decidim_category_id,
             title: @form.title,
             short_description: @form.short_description,
             description: @form.description,

--- a/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/update_meeting.rb
@@ -28,8 +28,8 @@ module Decidim
 
         def update_meeting
           @meeting.update_attributes!(
-            decidim_scope_id: @form.decidim_scope_id,
-            decidim_category_id: @form.decidim_category_id,
+            scope: @form.scope,
+            category: @form.category,
             title: @form.title,
             short_description: @form.short_description,
             description: @form.description,

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -52,8 +52,7 @@ module Decidim
 
       def context_params
         {
-          feature_id: current_feature.id,
-          organization_id: current_organization.id
+          feature: current_feature
         }
       end
     end

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -8,7 +8,7 @@ module Decidim
     # Note that it inherits from `Decidim::Features::BaseController`, which
     # override its layout and provide all kinds of useful methods.
     class MeetingsController < Decidim::Meetings::ApplicationController
-      helper_method :meetings, :meeting, :search_params
+      helper_method :meetings, :meeting, :search_params, :filter
 
       def index
         respond_to do |format|
@@ -28,7 +28,17 @@ module Decidim
       end
 
       def search_params
-        default_search_params.merge(params.to_unsafe_h)
+        default_search_params
+          .merge(params.to_unsafe_h.except(:filter))
+          .merge(params.to_unsafe_h[:filter])
+      end
+
+      def filter
+        @filter ||= filter_klass.new(params.dig(:filter, :category_id), params[:order_start_time], params[:scope_id])
+      end
+
+      def filter_klass
+        Struct.new(:category_id, :order_start_time, :scope_id)
       end
 
       def default_search_params

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -20,7 +20,7 @@ module Decidim
       private
 
       def meetings
-        @meetings ||= MeetingsSearch.new(search_params.merge(feature_id: current_feature.id)).results
+        @meetings ||= MeetingsSearch.new(search_params.merge(context_params)).results
       end
 
       def meeting
@@ -37,6 +37,9 @@ module Decidim
         @filter ||= filter_klass.new(params.dig(:filter, :category_id), params[:order_start_time], params[:scope_id])
       end
 
+      # Internal: Defines a class that will wrap in an object the URL params used by the filter.
+      # this way we can use Rails' form helpers and have automatically cehcked checkboxes and
+      # radio buttons in the view, for example.
       def filter_klass
         Struct.new(:category_id, :order_start_time, :scope_id)
       end
@@ -45,6 +48,13 @@ module Decidim
         {
           order_start_time: "asc"
         }.with_indifferent_access
+      end
+
+      def context_params
+        {
+          feature_id: current_feature.id,
+          organization_id: current_organization.id
+        }
       end
     end
   end

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -8,16 +8,33 @@ module Decidim
     # Note that it inherits from `Decidim::Features::BaseController`, which
     # override its layout and provide all kinds of useful methods.
     class MeetingsController < Decidim::Meetings::ApplicationController
-      helper_method :meetings, :meeting
+      helper_method :meetings, :meeting, :search_params
+
+      def index
+        respond_to do |format|
+          format.html
+          format.js
+        end
+      end
 
       private
 
       def meetings
-        @meetings ||= MeetingsSearch.new(current_feature: current_feature, order_start_time: :asc).results
+        @meetings ||= MeetingsSearch.new(search_params.merge(feature_id: current_feature.id)).results
       end
 
       def meeting
         @meeting ||= meetings.find(params[:id])
+      end
+
+      def search_params
+        default_search_params.merge(params)
+      end
+
+      def default_search_params
+        {
+          order_start_time: "asc"
+        }.with_indifferent_access
       end
     end
   end

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -13,7 +13,7 @@ module Decidim
       private
 
       def meetings
-        @meetings ||= Meeting.where(decidim_feature_id: current_feature.id).order(start_time: :asc)
+        @meetings ||= MeetingsSearch.new(current_feature: current_feature, order_start_time: :asc).results
       end
 
       def meeting

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -30,7 +30,7 @@ module Decidim
       def search_params
         default_search_params
           .merge(params.to_unsafe_h.except(:filter))
-          .merge(params.to_unsafe_h[:filter])
+          .merge(params.to_unsafe_h[:filter] || {})
       end
 
       def filter

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -28,7 +28,7 @@ module Decidim
       end
 
       def search_params
-        default_search_params.merge(params)
+        default_search_params.merge(params.to_unsafe_h)
       end
 
       def default_search_params

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -27,10 +27,16 @@ module Decidim
 
         validates :current_feature, presence: true
         validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
+        validates :category, presence: true, if: ->(form) { form.decidim_category_id.present? }
 
         def scope
           return unless current_feature
           @scope ||= current_feature.scopes.where(id: decidim_scope_id).first
+        end
+
+        def category
+          return unless current_feature
+          @category ||= current_feature.categories.where(id: decidim_category_id).first
         end
       end
     end

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -15,6 +15,7 @@ module Decidim
         attribute :start_time, DateTime
         attribute :end_time, DateTime
         attribute :decidim_scope_id, Integer
+        attribute :decidim_category_id, Integer
 
         validates :title, translatable_presence: true
         validates :short_description, translatable_presence: true
@@ -28,6 +29,7 @@ module Decidim
         validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
 
         def scope
+          return unless current_feature
           @scope ||= current_feature.scopes.where(id: decidim_scope_id).first
         end
       end

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -14,6 +14,7 @@ module Decidim
         attribute :address, String
         attribute :start_time, DateTime
         attribute :end_time, DateTime
+        attribute :decidim_scope_id, Integer
 
         validates :title, translatable_presence: true
         validates :short_description, translatable_presence: true
@@ -24,6 +25,11 @@ module Decidim
         validates :end_time, presence: true, date: { after: :start_time }
 
         validates :current_feature, presence: true
+        validates :scope, presence: true, if: ->(form) { form.decidim_scope_id.present? }
+
+        def scope
+          @scope ||= current_feature.scopes.where(id: decidim_scope_id).first
+        end
       end
     end
   end

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 module Decidim
-  module Proposals
-    # Custom helpers, scoped to the proposals engine.
+  module Meetings
+    # Custom helpers, scoped to the meetings engine.
     #
     module ApplicationHelper
-      include Decidim::Comments::CommentsHelper
       include PaginateHelper
     end
   end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -6,6 +6,7 @@ module Decidim
     class Meeting < Meetings::ApplicationRecord
       belongs_to :feature, foreign_key: "decidim_feature_id", class_name: Decidim::Feature
       belongs_to :scope, foreign_key: "decidim_scope_id", class_name: Decidim::Scope
+      belongs_to :category, foreign_key: "decidim_category_id", class_name: Decidim::Category
 
       validates :title, presence: true
 

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -5,8 +5,18 @@ module Decidim
     # title, description and any other useful information to render a custom meeting.
     class Meeting < Meetings::ApplicationRecord
       belongs_to :feature, foreign_key: "decidim_feature_id", class_name: Decidim::Feature
+      belongs_to :scope, foreign_key: "decidim_scope_id", class_name: Decidim::Scope
 
       validates :title, presence: true
+
+      validate :scope_belongs_to_organization
+
+      private
+
+      def scope_belongs_to_organization
+        return unless scope
+        errors.add(:scope, :invalid) unless feature.scopes.where(id: scope.id).exists?
+      end
     end
   end
 end

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -11,12 +11,18 @@ module Decidim
       validates :title, presence: true
 
       validate :scope_belongs_to_organization
+      validate :category_belongs_to_organization
 
       private
 
       def scope_belongs_to_organization
         return unless scope
         errors.add(:scope, :invalid) unless feature.scopes.where(id: scope.id).exists?
+      end
+
+      def category_belongs_to_organization
+        return unless category
+        errors.add(:category, :invalid) unless feature.categories.where(id: category.id).exists?
       end
     end
   end

--- a/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
@@ -6,8 +6,8 @@ module Decidim
     # find the meetings.
     class MeetingsSearch < Searchlight::Search
       def base_query
-        raise "Missing feature" unless options[:current_feature]
-        Meeting.where(feature: options[:current_feature])
+        raise "Missing feature" unless options[:feature_id]
+        Meeting.where(feature: current_feature)
       end
 
       def search_order_start_time
@@ -15,7 +15,17 @@ module Decidim
       end
 
       def search_scope_id
-        query.where(decidim_scope_id: scope_id)
+        query.where(decidim_scope_id: parsed_scope_id)
+      end
+
+      private
+
+      def parsed_scope_id
+        scope_id
+      end
+
+      def current_feature
+        @feature ||= Feature.where(id: options[:feature_id]).first
       end
     end
   end

--- a/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Decidim
+  module Meetings
+    # This class handles search and filtering of meetings. Needs a
+    # `current_feature` param with a `Decidim::Feature` in order to
+    # find the meetings.
+    class MeetingsSearch < Searchlight::Search
+      def base_query
+        raise "Missing feature" unless options[:current_feature]
+        Meeting.where(feature: options[:current_feature])
+      end
+
+      def search_order_start_time
+        query.order(start_time: order_start_time)
+      end
+
+      def search_scope_id
+        query.where(decidim_scope_id: scope_id)
+      end
+    end
+  end
+end

--- a/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
@@ -19,14 +19,14 @@ module Decidim
       end
 
       def search_scope_id
-        query.where(decidim_scope_id: parsed_scope_id)
+        query.where(decidim_scope_id: scope_id)
+      end
+
+      def search_category_id
+        query.where(decidim_category_id: category_id)
       end
 
       private
-
-      def parsed_scope_id
-        scope_id
-      end
 
       def current_feature
         return unless options[:feature_id].present?

--- a/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
@@ -7,7 +7,7 @@ module Decidim
     class MeetingsSearch < Searchlight::Search
       def base_query
         raise "Missing feature" unless options[:feature_id]
-        Meeting.where(feature: current_feature)
+        Meeting.page(options[:page] || 1).per(1).where(feature: current_feature)
       end
 
       def search_order_start_time

--- a/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
@@ -23,10 +23,17 @@ module Decidim
       end
 
       def search_category_id
-        query.where(decidim_category_id: category_id)
+        query.where(decidim_category_id: category_ids)
       end
 
       private
+
+      def category_ids
+        Category
+          .where(id: category_id)
+          .or(Category.where(parent_id: category_id))
+          .pluck(:id)
+      end
 
       def current_feature
         return unless options[:feature_id].present?

--- a/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
@@ -6,8 +6,12 @@ module Decidim
     # find the meetings.
     class MeetingsSearch < Searchlight::Search
       def base_query
-        raise "Missing feature" unless options[:feature_id]
-        Meeting.page(options[:page] || 1).per(1).where(feature: current_feature)
+        raise "Missing feature" unless current_feature
+
+        Meeting
+          .page(options[:page] || 1)
+          .per(options[:per_page] || 12)
+          .where(feature: current_feature)
       end
 
       def search_order_start_time
@@ -25,6 +29,7 @@ module Decidim
       end
 
       def current_feature
+        return unless options[:feature_id].present?
         @feature ||= Feature.where(id: options[:feature_id]).first
       end
     end

--- a/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
@@ -29,15 +29,24 @@ module Decidim
       private
 
       def category_ids
-        Category
+        current_feature
+          .categories
           .where(id: category_id)
-          .or(Category.where(parent_id: category_id))
+          .or(current_feature.categories.where(parent_id: category_id))
           .pluck(:id)
       end
 
       def current_feature
-        return unless options[:feature_id].present?
-        @feature ||= Feature.where(id: options[:feature_id]).first
+        return unless options[:feature_id].present? || !current_organization
+        @feature ||= Feature.where(
+          id: options[:feature_id],
+          decidim_participatory_process_id: current_organization.participatory_processes.pluck(:id)
+        ).first
+      end
+
+      def current_organization
+        return unless options[:organization_id].present?
+        @organization ||= Organization.where(id: options[:organization_id]).first
       end
     end
   end

--- a/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meetings_search.rb
@@ -37,16 +37,7 @@ module Decidim
       end
 
       def current_feature
-        return unless options[:feature_id].present? || !current_organization
-        @feature ||= Feature.where(
-          id: options[:feature_id],
-          decidim_participatory_process_id: current_organization.participatory_processes.pluck(:id)
-        ).first
-      end
-
-      def current_organization
-        return unless options[:organization_id].present?
-        @organization ||= Organization.where(id: options[:organization_id]).first
+        options[:feature]
       end
     end
   end

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -11,11 +11,11 @@
 </div>
 
 <div class="field" >
-  <%= form.translated :editor, :location %>
+  <%= form.translated :text_area, :location %>
 </div>
 
 <div class="field" >
-  <%= form.translated :editor, :location_hints %>
+  <%= form.translated :text_area, :location_hints %>
 </div>
 
 <div class="field" >

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -35,5 +35,5 @@
 </div>
 
 <div class="field" >
-  <%= form.categories_select :decidim_category_id, current_participatory_process.categories, "" %>
+  <%= form.categories_select :decidim_category_id, current_participatory_process.categories, prompt: "" %>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -35,5 +35,5 @@
 </div>
 
 <div class="field" >
-  <%= form.categories_select :decidim_category_id, current_participatory_process.categories, prompt: "" %>
+  <%= form.categories_select :decidim_category_id, current_participatory_process.categories, prompt: "", disable_parents: false %>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -30,3 +30,6 @@
   <%= form.datetime_field :end_time %>
 </div>
 
+<div class="field" >
+  <%= form.collection_select :decidim_scope_id, current_organization.scopes, :id, :name, include_blank: true %>
+</div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_form.html.erb
@@ -33,3 +33,7 @@
 <div class="field" >
   <%= form.collection_select :decidim_scope_id, current_organization.scopes, :id, :name, include_blank: true %>
 </div>
+
+<div class="field" >
+  <%= form.categories_select :decidim_category_id, current_participatory_process.categories, "" %>
+</div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -1,5 +1,5 @@
 <div class="filters">
-  <%= form_tag url_for, method: :get, id: "filter_form", remote: true do %>
+  <%= form_for filter, url: url_for, as: :filter, method: :get, remote: true do |form| %>
     <div class="filters__section">
       <fieldset>
         <legend>
@@ -20,9 +20,15 @@
         <legend><h6 class="heading6"><%= t('.scopes') %></h6></legend>
         <% current_organization.scopes.each do |scope| %>
           <label>
-            <input value="<%= scope.id %>" type="checkbox"  name="scope_id[]" <%= "checked" if (search_params[:scope_id] || []).include?(scope.id.to_s) %>><%= scope.name %>
+            <input value="<%= scope.id %>" type="checkbox"  name="scope_id[]" <%= "checked" if (filter.scope_id || []).include?(scope.id.to_s) %>><%= scope.name %>
           </label>
         <% end %>
+      </fieldset>
+    </div>
+    <div class="filters__section">
+      <fieldset>
+        <legend><h6 class="heading6"><%= t('.category') %></h6></legend>
+        <%= form.categories_select :category_id, current_feature.categories, disable_parents: false, label: false, include_blank: true %>
       </fieldset>
     </div>
   <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -1,0 +1,31 @@
+<div class="filters">
+  <%= form_tag url_for, method: :get, id: "filter_form", remote: true do %>
+    <div class="filters__section">
+      <fieldset>
+        <legend>
+          <h6 class="heading6">
+            Date
+          </h6>
+        </legend>
+        <label>
+          <input value="asc" type="radio" name="order_start_time" <%= search_params[:order_start_time] == "asc" ? "checked" : nil %>>Ascendent
+        </label>
+        <label>
+          <input value="desc" type="radio" name="order_start_time" <%= search_params[:order_start_time] == "desc" ? "checked" : nil %>>Descendent
+        </label>
+      </fieldset>
+    </div>
+    <div class="filters__section">
+      <fieldset>
+        <legend><h6 class="heading6">Scopes</h6></legend>
+        <% current_organization.scopes.each do |scope| %>
+          <label>
+            <input value="<%= scope.id %>" type="checkbox"  name="scope_id[]" <%= "checked" if (search_params[:scope_id] || "").split(",").include?(scope.id.to_s) %>><%= scope.name %>
+          </label>
+        <% end %>
+      </fieldset>
+    </div>
+  <% end %>
+</div>
+
+<%= javascript_include_tag "decidim/meetings/meetings_filters" %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -4,20 +4,20 @@
       <fieldset>
         <legend>
           <h6 class="heading6">
-            Date
+            <%= t('.date') %>
           </h6>
         </legend>
         <label>
-          <input value="asc" type="radio" name="order_start_time" <%= search_params[:order_start_time] == "asc" ? "checked" : nil %>>Ascendent
+          <input value="asc" type="radio" name="order_start_time" <%= search_params[:order_start_time] == "asc" ? "checked" : nil %>><%= t('.ascendent') %>
         </label>
         <label>
-          <input value="desc" type="radio" name="order_start_time" <%= search_params[:order_start_time] == "desc" ? "checked" : nil %>>Descendent
+          <input value="desc" type="radio" name="order_start_time" <%= search_params[:order_start_time] == "desc" ? "checked" : nil %>><%= t('.descendent') %>
         </label>
       </fieldset>
     </div>
     <div class="filters__section">
       <fieldset>
-        <legend><h6 class="heading6">Scopes</h6></legend>
+        <legend><h6 class="heading6"><%= t('.scopes') %></h6></legend>
         <% current_organization.scopes.each do |scope| %>
           <label>
             <input value="<%= scope.id %>" type="checkbox"  name="scope_id[]" <%= "checked" if (search_params[:scope_id] || []).include?(scope.id.to_s) %>><%= scope.name %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -15,22 +15,28 @@
         </label>
       </fieldset>
     </div>
-    <div class="filters__section">
-      <fieldset>
-        <legend><h6 class="heading6"><%= t('.scopes') %></h6></legend>
-        <% current_organization.scopes.each do |scope| %>
-          <label>
-            <input value="<%= scope.id %>" type="checkbox"  name="scope_id[]" <%= "checked" if (filter.scope_id || []).include?(scope.id.to_s) %>><%= scope.name %>
-          </label>
-        <% end %>
-      </fieldset>
-    </div>
-    <div class="filters__section">
-      <fieldset>
-        <legend><h6 class="heading6"><%= t('.category') %></h6></legend>
-        <%= form.categories_select :category_id, current_feature.categories, disable_parents: false, label: false, include_blank: true %>
-      </fieldset>
-    </div>
+
+    <% if current_organization.scopes.any? %>
+      <div class="filters__section">
+        <fieldset>
+          <legend><h6 class="heading6"><%= t('.scopes') %></h6></legend>
+          <% current_organization.scopes.each do |scope| %>
+            <label>
+              <input value="<%= scope.id %>" type="checkbox"  name="scope_id[]" <%= "checked" if (filter.scope_id || []).include?(scope.id.to_s) %>><%= scope.name %>
+            </label>
+          <% end %>
+        </fieldset>
+      </div>
+    <% end %>
+
+    <% if current_feature.categories.any? %>
+      <div class="filters__section">
+        <fieldset>
+          <legend><h6 class="heading6"><%= t('.category') %></h6></legend>
+          <%= form.categories_select :category_id, current_feature.categories, disable_parents: false, label: false, include_blank: true %>
+        </fieldset>
+      </div>
+    <% end %>
   <% end %>
 </div>
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -20,7 +20,7 @@
         <legend><h6 class="heading6">Scopes</h6></legend>
         <% current_organization.scopes.each do |scope| %>
           <label>
-            <input value="<%= scope.id %>" type="checkbox"  name="scope_id[]" <%= "checked" if (search_params[:scope_id] || "").split(",").include?(scope.id.to_s) %>><%= scope.name %>
+            <input value="<%= scope.id %>" type="checkbox"  name="scope_id[]" <%= "checked" if (search_params[:scope_id] || []).include?(scope.id.to_s) %>><%= scope.name %>
           </label>
         <% end %>
       </fieldset>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -15,16 +15,7 @@
             </div>
           </div>
           <%== translated_attribute meeting.description %>
-          <% if meeting.category.present? || meeting.scope.present? %>
-            <ul class="tags tags--meeting" >
-              <% if meeting.category.present? %>
-                <li><a><%= translated_attribute meeting.category.name %></a></li>
-              <% end %>
-              <% if meeting.scope.present? %>
-                <li><a><%= meeting.scope.name %></a></li>
-              <% end %>
-            </ul>
-          <% end %>
+          <%= render partial: "tags", locals: { meeting: meeting } %>
           <div class="address card__extra">
             <div class="address__icon">
               <%= icon "meetings", removeIconClass: true, width: 40, height: 70 %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -15,6 +15,16 @@
             </div>
           </div>
           <%== translated_attribute meeting.description %>
+          <% if meeting.category.present? || meeting.scope.present? %>
+            <ul class="tags tags--meeting" >
+              <% if meeting.category.present? %>
+                <li><a><%= translated_attribute meeting.category.name %></a></li>
+              <% end %>
+              <% if meeting.scope.present? %>
+                <li><a><%= meeting.scope.name %></a></li>
+              <% end %>
+            </ul>
+          <% end %>
           <div class="address card__extra">
             <div class="address__icon">
               <%= icon "meetings", removeIconClass: true, width: 40, height: 70 %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -36,4 +36,4 @@
     </div>
   <% end %>
 </div>
-<%= decidim_paginate meetings, params %>
+<%= decidim_paginate meetings, order_start_time: params[:order_start_time], scope_id: params[:scope_id] %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -36,10 +36,4 @@
     </div>
   <% end %>
 </div>
-<%
-  # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
-  # and unless we remove these params they are added again as query string 😩
-  params.delete("participatory_process_id")
-  params.delete("feature_id")
-%>
-<%= paginate meetings, theme: "decidim", params: { order_start_time: params[:order_start_time], scope_id: params[:scope_id] } %>
+<%= decidim_paginate meetings, params %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -1,26 +1,35 @@
-<% meetings.each do |meeting| %>
-  <div class="column">
-    <article class="card card--meeting">
-      <div class="card__content">
-        <%= link_to meeting, class: "card__link" do %>
-          <h5 class="card__title"><%= translated_attribute meeting.title %></h5>
-        <% end %>
-        <div class="card__datetime">
-          <div class="card__datetime__date">
-            <%= l meeting.start_time, format: "%d" %> <span class="card__datetime__month"><%= l meeting.start_time, format: "%B" %></span>
+<div class="row small-up-1 medium-up-2 card-grid">
+  <% meetings.each do |meeting| %>
+    <div class="column">
+      <article class="card card--meeting">
+        <div class="card__content">
+          <%= link_to meeting, class: "card__link" do %>
+            <h5 class="card__title"><%= translated_attribute meeting.title %></h5>
+          <% end %>
+          <div class="card__datetime">
+            <div class="card__datetime__date">
+              <%= l meeting.start_time, format: "%d" %> <span class="card__datetime__month"><%= l meeting.start_time, format: "%B" %></span>
+            </div>
+            <div class="card__datetime__time">
+              <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>
+            </div>
           </div>
-          <div class="card__datetime__time">
-            <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>
+          <%== translated_attribute meeting.description %>
+          <div class="address card__extra">
+            <div class="address__icon">
+              <%= icon "meetings", removeIconClass: true, width: 40, height: 70 %>
+            </div>
+            <%= render partial: 'address_details', locals: { meeting: meeting } %>
           </div>
         </div>
-        <%== translated_attribute meeting.description %>
-        <div class="address card__extra">
-          <div class="address__icon">
-            <%= icon "meetings", removeIconClass: true, width: 40, height: 70 %>
-          </div>
-          <%= render partial: 'address_details', locals: { meeting: meeting } %>
-        </div>
-      </div>
-    </article>
-  </div>
-<% end %>
+      </article>
+    </div>
+  <% end %>
+</div>
+<%
+  # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
+  # and unless we remove these params they are added again as query string 😩
+  params.delete("participatory_process_id")
+  params.delete("feature_id")
+%>
+<%= paginate meetings, theme: "decidim", params: { order_start_time: params[:order_start_time], scope_id: params[:scope_id] } %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -1,0 +1,26 @@
+<% meetings.each do |meeting| %>
+  <div class="column">
+    <article class="card card--meeting">
+      <div class="card__content">
+        <%= link_to meeting, class: "card__link" do %>
+          <h5 class="card__title"><%= translated_attribute meeting.title %></h5>
+        <% end %>
+        <div class="card__datetime">
+          <div class="card__datetime__date">
+            <%= l meeting.start_time, format: "%d" %> <span class="card__datetime__month"><%= l meeting.start_time, format: "%B" %></span>
+          </div>
+          <div class="card__datetime__time">
+            <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>
+          </div>
+        </div>
+        <%== translated_attribute meeting.description %>
+        <div class="address card__extra">
+          <div class="address__icon">
+            <%= icon "meetings", removeIconClass: true, width: 40, height: 70 %>
+          </div>
+          <%= render partial: 'address_details', locals: { meeting: meeting } %>
+        </div>
+      </div>
+    </article>
+  </div>
+<% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_tags.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_tags.html.erb
@@ -1,0 +1,10 @@
+<% if meeting.category.present? || meeting.scope.present? %>
+  <ul class="tags tags--meeting" >
+    <% if meeting.category.present? %>
+      <li><%= link_to translated_attribute(meeting.category.name), decidim_meetings.meetings_path(filter: { category_id: meeting.category.id }) %></li>
+    <% end %>
+    <% if meeting.scope.present? %>
+      <li><%= link_to meeting.scope.name, decidim_meetings.meetings_path(scope_id: [meeting.scope.id]) %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -6,9 +6,7 @@
       <%= render partial: "filters" %>
     </div>
   </div>
-  <div class="columns mediumlarge-8 large-9">
-    <div id="meetings" class="row small-up-1 medium-up-2 card-grid">
-      <%= render partial: "meetings" %>
-    </div>
+  <div id="meetings" class="columns mediumlarge-8 large-9">
+    <%= render partial: "meetings" %>
   </div>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -1,30 +1,14 @@
 <% content_for(:title, t(".title")) %>
 
-<div class="row small-up-1 medium-up-2 large-up-3 card-grid">
-  <% meetings.each do |meeting| %>
-    <div class="column">
-      <article class="card card--meeting">
-        <div class="card__content">
-          <%= link_to meeting, class: "card__link" do %>
-            <h5 class="card__title"><%= translated_attribute meeting.title %></h5>
-          <% end %>
-          <div class="card__datetime">
-            <div class="card__datetime__date">
-              <%= l meeting.start_time, format: "%d" %> <span class="card__datetime__month"><%= l meeting.start_time, format: "%B" %></span>
-            </div>
-            <div class="card__datetime__time">
-              <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>
-            </div>
-          </div>
-          <%== translated_attribute meeting.description %>
-          <div class="address card__extra">
-            <div class="address__icon">
-              <%= icon "meetings", removeIconClass: true, width: 40, height: 70 %>
-            </div>
-            <%= render partial: 'address_details', locals: { meeting: meeting } %>
-          </div>
-        </div>
-      </article>
+<div class="row">
+  <div class="columns mediumlarge-4 large-3">
+    <div class="card card--secondary show-for-mediumlarge" >
+      <%= render partial: "filters" %>
     </div>
-  <% end %>
+  </div>
+  <div class="columns mediumlarge-8 large-9">
+    <div id="meetings" class="row small-up-1 medium-up-2 card-grid">
+      <%= render partial: "meetings" %>
+    </div>
+  </div>
 </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
@@ -1,2 +1,2 @@
-const $meetings = $('#meetings');
+var $meetings = $('#meetings');
 $meetings.html('<%= j(render partial: "meetings") %>');

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
@@ -1,0 +1,2 @@
+const $meetings = $('#meetings');
+$meetings.html('<%= j(render partial: "meetings") %>');

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -30,6 +30,7 @@
           </div>
         </div>
       </div>
+      <%= render partial: "tags", locals: { meeting: meeting } %>
     </div>
     <div class="section">
       <h3 class="section-heading"><%= t(".meeting_description") %></h3>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -33,6 +33,11 @@ en:
           meeting:
             name: Meeting
       meetings:
+        filters:
+          ascendent: Ascendent
+          date: Date
+          descendent: Descendent
+          scopes: Scopes
         index:
           title: Meetings
         show:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
       meetings:
         filters:
           ascendent: Ascendent
+          category: Category
           date: Date
           descendent: Descendent
           scopes: Scopes

--- a/decidim-meetings/db/migrate/20161130121354_create_meetings.rb
+++ b/decidim-meetings/db/migrate/20161130121354_create_meetings.rb
@@ -12,6 +12,7 @@ class CreateMeetings < ActiveRecord::Migration[5.0]
       t.references :decidim_feature, index: true
       t.references :decidim_author, index: true
       t.references :decidim_scope, index: true
+      t.references :decidim_category, index: true
 
       t.timestamps
     end

--- a/decidim-meetings/db/migrate/20161130121354_create_meetings.rb
+++ b/decidim-meetings/db/migrate/20161130121354_create_meetings.rb
@@ -11,6 +11,7 @@ class CreateMeetings < ActiveRecord::Migration[5.0]
       t.jsonb :location_hints
       t.references :decidim_feature, index: true
       t.references :decidim_author, index: true
+      t.references :decidim_scope, index: true
 
       t.timestamps
     end

--- a/decidim-meetings/decidim-meetings.gemspec
+++ b/decidim-meetings/decidim-meetings.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rectify", "~> 0.8"
   s.add_dependency "date_validator", "~> 0.9"
   s.add_dependency "searchlight", "~> 4.1.0"
+  s.add_dependency "kaminari", "~> 1.0.0.rc1"
 
   s.add_development_dependency "decidim-dev", Decidim.version
 end

--- a/decidim-meetings/decidim-meetings.gemspec
+++ b/decidim-meetings/decidim-meetings.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-core", Decidim.version
   s.add_dependency "rectify", "~> 0.8"
   s.add_dependency "date_validator", "~> 0.9"
+  s.add_dependency "searchlight", "~> 4.1.0"
 
   s.add_development_dependency "decidim-dev", Decidim.version
 end

--- a/decidim-meetings/lib/decidim/meetings/feature.rb
+++ b/decidim-meetings/lib/decidim/meetings/feature.rb
@@ -24,6 +24,7 @@ Decidim.register_feature(:meetings) do |feature|
       3.times do
         Decidim::Meetings::Meeting.create!(
           feature: feature,
+          scope: process.organization.scopes.sample,
           title: Decidim::Faker::Localized.sentence(2),
           description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(3)

--- a/decidim-meetings/lib/decidim/meetings/feature.rb
+++ b/decidim-meetings/lib/decidim/meetings/feature.rb
@@ -7,7 +7,7 @@ Decidim.register_feature(:meetings) do |feature|
   feature.admin_engine = Decidim::Meetings::AdminEngine
   feature.icon = "decidim/meetings/icon.svg"
 
-  feature.on(:destroy) do |instance|
+  feature.on(:before_destroy) do |instance|
     raise StandardError, "Can't remove this feature" if Decidim::Meetings::Meeting.where(feature: instance).any?
   end
 

--- a/decidim-meetings/lib/decidim/meetings/feature.rb
+++ b/decidim-meetings/lib/decidim/meetings/feature.rb
@@ -25,6 +25,7 @@ Decidim.register_feature(:meetings) do |feature|
         Decidim::Meetings::Meeting.create!(
           feature: feature,
           scope: process.organization.scopes.sample,
+          category: process.categories.sample,
           title: Decidim::Faker::Localized.sentence(2),
           description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(3)

--- a/decidim-meetings/lib/decidim/meetings/list_engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/list_engine.rb
@@ -13,6 +13,10 @@ module Decidim
         resources :meetings, only: [:index, :show]
         root to: "meetings#index"
       end
+
+      initializer "decidim_meetings.assets" do |app|
+        app.config.assets.precompile += %w(decidim_meetings_manifest.js)
+      end
     end
   end
 end

--- a/decidim-meetings/lib/decidim/meetings/list_engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/list_engine.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require "searchlight"
+
 module Decidim
   module Meetings
     # This is the engine that runs on the public interface of `decidim-meetings`.

--- a/decidim-meetings/lib/decidim/meetings/list_engine.rb
+++ b/decidim-meetings/lib/decidim/meetings/list_engine.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "searchlight"
+require "kaminari"
 
 module Decidim
   module Meetings

--- a/decidim-meetings/spec/commands/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/create_meeting_spec.rb
@@ -4,6 +4,7 @@ describe Decidim::Meetings::Admin::CreateMeeting do
   let(:organization) { create :organization, available_locales: [:en] }
   let(:participatory_process) { create :participatory_process, organization: organization }
   let(:current_feature) { create :feature, participatory_process: participatory_process }
+  let(:scope) { create :scope, organization: organization }
   let(:form) do
     double(
       :invalid? => invalid,
@@ -15,6 +16,7 @@ describe Decidim::Meetings::Admin::CreateMeeting do
       start_time: 1.day.from_now,
       end_time: 1.day.from_now + 1.hour,
       address: "address",
+      decidim_scope_id: scope.id,
       current_feature: current_feature
     )
   end

--- a/decidim-meetings/spec/commands/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/create_meeting_spec.rb
@@ -5,6 +5,7 @@ describe Decidim::Meetings::Admin::CreateMeeting do
   let(:participatory_process) { create :participatory_process, organization: organization }
   let(:current_feature) { create :feature, participatory_process: participatory_process }
   let(:scope) { create :scope, organization: organization }
+  let(:category) { create :category, participatory_process: participatory_process }
   let(:form) do
     double(
       :invalid? => invalid,
@@ -17,6 +18,7 @@ describe Decidim::Meetings::Admin::CreateMeeting do
       end_time: 1.day.from_now + 1.hour,
       address: "address",
       decidim_scope_id: scope.id,
+      decidim_category_id: category.id,
       current_feature: current_feature
     )
   end
@@ -33,8 +35,25 @@ describe Decidim::Meetings::Admin::CreateMeeting do
   end
 
   context "when everything is ok" do
+    let(:meeting) { Decidim::Meetings::Meeting.last }
+
     it "creates the meeting" do
       expect { subject.call }.to change { Decidim::Meetings::Meeting.count }.by(1)
+    end
+
+    it "sets the scope" do
+      subject.call
+      expect(meeting.scope).to eq scope
+    end
+
+    it "sets the category" do
+      subject.call
+      expect(meeting.category).to eq category
+    end
+
+    it "sets the feature" do
+      subject.call
+      expect(meeting.feature).to eq current_feature
     end
   end
 end

--- a/decidim-meetings/spec/commands/create_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/create_meeting_spec.rb
@@ -17,8 +17,8 @@ describe Decidim::Meetings::Admin::CreateMeeting do
       start_time: 1.day.from_now,
       end_time: 1.day.from_now + 1.hour,
       address: "address",
-      decidim_scope_id: scope.id,
-      decidim_category_id: category.id,
+      scope: scope,
+      category: category,
       current_feature: current_feature
     )
   end

--- a/decidim-meetings/spec/commands/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/update_meeting_spec.rb
@@ -15,8 +15,8 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
       location_hints: {en: "location_hints"},
       start_time: 1.day.from_now,
       end_time: 1.day.from_now + 1.hour,
-      decidim_scope_id: scope.id,
-      decidim_category_id: category.id,
+      scope: scope,
+      category: category,
       address: "address"
     )
   end

--- a/decidim-meetings/spec/commands/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/update_meeting_spec.rb
@@ -4,6 +4,7 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
   let(:meeting) { create :meeting}
   let(:organization) { meeting.feature.organization }
   let(:scope) { create :scope, organization: organization }
+  let(:category) { create :category, participatory_process: meeting.feature.participatory_process }
   let(:form) do
     double(
       :invalid? => invalid,
@@ -15,6 +16,7 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
       start_time: 1.day.from_now,
       end_time: 1.day.from_now + 1.hour,
       decidim_scope_id: scope.id,
+      decidim_category_id: category.id,
       address: "address"
     )
   end
@@ -31,8 +33,19 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
   end
 
   context "when everything is ok" do
-    it "creates the meeting" do
-      expect { subject.call }.to change { Decidim::Meetings::Meeting.count }.by(1)
+    it "updates the meeting" do
+      subject.call
+      expect(translated(meeting.title)).to eq "title"
+    end
+
+    it "sets the scope" do
+      subject.call
+      expect(meeting.scope).to eq scope
+    end
+
+    it "sets the category" do
+      subject.call
+      expect(meeting.category).to eq category
     end
   end
 end

--- a/decidim-meetings/spec/commands/update_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/update_meeting_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Decidim::Meetings::Admin::UpdateMeeting do
   let(:meeting) { create :meeting}
   let(:organization) { meeting.feature.organization }
+  let(:scope) { create :scope, organization: organization }
   let(:form) do
     double(
       :invalid? => invalid,
@@ -13,6 +14,7 @@ describe Decidim::Meetings::Admin::UpdateMeeting do
       location_hints: {en: "location_hints"},
       start_time: 1.day.from_now,
       end_time: 1.day.from_now + 1.hour,
+      decidim_scope_id: scope.id,
       address: "address"
     )
   end

--- a/decidim-meetings/spec/factories.rb
+++ b/decidim-meetings/spec/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     location_hints { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     address { Faker::Lorem.sentence(3) }
     start_time { 1.day.from_now }
-    end_time { 1.day.from_now + 2.hours }
+    end_time { start_time + 2.hours }
     feature
   end
 end

--- a/decidim-meetings/spec/factories.rb
+++ b/decidim-meetings/spec/factories.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     location_hints { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     address { Faker::Lorem.sentence(3) }
     start_time { 1.day.from_now }
-    end_time { start_time + 2.hours }
+    end_time { start_time.advance(hours: 2) }
     feature
   end
 end

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -34,6 +34,7 @@ describe "Explore meetings", type: :feature do
 
   context "show" do
     let(:path) { decidim_meetings.meeting_path(id: meeting.id, participatory_process_id: participatory_process.id, feature_id: current_feature.id) }
+    let(:meetings_count) { 1 }
     let(:meeting) { meetings.first }
 
     it "shows all meeting info" do
@@ -48,6 +49,58 @@ describe "Explore meetings", type: :feature do
         expect(page).to have_content(13)
         expect(page).to have_content(/December/i)
         expect(page).to have_content("14:15 - 16:17")
+      end
+    end
+
+    context "without category or scope" do
+      it "does not show any tag" do
+        expect(page).not_to have_selector("ul.tags.tags--meeting")
+      end
+    end
+
+    context "with a category" do
+      let(:meeting) do
+        meeting = meetings.first
+        meeting.category = create :category, participatory_process: participatory_process
+        meeting.save
+        meeting
+      end
+
+      it "shows tags for category" do
+        expect(page).to have_selector("ul.tags.tags--meeting")
+        within "ul.tags.tags--meeting" do
+          expect(page).to have_content(translated(meeting.category.name))
+        end
+      end
+
+      it "links to the filter for this category" do
+        within "ul.tags.tags--meeting" do
+          click_link translated(meeting.category.name)
+        end
+        expect(page).to have_select("filter_category_id", selected: translated(meeting.category.name))
+      end
+    end
+
+    context "with a scope" do
+      let(:meeting) do
+        meeting = meetings.first
+        meeting.scope = create :scope, organization: organization
+        meeting.save
+        meeting
+      end
+
+      it "shows tags for scope" do
+        expect(page).to have_selector("ul.tags.tags--meeting")
+        within "ul.tags.tags--meeting" do
+          expect(page).to have_content(meeting.scope.name)
+        end
+      end
+
+      it "links to the filter for this scope" do
+        within "ul.tags.tags--meeting" do
+          click_link meeting.scope.name
+        end
+        expect(page).to have_checked_field(meeting.scope.name)
       end
     end
   end

--- a/decidim-meetings/spec/forms/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/meeting_form_spec.rb
@@ -30,8 +30,12 @@ describe Decidim::Meetings::Admin::MeetingForm do
   let(:address) { Faker::Lorem.sentence(3) }
   let(:start_time) { 2.days.from_now }
   let(:end_time) { 2.days.from_now + 4.hours }
+  let(:scope) { create :scope, organization: organization }
+  let(:category) { create :category, participatory_process: participatory_process }
   let(:attributes) do
     {
+      decidim_scope_id: scope.id,
+      decidim_category_id: category.id,
       title_en: title[:en],
       description_en: description[:en],
       short_description_en: short_description[:en],

--- a/decidim-meetings/spec/forms/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/meeting_form_spec.rb
@@ -31,11 +31,13 @@ describe Decidim::Meetings::Admin::MeetingForm do
   let(:start_time) { 2.days.from_now }
   let(:end_time) { 2.days.from_now + 4.hours }
   let(:scope) { create :scope, organization: organization }
+  let(:scope_id) { scope.id }
   let(:category) { create :category, participatory_process: participatory_process }
+  let(:category_id) { category.id }
   let(:attributes) do
     {
-      decidim_scope_id: scope.id,
-      decidim_category_id: category.id,
+      decidim_scope_id: scope_id,
+      decidim_category_id: category_id,
       title_en: title[:en],
       description_en: description[:en],
       short_description_en: short_description[:en],
@@ -113,6 +115,18 @@ describe Decidim::Meetings::Admin::MeetingForm do
 
   describe "when start_time is equal to start_time" do
     let(:start_time) { end_time }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe "when the scope does not exist" do
+    let(:scope_id) { scope.id + 10 }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe "when the category does not exist" do
+    let(:category_id) { category.id + 10 }
 
     it { is_expected.not_to be_valid }
   end

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -7,4 +7,24 @@ describe Decidim::Meetings::Meeting do
   subject { meeting }
 
   it { is_expected.to be_valid }
+
+  context "without a title" do
+    let(:meeting) { build :meeting, title: nil }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when the scope is from another organization" do
+    let(:scope) { create :scope }
+    let(:meeting) { build :meeting, scope: scope }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when the category is from another organization" do
+    let(:category) { create :category }
+    let(:meeting) { build :meeting, category: category }
+
+    it { is_expected.not_to be_valid }
+  end
 end

--- a/decidim-meetings/spec/services/meetings_search_spec.rb
+++ b/decidim-meetings/spec/services/meetings_search_spec.rb
@@ -4,11 +4,14 @@ describe Decidim::Meetings::MeetingsSearch do
   let(:current_feature) { create :feature }
   let(:scope1) { create :scope, organization: current_feature.organization }
   let(:scope2) { create :scope, organization: current_feature.organization }
+  let(:category1) { create :category, participatory_process: current_feature.participatory_process }
+  let(:category2) { create :category, participatory_process: current_feature.participatory_process }
   let!(:meeting1) do
     create(
       :meeting,
       feature: current_feature,
       start_time: 1.day.from_now,
+      category: category1,
       scope: scope1
     )
   end
@@ -17,6 +20,7 @@ describe Decidim::Meetings::MeetingsSearch do
       :meeting,
       feature: current_feature,
       start_time: 2.day.from_now,
+      category: category2,
       scope: scope2
     )
   end
@@ -88,6 +92,14 @@ describe Decidim::Meetings::MeetingsSearch do
         it "filters meetings by scope" do
           expect(subject.results).to match_array [meeting1,meeting2]
         end
+      end
+    end
+
+    context "category_id" do
+      let(:params) { default_params.merge(category_id: category1.id) }
+
+      it "filters meetings by category" do
+        expect(subject.results).to eq [meeting1]
       end
     end
   end

--- a/decidim-meetings/spec/services/meetings_search_spec.rb
+++ b/decidim-meetings/spec/services/meetings_search_spec.rb
@@ -27,30 +27,14 @@ describe Decidim::Meetings::MeetingsSearch do
   let(:external_meeting) { create :meeting }
   let(:feature_id) { current_feature.id }
   let(:organization_id) { current_feature.organization.id }
-  let(:default_params) { { feature_id: feature_id, organization_id: organization_id } }
+  let(:default_params) { { feature: current_feature } }
   let(:params) { default_params }
 
   subject { described_class.new(params) }
 
   describe "base query" do
-    context "when no feature_id is passed" do
-      let(:feature_id) { nil }
-
-      it "raises an error" do
-        expect{ subject.results }.to raise_error(StandardError, "Missing feature")
-      end
-    end
-
-    context "when the feature_id is from another organization" do
-      let(:feature_id) { create(:feature).id }
-
-      it "raises an error" do
-        expect{ subject.results }.to raise_error(StandardError, "Missing feature")
-      end
-    end
-
-    context "when the feature does not exist" do
-      let(:feature_id) { current_feature.id + 100000 }
+    context "when no feature is passed" do
+      let(:default_params) { { feature: nil } }
 
       it "raises an error" do
         expect{ subject.results }.to raise_error(StandardError, "Missing feature")

--- a/decidim-meetings/spec/services/meetings_search_spec.rb
+++ b/decidim-meetings/spec/services/meetings_search_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+describe Decidim::Meetings::MeetingsSearch do
+  let(:current_feature) { create :feature }
+  let(:scope1) { create :scope, organization: current_feature.organization }
+  let(:scope2) { create :scope, organization: current_feature.organization }
+  let!(:meeting1) do
+    create(
+      :meeting,
+      feature: current_feature,
+      start_time: 1.day.from_now,
+      scope: scope1
+    )
+  end
+  let!(:meeting2) do
+    create(
+      :meeting,
+      feature: current_feature,
+      start_time: 2.day.from_now,
+      scope: scope2
+    )
+  end
+  let(:external_meeting) { create :meeting }
+  let(:default_params) { { current_feature: current_feature } }
+
+  subject { described_class.new(params) }
+
+  describe "base query" do
+    context "when no current_feature is passed" do
+      let(:params) {}
+
+      it "raises an error" do
+        expect{ subject.results }.to raise_error(StandardError)
+      end
+    end
+  end
+
+  describe "filters" do
+    context "order_start_time" do
+      let(:params) { default_params.merge(order_start_time: order) }
+
+      context "is :asc" do
+        let(:order) { :asc }
+
+        it "sorts the meetings by start_time asc" do
+          expect(subject.results).to eq [meeting1, meeting2]
+        end
+      end
+
+      context "is :desc" do
+        let(:order) { :desc }
+
+        it "sorts the meetings by start_time desc" do
+          expect(subject.results).to eq [meeting2, meeting1]
+        end
+      end
+    end
+
+    context "scope_id" do
+      let(:params) { default_params.merge(scope_id: scope1.id) }
+
+      it "filters meetings by scope" do
+        expect(subject.results).to eq [meeting1]
+      end
+    end
+  end
+end

--- a/decidim-meetings/spec/services/meetings_search_spec.rb
+++ b/decidim-meetings/spec/services/meetings_search_spec.rb
@@ -21,7 +21,7 @@ describe Decidim::Meetings::MeetingsSearch do
     )
   end
   let(:external_meeting) { create :meeting }
-  let(:default_params) { { current_feature: current_feature } }
+  let(:default_params) { { feature_id: current_feature.id } }
 
   subject { described_class.new(params) }
 
@@ -57,10 +57,20 @@ describe Decidim::Meetings::MeetingsSearch do
     end
 
     context "scope_id" do
-      let(:params) { default_params.merge(scope_id: scope1.id) }
+      context "when a single id is being sent" do
+        let(:params) { default_params.merge(scope_id: scope1.id) }
 
-      it "filters meetings by scope" do
-        expect(subject.results).to eq [meeting1]
+        it "filters meetings by scope" do
+          expect(subject.results).to eq [meeting1]
+        end
+      end
+
+      context "when multiple ids are sent" do
+        let(:params) { default_params.merge(scope_id: "#{scope2.id},#{scope1.id}") }
+
+        it "filters meetings by scope" do
+          expect(subject.results).to match_array [meeting1,meeting2]
+        end
       end
     end
   end

--- a/decidim-meetings/spec/shared/admin_shared_context.rb
+++ b/decidim-meetings/spec/shared/admin_shared_context.rb
@@ -5,5 +5,6 @@ RSpec.shared_context "admin" do
   let(:process_admin) { create :user, :confirmed, organization: organization }
   let!(:user_role) { create :participatory_process_user_role, user: process_admin, participatory_process: participatory_process }
   let(:current_feature) { create :feature, participatory_process: participatory_process, manifest_name: "meetings" }
-  let!(:meeting) { create :meeting, feature: current_feature }
+  let(:scope) { create :scope, organization: organization }
+  let!(:meeting) { create :meeting, scope: scope, feature: current_feature }
 end

--- a/decidim-meetings/spec/shared/admin_shared_context.rb
+++ b/decidim-meetings/spec/shared/admin_shared_context.rb
@@ -1,10 +1,11 @@
 RSpec.shared_context "admin" do
   let(:organization) { create(:organization) }
-  let!(:user) { create(:user, :admin, :confirmed, organization: organization) }
+  let!(:user) { create(:user, :admin, :confirmed, organization: organization, email: "admin@decidim.org") }
   let(:participatory_process) { create(:participatory_process, organization: organization) }
   let(:process_admin) { create :user, :confirmed, organization: organization }
   let!(:user_role) { create :participatory_process_user_role, user: process_admin, participatory_process: participatory_process }
   let(:current_feature) { create :feature, participatory_process: participatory_process, manifest_name: "meetings" }
   let(:scope) { create :scope, organization: organization }
+  let!(:category) { create :category, participatory_process: participatory_process }
   let!(:meeting) { create :meeting, scope: scope, feature: current_feature }
 end

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -49,14 +49,14 @@ RSpec.shared_examples "manage meetings" do
         es: "Mi meeting",
         ca: "El meu meeting"
       )
-      fill_in_i18n_editor(
+      fill_in_i18n(
         :meeting_location,
         "#location-tabs",
         en: "Location",
         es: "Location",
         ca: "Location"
       )
-      fill_in_i18n_editor(
+      fill_in_i18n(
         :meeting_location_hints,
         "#location_hints-tabs",
         en: "Location hints",
@@ -81,6 +81,8 @@ RSpec.shared_examples "manage meetings" do
       fill_in :meeting_address, with: "Address"
       fill_in :meeting_start_time, with: 1.day.from_now
       fill_in :meeting_end_time, with: 1.day.from_now + 2.hours
+
+      select scope.name, from: :meeting_decidim_scope_id
 
       find("*[type=submit]").click
     end

--- a/decidim-meetings/spec/shared/manage_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/manage_meetings_examples.rb
@@ -83,6 +83,7 @@ RSpec.shared_examples "manage meetings" do
       fill_in :meeting_end_time, with: 1.day.from_now + 2.hours
 
       select scope.name, from: :meeting_decidim_scope_id
+      select translated(category.name), from: :meeting_decidim_category_id
 
       find("*[type=submit]").click
     end

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -12,12 +12,6 @@
     <div class="row small-up-1 medium-up-3 card-grid">
       <%= render @proposals %>
     </div>
-    <%
-      # Kaminari uses url_for to generate the url, but this doesn't play nice with our engine system
-      # and unless we remove these params they are added again as query string 😩
-      params.delete("participatory_process_id")
-      params.delete("feature_id")
-    %>
-    <%= paginate @proposals, theme: "decidim", params: { random_seed: @random_seed } %>
+    <%= decidim_paginate @proposals %>
   </div>
 </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -12,6 +12,6 @@
     <div class="row small-up-1 medium-up-3 card-grid">
       <%= render @proposals %>
     </div>
-    <%= decidim_paginate @proposals %>
+    <%= decidim_paginate @proposals, random_seed: @random_seed %>
   </div>
 </div>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,11 +9,13 @@ module.exports = function(config) {
   config.set({
     basePath: '',
     frameworks: ['jasmine'],
-    files: [testGlob, srcGlob],
+    files: [testGlob, srcGlob, 'decidim-meetings/**/*.component.js.es6', 'decidim-meetings/**/*.test.js'],
     exclude: ['decidim-*/app/frontend/entry.js'],
     preprocessors: {
       [testGlob]: ['webpack', 'sourcemap'],
-      [srcGlob]: ['webpack']
+      [srcGlob]: ['webpack'],
+      'decidim-meetings/**/*.test.js': ['webpack', 'sourcemap'],
+      'decidim-meetings/**/*.component.js.es6': ['webpack']
     },
     webpack: webpackConfig,
     webpackMiddleware: { noInfo: true },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "yaml-loader": "^0.4.0"
   },
   "dependencies": {
+    "jquery": "^3.1.1",
     "react-addons-update": "^15.4.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,10 +25,14 @@ module.exports = env => {
         /\/sinon\.js/
       ],
       loaders: [
-        { 
+        {
           test: /\.jsx?$/,
           exclude: /node_modules/,
-          loaders: ['babel-loader', 'eslint-loader'] 
+          loaders: ['babel-loader', 'eslint-loader']
+        },
+        {
+          test: /\.js.es6$/,
+          loaders: ['babel-loader', 'eslint-loader']
         },
         {
           test: /\.(yml|yaml)$/,
@@ -42,9 +46,13 @@ module.exports = env => {
           test: /\.json$/,
           loaders: ['json-loader']
         },
-        { 
+        {
           test: require.resolve("react"),
           loader: "expose-loader?React"
+        },
+        {
+          test: require.resolve("jquery"),
+          loader: "expose-loader?$"
         }
       ]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,6 +1281,10 @@ circular-json@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -2963,6 +2967,10 @@ joi@9.0.0-0:
     moment "2.x.x"
     topo "2.x.x"
 
+jquery@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.1.1.tgz#347c1c21c7e004115e0a4da32cece041fad3c8a3"
+
 js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
@@ -3170,7 +3178,7 @@ loader-runner@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.2.0.tgz#824c1b699c4e7a2b6501b85902d5b862bf45b3fa"
 
-loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.5, loader-utils@^0.2.7:
+loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.5, loader-utils@^0.2.7:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.16.tgz#f08632066ed8282835dff88dfb52704765adee6d"
   dependencies:
@@ -3440,10 +3448,6 @@ mime-types@~2.0.4:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.0.14.tgz#310e159db23e077f8bb22b748dabfa4957140aa6"
   dependencies:
     mime-db "~1.12.0"
-
-mime@1.2.x:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
 
 mime@^1.3.4:
   version "1.3.4"
@@ -4791,13 +4795,6 @@ ultron@1.0.x:
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
-
-url-loader@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-0.5.7.tgz#67e8779759f8000da74994906680c943a9b0925d"
-  dependencies:
-    loader-utils "0.2.x"
-    mime "1.2.x"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a way to filter meetings by scope and to order them by start time. 

#### :pushpin: Related Issues
- Fixes #372 

#### :clipboard: Subtasks
- [x] Filter by scope
- [x] Order by start time
- [x] Paginate meetings
- [x] Fix specs for `MeetingSearch`
- [x] Fix i18n
- [x] Add categories to meetings
- [x] Filter by category
- [x] Move `destroy` callback to `before_destroy`
- [x] Add `decidim_paginate` helper to encapsulate the pagination logic
- [x] Add feature specs
- [x] Check if we can inject the current feature from the controller instead of passing IDs around
- [x] Remove the `params.delete` part (See @oriolgual's first review)

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/orFfc1A.png)
