### PR TITLE
Fix viewport to allow working with mobile devices

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_meta.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_meta.html.erb
@@ -1,3 +1,4 @@
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <% available_locales.each do |locale| %>
   <link rel="alternate" href="<%= url_for(request.parameters.merge(locale: locale)) %>" hreflang="<%= locale %>" />
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
We were missing the `meta viewport` tag in order for the website to properly work on mobile devices.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3o7TKIVMP71RCBztCw/giphy.gif)
