### PR TITLE
Leverage `with_context` in form factories

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,7 +11,7 @@ engines:
         javascript:
           mass_threshold: 1000
         ruby:
-          mass_threshold: 50
+          mass_threshold: 80
     exclude_fingerprints:
     - 645ddab80611224e15d61c8426285296
     - 82b4059b3b55d7b7f06d8aba6cb7b81a

--- a/decidim-admin/app/controllers/decidim/admin/static_pages_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/static_pages_controller.rb
@@ -13,12 +13,12 @@ module Decidim
 
       def new
         authorize! :new, StaticPage
-        @form = StaticPageForm.new
+        @form = form(StaticPageForm).instance
       end
 
       def create
         authorize! :new, StaticPage
-        @form = StaticPageForm.from_params(form_params)
+        @form = form(StaticPageForm).from_params(form_params)
 
         CreateStaticPage.call(@form) do
           on(:ok) do
@@ -35,13 +35,13 @@ module Decidim
 
       def edit
         authorize! :update, page
-        @form = StaticPageForm.from_model(page)
+        @form = form(StaticPageForm).from_model(page)
       end
 
       def update
         @page = collection.find(params[:id])
         authorize! :update, page
-        @form = StaticPageForm.from_params(form_params)
+        @form = form(StaticPageForm).from_params(form_params)
 
         UpdateStaticPage.call(page, @form) do
           on(:ok) do

--- a/decidim-admin/app/forms/decidim/admin/category_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/category_form.rb
@@ -13,15 +13,9 @@ module Decidim
       mimic :category
 
       validates :name, :description, translatable_presence: true
-      validates :current_process, presence: true
       validates :parent_id, inclusion: { in: :parent_categories_ids }, allow_blank: true
 
-      attr_reader :current_process
-
-      def initialize(attributes = {})
-        @current_process = attributes.delete("current_process") || attributes.delete(:current_process)
-        super
-      end
+      delegate :current_process, to: :context, prefix: false
 
       def parent_categories
         @parent_categories ||= current_process.categories.first_class.where.not(id: id)

--- a/decidim-admin/app/forms/decidim/admin/static_page_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/static_page_form.rb
@@ -6,22 +6,19 @@ module Decidim
       include TranslatableAttributes
 
       attribute :slug, String
-      attribute :organization, Decidim::Organization
       translatable_attribute :title, String
       translatable_attribute :content, String
 
       mimic :static_page
 
-      validates :slug, :organization, presence: true
+      validates :slug, presence: true
       validates :title, :content, translatable_presence: true
       validate :slug, :slug_uniqueness
-
-      alias current_organization organization
 
       private
 
       def slug_uniqueness
-        return unless organization && organization.static_pages.where(slug: slug).where.not(id: id).any?
+        return unless current_organization && current_organization.static_pages.where(slug: slug).where.not(id: id).any?
 
         errors.add(:slug, :taken)
       end

--- a/decidim-admin/app/forms/decidim/admin/static_page_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/static_page_form.rb
@@ -15,10 +15,12 @@ module Decidim
       validates :title, :content, translatable_presence: true
       validate :slug, :slug_uniqueness
 
+      alias organization current_organization
+
       private
 
       def slug_uniqueness
-        return unless current_organization && current_organization.static_pages.where(slug: slug).where.not(id: id).any?
+        return unless organization && organization.static_pages.where(slug: slug).where.not(id: id).any?
 
         errors.add(:slug, :taken)
       end

--- a/decidim-admin/lib/decidim/admin/features/base_controller.rb
+++ b/decidim-admin/lib/decidim/admin/features/base_controller.rb
@@ -14,11 +14,11 @@ module Decidim
           authorize! :manage, current_feature
         end
 
-        private
-
         def current_feature
           request.env["decidim.current_feature"]
         end
+
+        private
 
         def current_participatory_process
           request.env["decidim.current_participatory_process"]

--- a/decidim-admin/spec/commands/create_category_spec.rb
+++ b/decidim-admin/spec/commands/create_category_spec.rb
@@ -22,8 +22,9 @@ module Decidim
         let(:form) do
           CategoryForm.from_params(
             form_params,
-            current_organization: organization,
             current_process: participatory_process
+          ).with_context(
+            current_organization: organization,
           )
         end
         let(:command) { described_class.new(form, participatory_process) }

