### PR TITLE
Fix caching issues with getScript

### DIFF
--- a/decidim-comments/app/helpers/decidim/comments/comments_helper.rb
+++ b/decidim-comments/app/helpers/decidim/comments/comments_helper.rb
@@ -29,8 +29,11 @@ module Decidim
       def react_comments_component(node_id, props)
         content_tag("div", "", id: node_id) +
           javascript_tag(%{
-            $.getScript('#{asset_path("decidim/comments/comments.js")}')
-              .then(function () {
+            jQuery.ajax({
+              url: '#{asset_path("decidim/comments/comments.js")}',
+              dataType: 'script',
+              cache: true
+            }).then(function () {
                 window.DecidimComments.renderCommentsComponent(
                   '#{node_id}',
                   {


### PR DESCRIPTION
#### :tophat: What? Why?
jQuery's `getScript` automatically appends a timestamp so that results don't get cached. WE DON'T WANT THAT, THANKS.

This resorts to a regular `jQuery.ajax` call that enables cache.

#### :pushpin: Related Issues
- Fixes #405 

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/yoJC2El7xJkYCadlWE/giphy.gif)
