### PR TITLE
Authorizations can be unique

### DIFF
--- a/decidim-core/app/commands/decidim/authorize_user.rb
+++ b/decidim-core/app/commands/decidim/authorize_user.rb
@@ -16,7 +16,7 @@ module Decidim
     #
     # Returns nothing.
     def call
-      return broadcast(:invalid) unless handler.authorized?
+      return broadcast(:invalid) unless handler.valid?
 
       create_authorization
       broadcast(:ok)
@@ -29,6 +29,7 @@ module Decidim
     def create_authorization
       Authorization.create!(
         user: handler.user,
+        unique_id: handler.unique_id,
         name: handler.handler_name,
         metadata: handler.metadata
       )

--- a/decidim-core/app/services/decidim/authorization_handler.rb
+++ b/decidim-core/app/services/decidim/authorization_handler.rb
@@ -98,15 +98,14 @@ module Decidim
     def identifier_uniqueness
       return true if unique_id.nil?
 
-      existing = Authorization.where(
+      duplicates = Authorization.where(
         user: User.where(organization: user.organization.id),
         name: handler_name,
         unique_id: unique_id
-      ).any?
+      )
 
-      if existing
-        errors.add(:base, I18n.t("decidim.authorization_handlers.errors.duplicate_authorization"))
-      end
+      return true if duplicates.empty?
+      errors.add(:base, I18n.t("decidim.authorization_handlers.errors.duplicate_authorization"))
     end
   end
 end

--- a/decidim-core/app/services/decidim/authorization_handler.rb
+++ b/decidim-core/app/services/decidim/authorization_handler.rb
@@ -2,9 +2,12 @@
 module Decidim
   # This is the base class for authorization handlers, all implementations
   # should inherit from it.
-  # Each AuthorizationHandler must define an `authorized?` method that will be
-  # used to check if the authorization is valid or not. When it is valid a new
-  # authorization will be created for the user.
+  # Each AuthorizationHandler is a form that will be used to check if the
+  # authorization is valid or not. When it is valid a new authorization will
+  # be created for the user.
+  #
+  # Feel free to use validations to assert fields against a remote API,
+  # local database, or whatever.
   #
   # It also sets two default attributes, `user` and `handler_name`.
   class AuthorizationHandler < Form
@@ -15,22 +18,21 @@ module Decidim
     # infer the class name of the authorization handler.
     attribute :handler_name, String
 
+    validate :identifier_uniqueness
+
+    # A unique ID to be implemented by the authorization handler that ensures
+    # no duplicates are created. This uniqueness check will be skipped if
+    # unique_id returns nil.
+    def unique_id
+      nil
+    end
+
     # THe attributes of the handler that should be exposed as form input when
     # rendering the handler in a form.
     #
     # Returns an Array of Strings.
     def form_attributes
       attributes.except(:id, :user).keys
-    end
-
-    # Whether the authorization is valid or not. Each AuthorizationHandler
-    # implementation must implemement this method. This is were you check for
-    # validation errors or against third party systems to validate the
-    # authorization.
-    #
-    # Returns a Boolean.
-    def authorized?
-      raise NotImplementedError
     end
 
     # The String partial path so Rails can render the handler as a form. This
@@ -89,6 +91,22 @@ module Decidim
       handler_klass.from_params(params || {})
     rescue NameError
       nil
+    end
+
+    private
+
+    def identifier_uniqueness
+      return true if unique_id.nil?
+
+      existing = Authorization.where(
+        user: User.where(organization: user.organization.id),
+        name: handler_name,
+        unique_id: unique_id
+      ).any?
+
+      if existing
+        errors.add(:base, I18n.t("decidim.authorization_handlers.errors.duplicate_authorization"))
+      end
     end
   end
 end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -27,6 +27,8 @@ en:
         title: My account
     authorization_handlers:
       decidim/dummy_authorization_handler: Example authorization