--- a/decidim-admin/spec/commands/create_static_page_spec.rb
+++ b/decidim-admin/spec/commands/create_static_page_spec.rb
@@ -6,7 +6,7 @@ module Decidim
     describe CreateStaticPage, :db do
       describe "call" do
         let(:organization) { create(:organization) }
-        let(:form) { StaticPageForm.from_model(build(:static_page).with_context(current_organization: organization)) }
+        let(:form) { StaticPageForm.from_model(build(:static_page)).with_context(current_organization: organization) }
         let(:command) { described_class.new(form) }
 
         describe "when the form is not valid" do

--- a/decidim-admin/spec/commands/create_static_page_spec.rb
+++ b/decidim-admin/spec/commands/create_static_page_spec.rb
@@ -6,7 +6,7 @@ module Decidim
     describe CreateStaticPage, :db do
       describe "call" do
         let(:organization) { create(:organization) }
-        let(:form) { StaticPageForm.from_model(build(:static_page, organization: organization)) }
+        let(:form) { StaticPageForm.from_model(build(:static_page).with_context(current_organization: organization)) }
         let(:command) { described_class.new(form) }
 
         describe "when the form is not valid" do

--- a/decidim-admin/spec/commands/update_category_spec.rb
+++ b/decidim-admin/spec/commands/update_category_spec.rb
@@ -23,8 +23,9 @@ module Decidim
         let(:form) do
           CategoryForm.from_params(
             form_params,
-            current_organization: organization,
             current_process: participatory_process
+          ).with_context(
+            current_organization: organization
           )
         end
         let(:command) { described_class.new(category, form) }

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -25,7 +25,7 @@ module Decidim
           { current_organization: organization }
         end
         let(:form) do
-          OrganizationForm.from_params(params, context)
+          OrganizationForm.from_params(params).with_context(context)
         end
         let(:command) { described_class.new(organization, form) }
 

--- a/decidim-admin/spec/commands/update_static_page_spec.rb
+++ b/decidim-admin/spec/commands/update_static_page_spec.rb
@@ -9,8 +9,9 @@ module Decidim
         let(:page) { create(:static_page, organization: organization) }
         let(:form) do
           StaticPageForm.from_params(
-            static_page: page.attributes.merge(slug: "new-slug"),
-            organization: page.organization
+            static_page: page.attributes.merge(slug: "new-slug")
+          ).with_context(
+            current_organization: page.organization
           )
         end
         let(:command) { described_class.new(page, form) }

--- a/decidim-admin/spec/forms/category_form_spec.rb
+++ b/decidim-admin/spec/forms/category_form_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require "spec_helper"
 
@@ -37,7 +38,8 @@ module Decidim
 
       subject do
         described_class.from_params(
-          attributes,
+          attributes
+        ).with_context(
           current_process: participatory_process,
           current_organization: organization
         )
@@ -45,12 +47,6 @@ module Decidim
 
       context "when everything is OK" do
         it { is_expected.to be_valid }
-      end
-
-      context "when participatory process is not set" do
-        let(:participatory_process) { nil }
-
-        it { is_expected.not_to be_valid }
       end
 
       context "when some language in name is missing" do

--- a/decidim-admin/spec/forms/organization_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_form_spec.rb
@@ -45,7 +45,11 @@ module Decidim
         }
       end
 
-      subject { described_class.from_params(attributes, context) }
+      subject do
+        described_class.from_params(attributes).with_context(
+          context
+        )
+      end
 
       context "when everything is OK" do
         it { is_expected.to be_valid }

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require "spec_helper"
 
@@ -54,7 +55,7 @@ module Decidim
         }
       end
 
-      subject { described_class.from_params(attributes, current_organization: organization) }
+      subject { described_class.from_params(attributes).with_context(current_organization: organization) }
 
       context "when everything is OK" do
         it { is_expected.to be_valid }

--- a/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require "spec_helper"
 
@@ -46,7 +47,7 @@ module Decidim
       end
       let(:organization) { build(:organization) }
 
-      subject { described_class.from_params(attributes, current_organization: organization) }
+      subject { described_class.from_params(attributes).with_context(current_organization: organization) }
 
       describe "dates" do
         context "when the dates are set" do

--- a/decidim-admin/spec/forms/scope_form_spec.rb
+++ b/decidim-admin/spec/forms/scope_form_spec.rb
@@ -19,7 +19,7 @@ module Decidim
         }
       end
 
