### PR TITLE
Fix path to dummy_autorhization_handler

### DIFF
--- a/lib/generators/decidim/demo_generator.rb
+++ b/lib/generators/decidim/demo_generator.rb
@@ -11,16 +11,16 @@ module Decidim
     class DemoGenerator < Rails::Generators::Base
       def source_paths
         [
-          File.expand_path("../../../../decidim-dev/lib/decidim", __FILE__)
+          File.expand_path("../../../../decidim-dev/lib/decidim/dev", __FILE__)
         ]
       end
 
       def authorization_handlers
         remove_file "app/services/example_authorization_handler.rb"
+        template "dummy_authorization_handler.rb", "app/services/decidim/dummy_authorization_handler.rb"
         gsub_file "config/initializers/decidim.rb",
                   /ExampleAuthorizationHandler/,
                   "Decidim::DummyAuthorizationHandler"
-        template "dummy_authorization_handler.rb", "app/services/decidim/dummy_authorization_handler.rb"
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
I was unable to generate demo app due to a missing file: dummy_authorization_handler.rb. Path to this file was wrong at ´demo_generator´ so it has been changed.

Also, since the process of creating the demo app stopped prematurely, I was unable to execute "rake development_app". To fix this, I've just changed "template line" order.

Thanks to @oriolgual for helping at this.
