### PR TITLE
Use short description in meetings index. Closes #432.

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -14,7 +14,7 @@
               <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>
             </div>
           </div>
-          <%== translated_attribute meeting.description %>
+          <%== translated_attribute meeting.short_description %>
           <%= render partial: "tags", locals: { meeting: meeting } %>
           <div class="address card__extra">
             <div class="address__icon">


### PR DESCRIPTION
#### :tophat: What? Why?

It doesn't make sense to use the long description in the index view.

#### :pushpin: Related Issues
- Fixes #432

#### :ghost: GIF
![](https://i.imgur.com/usvEKXY.gif)