-      subject { described_class.from_params(attributes, context) }
+      subject { described_class.from_params(attributes).with_context(context) }
 
       context "when everything is OK" do
         it { is_expected.to be_valid }

--- a/decidim-admin/spec/forms/static_page_form_spec.rb
+++ b/decidim-admin/spec/forms/static_page_form_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require "spec_helper"
 
@@ -35,7 +36,7 @@ module Decidim
         }
       end
 
-      subject { described_class.from_params(attributes) }
+      subject { described_class.from_params(attributes).with_context(current_organization: organization) }
 
       context "when everything is OK" do
         it { is_expected.to be_valid }
@@ -64,12 +65,6 @@ module Decidim
 
       context "when slug is missing" do
         let(:slug) { nil }
-
-        it { is_expected.to be_invalid }
-      end
-
-      context "when organization is missing" do
-        let(:organization) { nil }
 
         it { is_expected.to be_invalid }
       end

--- a/decidim-core/app/controllers/concerns/decidim/form_factory.rb
+++ b/decidim-core/app/controllers/concerns/decidim/form_factory.rb
@@ -33,45 +33,48 @@ module Decidim
           # Initializes the form factory object.
           #
           # klass - the class name of the Form object that will be initialized
-          # context - the Controller where the form is built.
-          def initialize(klass, context)
+          # controller - the Controller where the form is built.
+          def initialize(klass, controller)
             @klass = klass
-            @context = context
+            @controller = controller
           end
 
           # Returns a simple instance of the form klass.
-          def instance(context = {})
-            @klass.new(context)
+          #
+          # extra_context - A Hash with optional extra context data.
+          def instance(extra_context = {})
+            @klass.new(context.merge(extra_context))
           end
 
           # Initializes a form object from a model. Delegates the functionality
           # to the form object class method.
           #
-          # model - the model instance from which the form object will be
-          #   initialized.
-          # context - a Hash with optional context data.
-          def from_model(model, context = {})
-            from_params(model.attributes, context)
+          # model         - the model instance from which the form object will be
+          #                 initialized.
+          # extra_context - a Hash with optional context data.
+          def from_model(model, extra_context = {})
+            @klass.from_model(model).with_context(context.merge(extra_context))
           end
 
           # Initializes a form object instance from params, and it
           # automatically adds some context. Context can be extended.
           #
-          # params - a Hash with params. Mostly a set of params from a form.
-          # context - a Hash with optional context data.
-          def from_params(params, context = {})
-            @klass.from_params(params, context_hash.merge(context))
+          # params        - a Hash with params. Mostly a set of params from a form.
+          # extra_context - a Hash with optional context data.
+          def from_params(params, extra_context = {})
+            @klass.from_params(params).with_context(context.merge(extra_context))
           end
 
           # Sets a base context from the current controller. Since this can be
           # used from some controllers that do not respond to the helper
           # methods used here, this Hash can have different keys depending on
           # the controller that uses it.
-          def context_hash
+          def context
             {
-              current_organization: @context.try(:current_organization),
-              current_user: @context.try(:current_user)
-            }.compact
+              current_organization: @controller.try(:current_organization),
+              current_feature: @controller.try(:current_feature),
+              current_user: @controller.try(:current_user)
+            }
           end
         end.new(klass, self)
       end

--- a/decidim-core/app/forms/decidim/form.rb
+++ b/decidim-core/app/forms/decidim/form.rb
@@ -9,7 +9,7 @@ module Decidim
              to: :context, prefix: false, allow_nil: true
 
     def available_locales
-      current_organization.available_locales
+      current_organization&.available_locales
     end
   end
 end

--- a/decidim-core/app/forms/decidim/form.rb
+++ b/decidim-core/app/forms/decidim/form.rb
@@ -3,13 +3,13 @@ module Decidim
   # A base form object to hold common logic, like automatically adding as
   # public method the params sent as context by the `FormFactory` concern.
   class Form < Rectify::Form
-    attr_reader :current_organization, :current_user, :current_feature
+    delegate :current_organization,
+             :current_user,
+             :current_feature,
+             to: :context, prefix: false, allow_nil: true
 
-    def initialize(attributes = {})
-      @current_organization = attributes.delete("current_organization") || attributes.delete(:current_organization)
-      @current_user = attributes.delete("current_user") || attributes.delete(:current_user)
-      @current_feature = attributes.delete("current_feature") || attributes.delete(:current_feature)
-      super
+    def available_locales
+      current_organization.available_locales
     end
   end
 end

