### PR TITLE
Ignore `.bundle/` folder in Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -77,6 +77,7 @@ coverage:
   - "bundle.js"
   - "vendor/*"
   - "node_modules/*"
+  - ".bundle/*"
 
 comment:
   layout: "header, diff, changes, sunburst, uncovered, tree"


### PR DESCRIPTION
#### :tophat: What? Why?
Looks like #485 made codecov go crazy about overage again. This PR fixes it by ignoring the `.bundle/` folder (where all gems are being installed on travis)

#### :pushpin: Related Issues
- Related to #485

#### :clipboard: Subtasks
None