### PR TITLE
Use foundation rails helper rc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN curl -sL https://deb.nodesource.com/setup_4.x | bash && \
     apt-get install -y nodejs yarn
 
 ADD Gemfile /tmp/Gemfile
-ADD Gemfile.common /tmp/Gemfile.common
 ADD Gemfile.lock /tmp/Gemfile.lock
 ADD decidim.gemspec /tmp/decidim.gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,3 @@ gemspec path: "decidim-api"
 gemspec path: "decidim-pages"
 gemspec path: "decidim-comments"
 gemspec path: "decidim-meetings"
-
-eval(File.read(File.join(File.dirname(__FILE__), "Gemfile.common")))

--- a/Gemfile.common
+++ b/Gemfile.common
@@ -1,1 +1,0 @@
-gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git", tag: "df0bd8e"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/sgruhier/foundation_rails_helper.git
-  revision: df0bd8eca1b43b8bfdcb163f9e1e3b3b9ab0595e
-  tag: df0bd8e
-  specs:
-    foundation_rails_helper (2.0.0)
-      actionpack (>= 4.1)
-      activemodel (>= 4.1)
-      activesupport (>= 4.1)
-      railties (>= 4.1)
-      tzinfo (~> 1.2, >= 1.2.2)
-
 PATH
   remote: .
   specs:
@@ -42,7 +30,7 @@ PATH
       devise (~> 4.2)
       devise-i18n (~> 1.1.0)
       devise_invitable (~> 1.7.0)
-      foundation_rails_helper (~> 2.0.0)
+      foundation_rails_helper (~> 3.0.0.rc)
       jquery-rails (~> 4.2.2)
       rails (~> 5.0.0, >= 5.0.0.1)
       rectify (~> 0.8.0)
@@ -64,7 +52,6 @@ PATH
   specs:
     decidim-comments (0.0.1)
       decidim-core (= 0.0.1)
-      foundation_rails_helper (~> 2.0.0)
       jquery-rails (~> 4.0)
       rails (~> 5.0.0, >= 5.0.0.1)
       turbolinks (~> 5.0.0, >= 5.0.0.1)
@@ -82,7 +69,7 @@ PATH
       devise-i18n (~> 1.1.0)
       file_validators (~> 2.1.0)
       foundation-rails (~> 6.3.0.0)
-      foundation_rails_helper (~> 2.0.0)
+      foundation_rails_helper (~> 3.0.0.rc)
       high_voltage (~> 3.0.0)
       jquery-rails (~> 4.2.2)
       mini_magick (~> 4.6.0)
@@ -148,7 +135,7 @@ PATH
       devise (~> 4.2)
       devise-i18n (~> 1.1.0)
       devise_invitable (~> 1.7.0)
-      foundation_rails_helper (~> 2.0.0)
+      foundation_rails_helper (~> 3.0.0.rc)
       jquery-rails (~> 4.2.2)
       rails (~> 5.0.0, >= 5.0.0.1)
       rectify (~> 0.8.0)
@@ -210,7 +197,7 @@ GEM
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
     bcrypt (3.1.11)
-    builder (3.2.2)
+    builder (3.2.3)
     byebug (9.0.6)
     cancancan (1.15.0)
     capybara (2.11.0)
@@ -285,6 +272,12 @@ GEM
       railties (>= 3.1.0)
       sass (>= 3.3.0, < 3.5)
       sprockets-es6 (>= 0.9.0)
+    foundation_rails_helper (3.0.0.rc2)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      activesupport (>= 4.1)
+      railties (>= 4.1)
+      tzinfo (~> 1.2, >= 1.2.2)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     graphiql-rails (1.4.1)
@@ -516,7 +509,6 @@ DEPENDENCIES
   decidim-meetings!
   decidim-pages!
   decidim-system!
-  foundation_rails_helper!
   rake (~> 12.0.0)
   rspec (~> 3.0)
 

--- a/decidim-admin/Gemfile
+++ b/decidim-admin/Gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'decidim', path: '..'
-gemspec
-
-eval(File.read(File.join(File.dirname(__FILE__), "..", "Gemfile.common")))

--- a/decidim-admin/decidim-admin.gemspec
+++ b/decidim-admin/decidim-admin.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sassc-rails", "~> 1.3.0"
   s.add_dependency "jquery-rails", "~> 4.2.2"
   s.add_dependency "turbolinks", *Decidim.rails_version
-  s.add_dependency "foundation_rails_helper", "~> 2.0.0"
+  s.add_dependency "foundation_rails_helper", "~> 3.0.0.rc"
   s.add_dependency "active_link_to", "~> 1.0.0"
   s.add_dependency "carrierwave", "~> 1.0.0.rc"
   s.add_dependency "cancancan", "~> 1.15.0"