--- a/decidim-core/lib/decidim/features/base_controller.rb
+++ b/decidim-core/lib/decidim/features/base_controller.rb
@@ -18,11 +18,11 @@ module Decidim
         authorize! :read, current_participatory_process
       end
 
-      private
-
       def current_feature
         request.env["decidim.current_feature"]
       end
+
+      private
 
       def current_participatory_process
         request.env["decidim.current_participatory_process"]

--- a/decidim-core/spec/controllers/concerns/form_factory_spec.rb
+++ b/decidim-core/spec/controllers/concerns/form_factory_spec.rb
@@ -3,9 +3,14 @@ require "spec_helper"
 module Decidim
   describe FormFactory do
     let(:form_klass) do
-      Class.new do
-        def initialize(context = {})
+      Class.new(Decidim::Form) do
+        include ActiveModel::Naming
+
+        def self.name
+          "FooForm"
         end
+
+        attribute :bar, String
       end
     end
 
@@ -28,35 +33,30 @@ module Decidim
     describe "instance" do
       it "returns an instance of the form" do
         expect(subject.instance).to be_kind_of(form_klass)
+
       end
     end
 
     describe "from_params" do
-      let(:params) { { foo: "bar" } }
-      let(:default_context) do
-        {
-          current_organization: "organization",
-          current_user: "user"
-        }
-      end
+      let(:params) { { bar: "baz" } }
 
-      it "initializes the form using the params" do
-        expect(form_klass).to receive(:from_params).with(params, anything)
-
-        subject.from_params(params)
-      end
-
-      it "injects the current user and current organization" do
-        expect(form_klass).to receive(:from_params).with(params, default_context)
-        subject.from_params(params)
+      it "injects the params into the form" do
+        form = subject.from_params(params)
+        expect(form.bar).to eq("baz")
+        expect(form.current_organization).to eq("organization")
+        expect(form.current_user).to eq("user")
       end
 
       context "with custom context" do
-        let(:context) { { somthing: "baz" } }
+        let(:context) { { something: "baz" } }
 
         it "initializes the form with params and the context" do
-          expect(form_klass).to receive(:from_params).with(params, hash_including(context))
-          subject.from_params(params, context)
+          form = subject.from_params(params, context)
+
+          expect(form.bar).to eq("baz")
+          expect(form.current_organization).to eq("organization")
+          expect(form.current_user).to eq("user")
+          expect(form.context.something).to eq("baz")
         end
       end
     end
@@ -64,26 +64,26 @@ module Decidim
     describe "from_model" do
       let(:attributes) do
         {
-          id: 1,
-          name: "Joe"
+          bar: "baz"
         }
       end
 
       let(:model) do
-        double(attributes: attributes)
+        double(attributes)
       end
 
       it "initializes the form with the model's attributes" do
-        expect(form_klass).to receive(:from_params).with(attributes, anything)
-        subject.from_model(model)
+        form = subject.from_model(model)
+        expect(form.bar).to eq("baz")
       end
 
       context "with custom context" do
-        let(:context) { { somthing: "baz" } }
+        let(:context) { { something: "baz" } }
 
         it "initializes the form with params and the context" do
-          expect(form_klass).to receive(:from_params).with(attributes, hash_including(context))
-          subject.from_model(model, context)
+          form = subject.from_model(model, context)
+          expect(form.context.something).to eq("baz")
+          expect(form.current_organization).to eq("organization")
         end
       end
     end

--- a/decidim-core/spec/forms/invite_admin_form_spec.rb
+++ b/decidim-core/spec/forms/invite_admin_form_spec.rb
@@ -10,7 +10,8 @@ module Decidim
 
     subject do
       described_class.from_params(
-        attributes,
+        attributes
+      ).with_context(
         current_user: current_user,
         current_organization: current_organization
       )

--- a/decidim-meetings/spec/forms/meeting_form_spec.rb
+++ b/decidim-meetings/spec/forms/meeting_form_spec.rb
@@ -49,7 +49,7 @@ describe Decidim::Meetings::Admin::MeetingForm do
     }
   end
 
-  subject { described_class.from_params(attributes, context).with_context(current_feature: current_feature) }
+  subject { described_class.from_params(attributes).with_context(context) }
 
   it { is_expected.to be_valid }
 

