### PR TITLE
Fix responsive offscreen navigation

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/append_elements.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/append_elements.js.es6
@@ -1,6 +1,8 @@
 // = require appendAround
 
 (function() {
-  let $appendableElements = $('.js-append');
-  $appendableElements.appendAround();
+  $(document).on("turbolinks:load", function () {
+    let $appendableElements = $('.js-append');
+    $appendableElements.appendAround();
+  })
 }(window));


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the broken behaviour on responsive offscreen navigation.

I had to add ``` $(document).on("turbolinks:load", ...``` before calling the appendAround() function, this populates the off-screen navigation every time the page is load on tablet and mobile devices.

#### :pushpin: Related Issues
- Fixes #430

#### :clipboard: Subtasks
- [x] Fix behaviour

### :camera: Screenshots (optional)
<img width="373" alt="screen shot 2017-01-04 at 11 40 35" src="https://cloud.githubusercontent.com/assets/953911/21639943/2cc2653c-d273-11e6-856b-de9ebbc29adf.png">
