### PR TITLE
Fix locales for external dev

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -15,6 +15,11 @@ module Decidim
 
   # Loads seeds from all engines.
   def self.seed!
+    # Faker needs to have the `:en` locale in order to work properly, so we
+    # must enforce it during the seeds.
+    original_locale = I18n.available_locales
+    I18n.available_locales = original_locale + [:en] unless original_locale.include?(:en)
+
     railties = Rails.application.railties.to_a.uniq.select do |railtie|
       railtie.respond_to?(:load_seed) && railtie.class.name.include?("Decidim::")
     end
@@ -28,6 +33,8 @@ module Decidim
       puts "Creating Feature (#{feature.name}) seeds..."
       feature.seed!
     end
+
+    I18n.available_locales = original_locale
   end
 
   # Exposes a configuration option: The application name String.

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -5,5 +5,5 @@ Decidim.configure do |config|
   config.authorization_handlers = [ExampleAuthorizationHandler]
 
   # Uncomment this lines to set your preferred locales
-  # config.available_locales = %{en ca es}
+  # config.available_locales = %i{en ca es}
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When developing for an external organization that does not have the English locale, things break. Faker needs the English locale in order to set some fields, so I added the English locale only during the seeding step.

I also fixed some commented ruby code that made things break.

#### :pushpin: Related Issues
- Fixes #463 

#### :clipboard: Subtasks
None