--- a/decidim-pages/Gemfile
+++ b/decidim-pages/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'decidim', path: '..'
+gemspec
+
+eval(File.read(File.join(File.dirname(__FILE__), "..", "Gemfile.common")))

--- a/decidim-pages/spec/commands/update_page_spec.rb
+++ b/decidim-pages/spec/commands/update_page_spec.rb
@@ -20,7 +20,8 @@ module Decidim
         end
         let(:form) do
           PageForm.from_params(
-            form_params,
+            form_params
+          ).with_context(
             current_organization: current_organization
           )
         end

--- a/decidim-pages/spec/forms/page_form_spec.rb
+++ b/decidim-pages/spec/forms/page_form_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 require "spec_helper"
 
@@ -6,7 +7,7 @@ module Decidim
     module Admin
       describe PageForm do
         let(:current_organization) { create(:organization) }
-        
+
         let(:title) do
           {
             "en" => "Hello world",
@@ -36,8 +37,7 @@ module Decidim
         end
 
         subject do
-          described_class.from_params(
-            attributes,
+          described_class.from_params(attributes).with_context(
             current_organization: current_organization
           )
         end

--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -5,9 +5,11 @@ module Decidim
     class CreateProposal < Rectify::Command
       # Public: Initializes the command.
       #
-      # form - A form object with the params.
-      def initialize(form)
+      # form         - A form object with the params.
+      # current_user - The current user.
+      def initialize(form, current_user)
         @form = form
+        @current_user = current_user
       end
 
       # Executes the command. Broadcasts these events:
@@ -33,7 +35,7 @@ module Decidim
           body: form.body,
           category: form.category,
           scope: form.scope,
-          author: form.author,
+          author: @current_user,
           feature: form.feature
         )
       end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -7,11 +7,11 @@ module Decidim
         helper_method :proposals
 
         def new
-          @form = form(Admin::ProposalForm).from_params({}, feature: current_feature)
+          @form = form(Admin::ProposalForm).from_params({})
         end
 
         def create
-          @form = form(Admin::ProposalForm).from_params(params, feature: current_feature)
+          @form = form(Admin::ProposalForm).from_params(params)
 
           Admin::CreateProposal.call(@form) do
             on(:ok) do

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -18,13 +18,13 @@ module Decidim
       end
 
       def new
-        @form = form(ProposalForm).from_params({}, author: current_user, feature: current_feature)
+        @form = form(ProposalForm).from_params({})
       end
 
       def create
-        @form = form(ProposalForm).from_params(params, author: current_user, feature: current_feature)
+        @form = form(ProposalForm).from_params(params)
 
-        CreateProposal.call(@form) do
+        CreateProposal.call(@form, current_user) do
           on(:ok) do |proposal|
             flash[:notice] = I18n.t("proposals.create.success", scope: "decidim")
             redirect_to proposal_path(proposal)

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposal_form.rb
@@ -10,27 +10,28 @@ module Decidim
         attribute :body, String
         attribute :category_id, Integer
         attribute :scope_id, Integer
-        attribute :feature, Decidim::Feature
 
-        validates :title, :body, :feature, presence: true
+        validates :title, :body, presence: true
         validates :category, presence: true, if: ->(form) { form.category_id.present? }
         validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
 
-        delegate :categories, to: :feature
-        delegate :scopes, to: :current_organization
+        delegate :categories, to: :current_feature, prefix: false
+        delegate :scopes, to: :current_organization, prefix: false
+
+        alias feature current_feature
 
         # Finds the Category from the category_id.
         #
         # Returns a Decidim::Category
         def category
-          @category ||= feature.categories.where(id: category_id).first
+          @category ||= categories.where(id: category_id).first
         end
 
         # Finds the Scope from the scope_id.
         #
         # Returns a Decidim::Scope
         def scope
-          @scope ||= feature.scopes.where(id: scope_id).first
+          @scope ||= scopes.where(id: scope_id).first
         end
       end
     end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -7,30 +7,30 @@ module Decidim
 
       attribute :title, String
       attribute :body, String
-      attribute :author, Decidim::User
       attribute :category_id, Integer
       attribute :scope_id, Integer
-      attribute :feature, Decidim::Feature
 
-      validates :title, :body, :author, :feature, presence: true
+      validates :title, :body, presence: true
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
       validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
 
       delegate :categories, to: :feature
       delegate :scopes, to: :current_organization
 
+      alias feature current_feature
+
       # Finds the Category from the category_id.
       #
       # Returns a Decidim::Category
       def category
-        @category ||= feature.categories.where(id: category_id).first
+        @category ||= current_feature.categories.where(id: category_id).first
       end
 
       # Finds the Scope from the scope_id.
       #
       # Returns a Decidim::Scope
       def scope
-        @scope ||= feature.scopes.where(id: scope_id).first
+        @scope ||= current_feature.scopes.where(id: scope_id).first
       end
     end
   end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_form.rb
@@ -14,7 +14,7 @@ module Decidim
       validates :category, presence: true, if: ->(form) { form.category_id.present? }
       validates :scope, presence: true, if: ->(form) { form.scope_id.present? }
 
-      delegate :categories, to: :feature
+      delegate :categories, to: :current_feature
       delegate :scopes, to: :current_organization
 
       alias feature current_feature
@@ -23,14 +23,14 @@ module Decidim
       #
       # Returns a Decidim::Category
       def category
-        @category ||= current_feature.categories.where(id: category_id).first
+        @category ||= categories.where(id: category_id).first
       end
 
       # Finds the Scope from the scope_id.
       #
       # Returns a Decidim::Scope
       def scope
-        @scope ||= current_feature.scopes.where(id: scope_id).first
+        @scope ||= scopes.where(id: scope_id).first
       end
     end
   end

--- a/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
@@ -12,18 +12,25 @@ module Decidim
           {
             title: "Proposal title",
             body: "Proposal body",
-            author: create(:user, organization: organization),
             feature: feature
           }
         end
+
+        let(:author) do
+          create(:user, organization: organization)
+        end
+
         let(:form) do
           ProposalForm.from_params(
-            form_params,
+            form_params
+          ).with_context(
             current_organization: organization,
+            current_feature: feature,
             current_process: participatory_process
           )
         end
-        let(:command) { described_class.new(form) }
+
+        let(:command) { described_class.new(form, author) }
 
         describe "when the form is not valid" do
           before do

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_form_spec.rb
@@ -18,12 +18,18 @@ module Decidim
           body: body,
           author: author,
           category_id: category_id,
-          scope_id: scope_id,
-          feature: feature
+          scope_id: scope_id
         }
       end
 
