### PR TITLE
Use https for edge and branch options

### DIFF
--- a/lib/generators/decidim/templates/Gemfile.erb
+++ b/lib/generators/decidim/templates/Gemfile.erb
@@ -4,9 +4,9 @@ ruby '<%= RUBY_VERSION %>'
 <% if options[:path] %>
 gem "decidim", path: "<%= options[:path] %>"
 <% elsif options[:edge] %>
-gem "decidim", github: 'AjuntamentdeBarcelona/decidim'
+gem "decidim", git: 'https://github.com/AjuntamentdeBarcelona/decidim.git'
 <% elsif options[:branch] %>
-gem "decidim", github: 'AjuntamentdeBarcelona/decidim', branch: "<%= options[:branch] %>"
+gem "decidim", git: 'https://github.com/AjuntamentdeBarcelona/decidim.git', branch: "<%= options[:branch] %>"
 <% else %>
 gem "decidim", "<%= Gem::Specification.find_by_name("decidim").version %>"
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

When generating a decidim app the `github` option was used to fetch the decidim gem from github. I changed to use the `git` options which can be used for fetching the gem through https.

#### :pushpin: Related Issues
- Implements #459

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
![](https://media.giphy.com/media/AGBaQ5glLgcXS/giphy.gif)
