### PR TITLE
Fix capybara have_css count expectancies

### DIFF
--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -86,7 +86,7 @@ describe "Proposals", type: :feature do
     end
 
     it "lists all the proposals" do
-      expect(page).to have_css(".card--proposal", 3)
+      expect(page).to have_css(".card--proposal", count: 3)
     end
 
     it "allows viewing a single proposal" do
@@ -101,16 +101,16 @@ describe "Proposals", type: :feature do
 
     context "when there are a lot of proposals" do
       before do
-        create_list(:proposal, 20, feature: feature)
+        create_list(:proposal, 17, feature: feature)
         visit current_path
       end
 
       it "paginates them" do
-        expect(page).to have_css(".card--proposal", 12)
+        expect(page).to have_css(".card--proposal", count: 12)
 
         find(".pagination-next a").click
 
-        expect(page).to have_css(".card--proposal", 8)
+        expect(page).to have_css(".card--proposal", count: 8)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Implements https://github.com/AjuntamentdeBarcelona/decidim/issues/491

#### :ghost: GIF
![](https://media.giphy.com/media/sWVx31scSCoTu/giphy.gif)
