### PR TITLE
Automatically order scopes by name

### DIFF
--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -6,7 +6,7 @@ module Decidim
   class Organization < ApplicationRecord
     has_many :participatory_processes, foreign_key: "decidim_organization_id", class_name: Decidim::ParticipatoryProcess, inverse_of: :organization
     has_many :static_pages, foreign_key: "decidim_organization_id", class_name: Decidim::StaticPage, inverse_of: :organization
-    has_many :scopes, foreign_key: "decidim_organization_id", class_name: Decidim::Scope, inverse_of: :organization
+    has_many :scopes, -> { order(name: :asc) }, foreign_key: "decidim_organization_id", class_name: Decidim::Scope, inverse_of: :organization
     has_many :admins, -> { where("roles @> ?", "{admin}") }, foreign_key: "decidim_organization_id", class_name: Decidim::User
 
     validates :name, :host, uniqueness: true


### PR DESCRIPTION
#### :tophat: What? Why?
Sorts organization scopes alphabetically by name.

#### :pushpin: Related Issues
- Fixes #496

#### :clipboard: Subtasks
None