--- a/decidim-comments/Gemfile
+++ b/decidim-comments/Gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'decidim', path: '..'
-gemspec
-
-eval(File.read(File.join(File.dirname(__FILE__), "..", "Gemfile.common")))

--- a/decidim-comments/decidim-comments.gemspec
+++ b/decidim-comments/decidim-comments.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", *Decidim.rails_version
   s.add_dependency "jquery-rails", "~> 4.0"
   s.add_dependency "turbolinks", *Decidim.rails_version
-  s.add_dependency "foundation_rails_helper", "~> 2.0.0"
 
   s.add_development_dependency "decidim-dev", Decidim.version
 end

--- a/decidim-core/Gemfile
+++ b/decidim-core/Gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'decidim', path: '..'
-gemspec
-
-eval(File.read(File.join(File.dirname(__FILE__), "..", "Gemfile.common")))

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", "~> 4.2.2"
   s.add_dependency "turbolinks", *Decidim.rails_version
   s.add_dependency "carrierwave", "~> 1.0.0"
-  s.add_dependency "foundation_rails_helper", "~> 2.0.0"
+  s.add_dependency "foundation_rails_helper", "~> 3.0.0.rc"
   s.add_dependency "active_link_to", "~> 1.0.0"
   s.add_dependency "pg", "~> 0.19.0"
   s.add_dependency "redis", "~> 3.3.0"

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -32,7 +32,7 @@ module Decidim
             string + content_tag(:li, class: tab_element_class_for("title", index)) do
               title = I18n.t(locale, scope: "locales")
               element_class = ""
-              element_class += "alert" if has_error?(name_with_locale(name, locale))
+              element_class += "alert" if error?(name_with_locale(name, locale))
               content_tag(:a, title, href: "##{name}-panel-#{index}", class: element_class)
             end
           end
@@ -71,7 +71,7 @@ module Decidim
         template += content_tag(:div, nil, class: "editor-container", data: {
                                   toolbar: options[:toolbar]
                                 }, style: "height: #{options[:lines]}rem")
-        template += error_for(name, options) if has_error?(name)
+        template += error_for(name, options) if error?(name)
         template.html_safe
       end
     end
@@ -156,7 +156,7 @@ module Decidim
     end
 
     def label_i18n(attribute, text = nil, options = {})
-      errored = has_error?(attribute) || locales.any? { |locale| has_error?(name_with_locale(attribute, locale)) }
+      errored = error?(attribute) || locales.any? { |locale| error?(name_with_locale(attribute, locale)) }
 
       if errored
         options[:class] ||= ""

--- a/decidim-dev/Gemfile
+++ b/decidim-dev/Gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'decidim', path: '..'
-gemspec
-
-eval(File.read(File.join(File.dirname(__FILE__), "..", "Gemfile.common")))

--- a/decidim-meetings/Gemfile
+++ b/decidim-meetings/Gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'decidim', path: '..'
-gemspec
-
-eval(File.read(File.join(File.dirname(__FILE__), "..", "Gemfile.common")))

--- a/decidim-pages/Gemfile
+++ b/decidim-pages/Gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'decidim', path: '..'
-gemspec
-
-eval(File.read(File.join(File.dirname(__FILE__), "..", "Gemfile.common")))

--- a/decidim-system/Gemfile
+++ b/decidim-system/Gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'decidim', path: '..'
-gemspec
-
-eval(File.read(File.join(File.dirname(__FILE__), "..", "Gemfile.common")))

--- a/decidim-system/decidim-system.gemspec
+++ b/decidim-system/decidim-system.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sassc-rails", "~> 1.3.0"
   s.add_dependency "jquery-rails", "~> 4.2.2"
   s.add_dependency "turbolinks", *Decidim.rails_version
-  s.add_dependency "foundation_rails_helper", "~> 2.0.0"
+  s.add_dependency "foundation_rails_helper", "~> 3.0.0.rc"
   s.add_dependency "active_link_to", "~> 1.0.0"
 
   s.add_development_dependency "decidim-dev", Decidim.version

--- a/lib/generators/decidim/templates/Gemfile.erb
+++ b/lib/generators/decidim/templates/Gemfile.erb
@@ -13,8 +13,6 @@ gem "decidim", "<%= Gem::Specification.find_by_name("decidim").version %>"
 gem 'puma', '~> 3.0'
 gem 'uglifier', '>= 1.3.0'
 
-gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git", tag: "df0bd8e"
-
 group :development, :test do
   gem 'byebug', platform: :mri
 end


### PR DESCRIPTION
#### :tophat: What? Why?
`foundation_rails_helper` 3.0.0.rc has been released so we're switching to using the release from rubygems instead of the ugly hack of using the version from GitHub. Yay!

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/gcqdOW7mbMNt6/giphy.gif)
