### PR TITLE
Always set an active step for a process

### DIFF
--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
@@ -41,9 +41,7 @@
             <td class="actions">
               <%= link_to t("actions.edit", scope: "decidim.admin"), edit_participatory_process_step_path(participatory_process, step) if can? :update, step %>
               <% if can? :activate, step %>
-                <% if step.active? %>
-                  <%= link_to t("actions.deactivate", scope: "decidim.admin"), participatory_process_step_activate_path(participatory_process, step), method: :delete, class: "small button secondary" %>
-                <% else %>
+                <% unless step.active? %>
                   <%= link_to t("actions.activate", scope: "decidim.admin"), participatory_process_step_activate_path(participatory_process, step), method: :post, class: "small button secondary" %>
                 <% end %>
               <% end %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -56,7 +56,6 @@ en:
         configure: Configure
         confirm_destroy: Are you sure you want to delete this?
         create: Create
-        deactivate: Deactivate
         destroy: Destroy
         edit: Edit
         new: New %{name}

--- a/decidim-admin/spec/commands/activate_participatory_process_step_spec.rb
+++ b/decidim-admin/spec/commands/activate_participatory_process_step_spec.rb
@@ -1,7 +1,9 @@
 require "spec_helper"
 
 describe Decidim::Admin::ActivateParticipatoryProcessStep do
-  let(:process_step) { create :participatory_process_step }
+  let(:active_step) { create :participatory_process_step }
+  let(:participatory_process) { active_step.participatory_process }
+  let(:process_step) { create :participatory_process_step, participatory_process: participatory_process }
 
   subject { described_class.new(process_step) }
 
@@ -14,7 +16,7 @@ describe Decidim::Admin::ActivateParticipatoryProcessStep do
   end
 
   context "when the step is active" do
-    let(:process_step) { create :participatory_process_step, :active }
+    subject { described_class.new(active_step) }
 
     it "is not valid" do
       expect { subject.call }.to broadcast(:invalid)
@@ -22,9 +24,6 @@ describe Decidim::Admin::ActivateParticipatoryProcessStep do
   end
 
   context "when the step is not active" do
-    let!(:active_step) do
-      create :participatory_process_step, :active, participatory_process: process_step.participatory_process
-    end
 
     it "is valid" do
       expect { subject.call }.to broadcast(:ok)

--- a/decidim-admin/spec/commands/deactivate_participatory_process_step_spec.rb
+++ b/decidim-admin/spec/commands/deactivate_participatory_process_step_spec.rb
@@ -14,7 +14,9 @@ describe Decidim::Admin::DeactivateParticipatoryProcessStep do
   end
 
   context "when the step is inactive" do
-    let(:process_step) { create :participatory_process_step }
+    before do
+      process_step.update_attribute(:active, false)
+    end
 
     it "is not valid" do
       expect { subject.call }.to broadcast(:invalid)

--- a/decidim-admin/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_steps_examples.rb
@@ -9,6 +9,13 @@ RSpec.shared_examples "manage process steps examples" do
     )
   end
 
+  let!(:inactive_step) do
+    create(
+      :participatory_process_step,
+      participatory_process: participatory_process,
+    )
+  end
+
   before do
     switch_to_host(organization.host)
     login_as user, scope: :user
@@ -127,26 +134,12 @@ RSpec.shared_examples "manage process steps examples" do
 
   context "activating a step" do
     it "activates a step" do
-      within find("tr", text: translated(process_step.title)) do
+      within find("tr", text: translated(inactive_step.title)) do
         click_link "Activate"
       end
 
-      within find("tr", text: translated(process_step.title)) do
-        expect(page).to have_content("Deactivate")
-      end
-    end
-  end
-
-  context "deactivating a step" do
-    let(:active) { true }
-
-    it "deactivates a step" do
-      within find("tr", text: translated(process_step.title)) do
-        click_link "Deactivate"
-      end
-
-      within find("tr", text: translated(process_step.title)) do
-        expect(page).to have_content("Activate")
+      within find("tr", text: translated(inactive_step.title)) do
+        expect(page).to_not have_content("Activate")
       end
     end
   end

