### PR TITLE
Resize logo to higher limit

### DIFF
--- a/decidim-core/app/uploaders/decidim/organization_logo_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/organization_logo_uploader.rb
@@ -3,7 +3,7 @@ module Decidim
   # This class deals with uploading hero images to ParticipatoryProcesses.
   class OrganizationLogoUploader < ImageUploader
     version :medium do
-      process resize_to_limit: [140, 45]
+      process resize_to_limit: [500, 500]
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Logos can be any size since https://github.com/AjuntamentdeBarcelona/decidim-design/pull/91 - this makes sure we keep them under an acceptable size.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3o6Zt8PfGhKbMPJ41G/giphy.gif)