+      errors:
+        duplicate_authorization: A user is already authorized with the same data.
     authorizations:
       create:
         error: There was an error creating the authorization.

--- a/decidim-core/db/migrate/20170117142904_add_uniqueness_field_to_authorizations.rb
+++ b/decidim-core/db/migrate/20170117142904_add_uniqueness_field_to_authorizations.rb
@@ -1,0 +1,7 @@
+class AddUniquenessFieldToAuthorizations < ActiveRecord::Migration[5.0]
+  def change
+    change_table :decidim_authorizations do |t|
+      t.string :unique_id, null: true
+    end
+  end
+end

--- a/decidim-core/spec/commands/decidim/authorize_user_spec.rb
+++ b/decidim-core/spec/commands/decidim/authorize_user_spec.rb
@@ -11,7 +11,7 @@ module Decidim
     end
 
     before do
-      expect(handler).to receive(:authorized?).and_return(authorized)
+      expect(handler).to receive(:valid?).and_return(authorized)
     end
 
     subject { described_class.new(handler) }

--- a/decidim-core/spec/services/decidim/authorization_handler_spec.rb
+++ b/decidim-core/spec/services/decidim/authorization_handler_spec.rb
@@ -67,5 +67,40 @@ module Decidim
         end
       end
     end
+
+    describe "uniqueness" do
+      let(:user) { create(:user) }
+
+      before do
+        subject.user = user
+        allow(subject).to receive(:unique_id).and_return "foo"
+        Decidim.authorization_handlers.push(described_class)
+      end
+
+      after do
+        Decidim.authorization_handlers.delete(described_class)
+      end
+
+      context "when there's no other authorizations" do
+        it "is valid if there's no authorization with the same id" do
+          expect(subject).to be_valid
+        end
+      end
+
+      context "when there's other authorizations" do
+        let!(:other_user) { create(:user, organization: user.organization)}
+
+        before do
+          create(:authorization,
+                 user: other_user,
+                 unique_id: "foo",
+                 name: handler.handler_name)
+        end
+
+        it "is invalid if there's another authorization with the same id" do
+          expect(subject).to be_invalid
+        end
+      end
+    end
   end
 end

--- a/decidim-core/spec/services/decidim/dummy_authorization_handler_spec.rb
+++ b/decidim-core/spec/services/decidim/dummy_authorization_handler_spec.rb
@@ -16,8 +16,8 @@ module Decidim
       it { is_expected.to eq(document_number: "123456") }
     end
 
-    describe "authorized?" do
-      subject { handler.authorized? }
+    describe "valid?" do
+      subject { handler.valid? }
       let(:params) { { document_number: document_number } }
 
       context "when no document number" do

--- a/decidim-dev/lib/decidim/dev/dummy_authorization_handler.rb
+++ b/decidim-dev/lib/decidim/dev/dummy_authorization_handler.rb
@@ -8,10 +8,6 @@ module Decidim
     validates :document_number, presence: true
     validate :valid_document_number
 
-    def authorized?
-      valid?
-    end
-
     def metadata
       super.merge(document_number: document_number)
     end

--- a/decidim-dev/lib/decidim/dev/test/authorization_shared_examples.rb
+++ b/decidim-dev/lib/decidim/dev/test/authorization_shared_examples.rb
@@ -6,14 +6,6 @@ RSpec.shared_examples "an authorization handler" do
     end
   end
 
-  describe "authorized?" do
-    it "is implemented" do
-      expect do
-        handler.authorized?
-      end.to_not raise_error
-    end
-  end
-
   describe "to_partial_path" do
     subject { handler.to_partial_path }
     it { is_expected.to be_kind_of(String) }


### PR DESCRIPTION
#### :tophat: What? Why?
After some offline discussion, we've decided that some authorizations need to be unique (like census calls). This adds an optional validation that will trigger whenever you add an `uniqueness_id` field.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/HFOpZAK6nesQU/giphy.gif)