-      subject { described_class.from_params(params) }
+      let(:form) do
+        described_class.from_params(params).with_context(
+          current_feature: feature,
+          current_organization: feature.organization
+        )
+      end
+
+      subject { form }
 
       context "when everything is OK" do
         it { is_expected.to be_valid }
@@ -36,11 +42,6 @@ module Decidim
 
       context "when there's no body" do
         let(:body) { nil }
-        it { is_expected.to be_invalid }
-      end
-
-      context "when there's no author" do
-        let(:author) { nil }
         it { is_expected.to be_invalid }
       end
 
@@ -65,7 +66,7 @@ module Decidim
       end
 
       describe "category" do
-        subject { described_class.from_params(params).category }
+        subject { form.category }
 
         context "when the category exists" do
           it { is_expected.to be_kind_of(Decidim::Category) }
@@ -83,7 +84,7 @@ module Decidim
       end
 
       describe "scope" do
-        subject { described_class.from_params(params).scope }
+        subject { form.scope }
 
         context "when the scope exists" do
           it { is_expected.to be_kind_of(Decidim::Scope) }

--- a/decidim-system/app/commands/decidim/system/register_organization.rb
+++ b/decidim-system/app/commands/decidim/system/register_organization.rb
@@ -49,12 +49,11 @@ module Decidim
 
       def invite_user_form(organization)
         Decidim::InviteAdminForm.from_params(
-          {
-            name: form.organization_admin_name,
-            email: form.organization_admin_email,
-            roles: %w(admin),
-            invitation_instructions: "organization_admin_invitation_instructions"
-          },
+          name: form.organization_admin_name,
+          email: form.organization_admin_email,
+          roles: %w(admin),
+          invitation_instructions: "organization_admin_invitation_instructions"
+        ).with_context(
           current_user: form.current_user,
           current_organization: organization
         )


### PR DESCRIPTION
#### :tophat: What? Why?
This improves form factories so they make use of `with_context`, fixing several bugs related to the way we were emulating `from_model` in the past.

#### :pushpin: Related Issues
- Closes #360 

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/ZNRYeoAh3B8Ry/giphy.gif)
![](https://media.giphy.com/media/Zt8aG3xQLKLiE/giphy.gif)
