### PR TITLE
Do not hardcode default locale for i18n tests

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/i18n_spec.rb
+++ b/decidim-dev/lib/decidim/dev/test/i18n_spec.rb
@@ -2,7 +2,7 @@
 require "i18n/tasks"
 
 RSpec.describe "I18n" do
-  let(:i18n) { I18n::Tasks::BaseTask.new(locales: ["en"]) }
+  let(:i18n) { I18n::Tasks::BaseTask.new(locales: [I18n.default_locale]) }
   let(:missing_keys) { i18n.missing_keys }
   let(:unused_keys) { i18n.unused_keys }
 


### PR DESCRIPTION
#### :tophat: What? Why?
The i18n tests have the default locale hardcoded and set to English. In https://github.com/HospitaletDeLlobregat/decidim-hospitalet we don't use English, so the tests always fail due to missing translations.

This PR uses the `I18n.default_locale` value to set the default locale for these tests.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*