### PR TITLE
Add inch CI for tracking inline code docs

### DIFF
--- a/.inch.yml
+++ b/.inch.yml
@@ -1,0 +1,5 @@
+files:
+  included:
+    - lib/**/*.rb
+    - decidim-*/{app,lib}/**/*.rb
+    - decidim-*/{app,lib}/**/*.js

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![codecov](https://img.shields.io/codecov/c/github/AjuntamentdeBarcelona/decidim.svg)](https://codecov.io/gh/AjuntamentdeBarcelona/decidim)
 [![Dependency Status](https://img.shields.io/gemnasium/AjuntamentdeBarcelona/decidim.svg)](https://gemnasium.com/github.com/AjuntamentdeBarcelona/decidim)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg)](https://crowdin.com/project/decidim/invite)
+[![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
 
 ### Project management
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/pulls)


### PR DESCRIPTION
#### :tophat: What? Why?
This adds Inch CI, which tracks documentation coverage.

Example: This is how the report looks on this branch: https://inch-ci.org/github/AjuntamentdeBarcelona/decidim?branch=feature%2Fadd_inch

And that's the badge it generates: [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=feature/add_inch)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/h1fCjcLTh3ML6/giphy.gif)
