### PR TITLE
Cache bundler on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ cache:
   directories:
     - $HOME/.bundle
     - $TRAVIS_BUILD_DIR/.yarn-cache
-    - $HOME/node_modules
+    - $TRAVIS_BUILD_DIR/node_modules
+    - $BUNDLE_PATH
 
 script:
   - cd $GEM;

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - yarn
   - gem environment
   
-bundler_args: --jobs=3 --retry=3 --deployment --path=$BUNDLE_PATH
+bundler_args: --jobs=3 --retry=3 --deployment --path="$BUNDLE_PATH"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,9 @@ before_install:
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   - yarn
   - gem environment
+  - $BUNDLE_PATH
   
-bundler_args: --jobs=3 --retry=3 --deployment --path="$BUNDLE_PATH"
+bundler_args: --jobs=3 --retry=3 --deployment --path="$HOME/.bundle"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
   # Repo for newer Node.js versions
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   - yarn
+  - gem environment
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_install:
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   - yarn
   - gem environment
-  - $BUNDLE_PATH
-  
+  - echo $BUNDLE_PATH
+
 bundler_args: --jobs=3 --retry=3 --deployment --path="$HOME/.bundle"
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,26 +8,28 @@ services:
 language: ruby
 
 branches:
-  only: 
+  only:
     - master
 
 env:
-  - GEM=. DB=postgres
-  - GEM=decidim-admin DB=postgres
-  - GEM=decidim-core DB=postgres
-  - GEM=decidim-system DB=postgres
-  - GEM=decidim-api DB=postgres
-  - GEM=decidim-pages DB=postgres
-  - GEM=decidim-comments DB=postgres
-  - GEM=decidim-meetings DB=postgres
-  - GEM=decidim-proposals DB=postgres
+  global:
+    - BUNDLE_GEMFILE="$TRAVIS_BUILD_DIR/Gemfile"
+    - BUNDLE_PATH="$HOME/.bundle"
+  matrix:
+    - GEM=. DB=postgres
+    - GEM=decidim-admin DB=postgres
+    - GEM=decidim-core DB=postgres
+    - GEM=decidim-system DB=postgres
+    - GEM=decidim-api DB=postgres
+    - GEM=decidim-pages DB=postgres
+    - GEM=decidim-comments DB=postgres
+    - GEM=decidim-meetings DB=postgres
+    - GEM=decidim-proposals DB=postgres
 
 before_install:
   # Repo for newer Node.js versions
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   - yarn
-  - export BUNDLE_GEMFILE="$TRAVIS_BUILD_DIR/Gemfile"
-  - export BUNDLE_PATH="$HOME/.bundle"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ before_install:
   # Repo for newer Node.js versions
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   - yarn
-  - gem environment
-  - echo $BUNDLE_PATH
 
 bundler_args: --jobs=3 --retry=3 --deployment --path="$HOME/.bundle"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 cache:
   directories:
     - $HOME/.bundle
-    - $HOME/.yarn-cache
+    - $TRAVIS_BUILD_DIR/.yarn-cache
     - $HOME/node_modules
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ before_install:
   - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
   - yarn
   - gem environment
+  
+bundler_args: --jobs=3 --retry=3 --deployment --path=$BUNDLE_PATH
 
 cache:
   directories:


### PR DESCRIPTION
#### :tophat: What? Why?
Installing the gem bundle takes almost 3min on Travis, per job. That's a lot. 

This is another take on trying to cache it, but now it features support directly from TravisCI, so this should be the last take on this.

#### :pushpin: Related Issues
- Related to #485 

#### :clipboard: Subtasks
None
