### PR TITLE
Replies now sorted by date

### DIFF
--- a/decidim-comments/app/types/decidim/comments/comment_type.rb
+++ b/decidim-comments/app/types/decidim/comments/comment_type.rb
@@ -16,7 +16,11 @@ module Decidim
 
       field :author, !AuthorType, "The comment's author"
 
-      field :replies, !types[CommentType], "The comment's replies"
+      field :replies, !types[CommentType], "The comment's replies" do
+        resolve lambda { |obj, _args, _ctx|
+          obj.replies.sort_by(&:created_at)
+        }
+      end
 
       field :canHaveReplies, !types.Boolean, "Define if a comment can or not have replies" do
         property :can_have_replies?

--- a/decidim-comments/spec/types/comment_type_spec.rb
+++ b/decidim-comments/spec/types/comment_type_spec.rb
@@ -27,7 +27,7 @@ module Decidim
 
       describe "replies" do
         let!(:random_comment) { FactoryGirl.create(:comment) }
-        let!(:replies) { 3.times.map { FactoryGirl.create(:comment, commentable: model) } }
+        let!(:replies) { FactoryGirl.create_list(:comment, 3, commentable: model) }
 
         let(:query) { "{ replies { id } }" }
 
@@ -36,6 +36,12 @@ module Decidim
             expect(response["replies"]).to include("id" => reply.id.to_s)
           end
           expect(response["replies"]).to_not include("id" => random_comment.id.to_s)
+        end
+
+        it "return comment's replies ordered by date" do
+          response_ids = response["replies"].map{|reply| reply["id"].to_i }
+          replies_ids = replies.map(&:id)
+          expect(response_ids).to eq(replies_ids)
         end
       end
 

--- a/decidim-comments/spec/types/comment_type_spec.rb
+++ b/decidim-comments/spec/types/comment_type_spec.rb
@@ -27,7 +27,8 @@ module Decidim
 
       describe "replies" do
         let!(:random_comment) { FactoryGirl.create(:comment) }
-        let!(:replies) { FactoryGirl.create_list(:comment, 3, commentable: model) }
+        let!(:replies) { 3.times.map { |n| FactoryGirl.create(:comment, commentable: model, created_at: Time.now - n.days) } }
+
 
         let(:query) { "{ replies { id } }" }
 
@@ -40,7 +41,7 @@ module Decidim
 
         it "return comment's replies ordered by date" do
           response_ids = response["replies"].map{|reply| reply["id"].to_i }
-          replies_ids = replies.map(&:id)
+          replies_ids = replies.sort_by(&:created_at).map(&:id)
           expect(response_ids).to eq(replies_ids)
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Comment replies were not ordered in any way, this adds "sort_by(created_at)" to the comment type to display them correctly.

#### :pushpin: Related Issues
- Fixes #456 

### :camera: Screenshots (optional)
![Current Status: ](https://cloud.githubusercontent.com/assets/953911/21771579/344b816c-d688-11e6-9bb2-4e184e69fcb9.png)

#### :ghost: GIF
![](https://media.giphy.com/media/3o6Zt5jXXzAzdikVmE/giphy.gif)
