### PR TITLE
Remove i18n from seed comments body

### DIFF
--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -17,7 +17,7 @@ module Decidim
           random = rand(Decidim::User.count)
           Comment.create(
             commentable: resource,
-            body: Decidim::Faker::Localized.sentence,
+            body: Faker::Lorem.sentence,
             author: Decidim::User.where(organization: organization).offset(random).first
           )
         end

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -17,7 +17,7 @@ module Decidim
           random = rand(Decidim::User.count)
           Comment.create(
             commentable: resource,
-            body: Faker::Lorem.sentence,
+            body: ::Faker::Lorem.sentence,
             author: Decidim::User.where(organization: organization).offset(random).first
           )
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Removes i18n from seed comments body.

#### :pushpin: Related Issues
- Fixes #519

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None