### PR TITLE
Raise on missing translations

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/i18n.rb
@@ -2,6 +2,7 @@
 RSpec.configure do |config|
   config.before(:suite) do
     I18n.config.enforce_available_locales = false
+    Rails.application.config.action_view.raise_on_missing_translations = true
   end
 
   config.around(:each) do |example|


### PR DESCRIPTION
#### :tophat: What? Why?
In order to easily spot missing translations, this will ensure exceptions arise on runtime when they're missing.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/l46CetRU8smTYQwQE/giphy.gif)
