### PR TITLE
Fix double initialization Foundation warning.

### DIFF
--- a/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
@@ -16,4 +16,3 @@ const pageLoad = () => {
 };
 
 $(document).on('turbolinks:load', pageLoad);
-$(pageLoad);


### PR DESCRIPTION
#### :tophat: What? Why?

This PR removes most of the browser console and tests warnings about duplicacted Foundation plugin: 
``` 
Tried to initialize off-canvas on an element that already has a Foundation plugin.
```
```
Tried to initialize dropdown on an element that already has a Foundation plugin.
```

Most of the ones that I was able to solve were part of the decidim-admin who was loading twice: ```$(document).foundation();```

When passing test we still having some of those warnings, I looked at it and seems that is happening when on a same test we have more than one call to ```expect(page).to ...```.

#### :pushpin: Related Issues
- Fixes #365
