### PR TITLE
Use in review label instead of skipping WIP

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -3,6 +3,6 @@
   "userBlacklist": ["decidim-bot"],
   "actions": ["opened", "labeled", "unlabeled", "edited"],
   "skipAlreadyMentionedPR": true,
-  "skipTitle": "WIP",
+  "withLabel": "in-review",
   "createReviewRequest": true
 }


### PR DESCRIPTION
#### :tophat: What? Why?
Skipping WIP on the title doesn't seem like the best way to go and is often forgotten. The `in-review` label allows much more control.

#### :pushpin: Related Issues
- Related to #482

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/j3GckJZs4vVHG/giphy.gif)
