### PR TITLE
Improve FormBuilder#categories_select

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -80,14 +80,29 @@ module Decidim
     #
     # name       - The name of the field (usually category_id)
     # collection - A collection of categories.
-    # prompt     - An optional String with the text to display as prompt.
+    # options    - An optional Hash with options:
+    # - prompt   - An optional String with the text to display as prompt.
+    # - disable_parents - A Boolean to disable parent categories. Defaults to `true`.
     #
     # Returns a String.
-    def categories_select(name, collection, prompt = nil)
+    def categories_select(name, collection, options = {})
+      options = {
+        prompt: nil,
+        disable_parents: true
+      }.merge(options)
+
+      prompt = options[:prompt]
+      disable_parents = options[:disable_parents]
+
       selected = object.send(name)
       categories = categories_for_select(collection)
-      categories = [[prompt]] + categories if prompt.present?
-      disabled = disabled_categories_for(collection)
+      categories = [[prompt]] + categories if prompt
+      disabled = if disable_parents
+                   disabled_categories_for(collection)
+                 else
+                   []
+                 end
+
       select(name, @template.options_for_select(categories, selected: selected, disabled: disabled))
     end
 

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -117,14 +117,15 @@ module Decidim
       end
     end
 
-    describe "caregories_for_select" do
+    describe "categories_for_select" do
       let!(:feature) { create(:feature) }
       let!(:category) { create(:category, name: { "en" => "Nice category" }, participatory_process: feature.participatory_process) }
       let!(:other_category) { create(:category, name: { "en" => "A better category" }, participatory_process: feature.participatory_process) }
       let!(:subcategory) { create(:category, name: { "en" => "Subcategory" }, parent: category, participatory_process: feature.participatory_process) }
       let(:scope) { feature.categories }
 
-      let(:output) { builder.categories_select(:category_id, scope) }
+      let(:options) { {} }
+      let(:output) { builder.categories_select(:category_id, scope, options) }
       subject { Nokogiri::HTML(output) }
 
       it "includes all the categories" do
@@ -137,9 +138,18 @@ module Decidim
       end
 
       context "when a category has subcategories" do
-        it "is disabled" do
-          expect(subject.xpath("//option[@disabled='disabled']").count).to eq(1)
-          expect(subject.xpath("//option[@disabled='disabled']").first.text).to eq(category.name["en"])
+        context "`disable_parents` is true" do
+          it "is disabled" do
+            expect(subject.xpath("//option[@disabled='disabled']").count).to eq(1)
+            expect(subject.xpath("//option[@disabled='disabled']").first.text).to eq(category.name["en"])
+          end
+        end
+
+        context "`disable_parents` is false" do
+          let(:options) { { disable_parents: false } }
+          it "is not disabled" do
+            expect(subject.xpath("//option[@disabled='disabled']").count).to eq(0)
+          end
         end
       end
 
@@ -156,7 +166,7 @@ module Decidim
       end
 
       context "when given a prompt" do
-        let(:output) { builder.categories_select(:category_id, scope, "Select something") }
+        let(:options) { { prompt: "Select something" } }
 
         it "includes it as an option" do
           expect(subject.css("option")[0].text).to eq("Select something")

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -20,13 +20,13 @@
 
           <% if @form.categories&.any? %>
             <div class="field">
-              <%= form.categories_select :category_id, @form.categories, t(".select_a_category") %>
+              <%= form.categories_select :category_id, @form.categories, prompt: t(".select_a_category") %>
             </div>
           <% end %>
 
           <% if @form.scopes&.any? %>
             <div class="field">
-              <%= form.select :scope_id, @form.scopes.map{|s| [translated_attribute(s.name), s.id]}, prompt: t(".select_a_scope") %>
+              <%= form.select :scope_id, @form.scopes.map{|s| [s.name, s.id]}, prompt: t(".select_a_scope") %>
             </div>
           <% end %>
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the ability to not disable parent categories in `FormBuilder#categories_select`

#### :pushpin: Related Issues
- Needed at #399 

#### :clipboard: Subtasks
![](https://i.imgur.com/go7IB1R.png)

(The `Minus est perspiciatis dicta a.` one is a parent category, and is not disabled)
### :camera: Screenshots (optional)
*None*