### PR TITLE
Update ruby graphql

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ PATH
   specs:
     decidim-api (0.0.1)
       graphiql-rails (~> 1.4.1)
-      graphql (~> 1.3.0)
+      graphql (~> 1.4.0)
       rack-cors (~> 0.4.0)
       rails (~> 5.0.0, >= 5.0.0.1)
       sprockets-es6 (~> 0.9.2)
@@ -281,7 +281,7 @@ GEM
       activesupport (>= 4.1.0)
     graphiql-rails (1.4.1)
       rails
-    graphql (1.3.0)
+    graphql (1.4.0)
     high_voltage (3.0.0)
     highline (1.7.8)
     htmlentities (4.3.4)

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "rails", *Decidim.rails_version
-  s.add_dependency "graphql", "~> 1.3.0"
+  s.add_dependency "graphql", "~> 1.4.0"
   s.add_dependency "graphiql-rails", "~> 1.4.1"
   s.add_dependency "rack-cors", "~> 0.4.0"
   s.add_dependency "sprockets-es6", "~> 0.9.2"


### PR DESCRIPTION
#### :tophat: What? Why?
`graphql` has just released 1.4.0. This updates it.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/RxusJJy53mGmA/source.gif)
