### PR TITLE
Improve Travis build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 language: ruby
 
 branches:
-  only: 
+  only:
     - master
 
 env:
@@ -34,6 +34,7 @@ cache:
   directories:
     - $TRAVIS_BUILD_DIR/.yarn-cache
     - $TRAVIS_BUILD_DIR/node_modules
+    - $BUNDLE_PATH
 
 script:
   - cd $GEM;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ before_install:
   - export BUNDLE_GEMFILE="$TRAVIS_BUILD_DIR/Gemfile"
   - export BUNDLE_PATH="$TRAVIS_BUILD_DIR/.bundle"
 
+bundler_args: --path=$BUNDLE_PATH
+
 cache:
-  bundler: true
   directories:
     - $TRAVIS_BUILD_DIR/.yarn-cache
     - $TRAVIS_BUILD_DIR/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - export BUNDLE_GEMFILE="$TRAVIS_BUILD_DIR/Gemfile"
   - export BUNDLE_PATH="$TRAVIS_BUILD_DIR/.bundle"
 
-bundler_args: --path=$BUNDLE_PATH
+bundler_args: --jobs=3 --retry=3 --deployment --path=$BUNDLE_PATH
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ before_install:
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   - yarn
   - export BUNDLE_GEMFILE="$TRAVIS_BUILD_DIR/Gemfile"
-  - export BUNDLE_PATH="$HOME/.bundle"
+  - export BUNDLE_PATH="$TRAVIS_BUILD_DIR/.bundle"
 
 cache:
   bundler: true
   directories:
-    - $HOME/.yarn-cache
-    - $HOME/node_modules
+    - $TRAVIS_BUILD_DIR/.yarn-cache
+    - $TRAVIS_BUILD_DIR/node_modules
 
 script:
   - cd $GEM;


### PR DESCRIPTION
#### :tophat: What? Why?
Job builds take 151s to `bundle install`, and 50s to `yarn`. Thats 200s installing dependencies (3min 20s), out of the ~6min that it currently takes to build a job in Travis. Reducing the time installing dependencies can be done by caching them, so we could speed up those jobs by chaching the deps.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

