### PR TITLE
Ensure scope is generated with a unique name

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -152,7 +152,7 @@ FactoryGirl.define do
   end
 
   factory :scope, class: Decidim::Scope do
-    name { Faker::Address.state }
+    name { generate(:name) }
     organization
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
 
Since scope validates name as uniqueness we need to ensure the factory generate uniqueness names as well.

#### :pushpin: Related Issues
- Fixes #473 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
![](https://media.giphy.com/media/hEwST9KM0UGti/giphy.gif)
