### PR TITLE
Attachment descriptions should be plain text, not html. Closes #445

### DIFF
--- a/decidim-admin/app/views/decidim/admin/participatory_process_attachments/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_attachments/_form.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class="field">
-  <%= form.translated :editor, :description, toolbar: :full, lines: 20 %>
+  <%= form.translated :text_field, :description %>
 </div>
 
 <div class="field">

--- a/decidim-admin/spec/shared/manage_process_attachments_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_attachments_examples.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 RSpec.shared_examples "manage process attachments examples" do
   let!(:attachment) do
@@ -42,7 +43,7 @@ RSpec.shared_examples "manage process attachments examples" do
         ca: "Document Molt Important"
       )
 
-      fill_in_i18n_editor(
+      fill_in_i18n(
         :participatory_process_attachment_description,
         "#description-tabs",
         en: "This document contains important information",


### PR DESCRIPTION
#### :tophat: What? Why?

Since the description in an attachment is usually a short text, it doesn't make any sense to enable a WYSIWYG editor for this field.

#### :pushpin: Related Issues
- Related to #445

#### :ghost: GIF
![](https://i.imgur.com/CuwQIIH.gif)