--- a/decidim-core/app/models/decidim/participatory_process_step.rb
+++ b/decidim-core/app/models/decidim/participatory_process_step.rb
@@ -16,6 +16,7 @@ module Decidim
     validates :position, uniqueness: { scope: :decidim_participatory_process_id }
 
     before_create :set_position
+    before_create :set_as_active
 
     private
 
@@ -33,6 +34,12 @@ module Decidim
       return self.position = 0 if participatory_process.steps.empty?
 
       self.position = participatory_process.steps.pluck(:position).last + 1
+    end
+
+    # Internal: As there always have to be an active step, the first step
+    # to be created hast to be set as so.
+    def set_as_active
+      self.active = true if participatory_process.steps.empty?
     end
   end
 end

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -56,16 +56,20 @@ describe "Participatory Processes", type: :feature do
       let!(:step) { create(:participatory_process_step, participatory_process: participatory_process) }
       let!(:active_step) do
         create(:participatory_process_step,
-               :active,
                participatory_process: participatory_process,
                title: { en: "Active step", ca: "Fase activa", es: "Fase activa" },
               )
       end
 
+      before do
+        participatory_process.steps.update_all(active: false)
+        active_step.update_attribute(:active, true)
+      end
+
       it "links to the active step" do
         visit decidim.participatory_processes_path
 
-        within "#processes-grid .column:nth-child(2) .card__footer" do
+        within "#processes-grid .column:nth-child(1) .card__footer" do
           expect(page).to have_content("Current step: Active step")
         end
       end

--- a/decidim-core/spec/features/participatory_processes_spec.rb
+++ b/decidim-core/spec/features/participatory_processes_spec.rb
@@ -69,7 +69,7 @@ describe "Participatory Processes", type: :feature do
       it "links to the active step" do
         visit decidim.participatory_processes_path
 
-        within "#processes-grid .column:nth-child(1) .card__footer" do
+        within "#processes-grid .column:nth-child(2) .card__footer" do
           expect(page).to have_content("Current step: Active step")
         end
       end

--- a/decidim-core/spec/models/decidim/participatory_process_step_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_process_step_spec.rb
@@ -37,6 +37,31 @@ module Decidim
     end
 
     context "active" do
+      context "is set before creation" do
+        context "when the step is the only one" do
+          it "automatically sets the step to be active" do
+            subject.active = false;
+            subject.save
+
+            expect(subject.active).to be_truthy
+          end
+        end
+
+        context "when there are more steps in the same process" do
+          let(:active_step) { create :participatory_process_step, :active }
+          let(:participatory_process_step) do
+            build(:participatory_process_step, participatory_process: active_step.participatory_process)
+          end
+
+          it "should not change step active state" do
+            subject.active = false;
+            subject.save
+
+            expect(subject.active).to be_falsy
+          end
+        end
+      end
+
       context "when there's an active step in the same process" do
         let(:active_step) { create :participatory_process_step, :active }
         let(:participatory_process_step) do


### PR DESCRIPTION
#### :tophat: What? Why?
An error happens when the user goes to a particular Participatory Process, and it has configured one or more steps and none of them are active.

To avoid this error, we must ensure that there is always an active step.

#### :pushpin: Related Issues
- Fixes #408 

#### :clipboard: Subtasks
- [x] First step created is set to active.
- [x] Remove "Deactivate" button from the active step on steps list.

### :camera: Screenshots (optional)
You can see in the next screenshot that "Deactivate" button has been remove from active steps.
<img width="837" alt="screen shot 2017-01-05 at 12 03 37" src="https://cloud.githubusercontent.com/assets/694481/21678473/2ce17ff4-d33f-11e6-9faf-566554a0693a.png">
