### PR TITLE
Bugfix: Vendor API assets

### DIFF
--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = "API engine for decidim"
   s.description = "API engine for decidim"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "rails", *Decidim.rails_version
   s.add_dependency "graphql", "~> 1.3.0"


### PR DESCRIPTION
#### :tophat: What? Why?
This adds decidim's API assets vendoring, which was causing it to fail.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/frdI56SVBnS92/giphy.gif)
