### PR TITLE
public/uploads added to .gitignore

### DIFF
--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -80,6 +80,13 @@ module Decidim
         ]
       end
 
+      def add_ignore_uploads
+        p options.inspect
+        unless options["skip_git"]
+          append_file ".gitignore", "\n# Ignore public uploads\npublic/uploads"
+        end
+      end
+
       def remove_default_error_pages
         remove_file "public/404.html"
         remove_file "public/500.html"

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -34,12 +34,6 @@ module Decidim
         append_file "db/seeds.rb", "\n# You can remove the 'faker' gem if you don't want Decidim seeds.\nDecidim.seed!"
       end
 
-      def add_seeds
-        file ".gitignore" do
-          append_file ".gitignore", "\n# Ignore public uploads\npublic/uploads"
-        end
-      end
-
       def copy_initializer
         template "initializer.rb", "config/initializers/decidim.rb"
         template "carrierwave.rb", "config/initializers/carrierwave.rb"

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -35,7 +35,9 @@ module Decidim
       end
 
       def add_seeds
-        append_file ".gitignore", "\n# Ignore public uploads\npublic/uploads"
+        file ".gitignore" do
+          append_file ".gitignore", "\n# Ignore public uploads\npublic/uploads"
+        end
       end
 
       def copy_initializer

--- a/lib/generators/decidim/install_generator.rb
+++ b/lib/generators/decidim/install_generator.rb
@@ -34,6 +34,10 @@ module Decidim
         append_file "db/seeds.rb", "\n# You can remove the 'faker' gem if you don't want Decidim seeds.\nDecidim.seed!"
       end
 
+      def add_seeds
+        append_file ".gitignore", "\n# Ignore public uploads\npublic/uploads"
+      end
+
       def copy_initializer
         template "initializer.rb", "config/initializers/decidim.rb"
         template "carrierwave.rb", "config/initializers/carrierwave.rb"


### PR DESCRIPTION
#### :tophat: What? Why?
This PR inject ```public/uploads``` to .gitignore inside the ```install_generator``` so all new projects will ignore it automatically.

#### :pushpin: Related Issues
- Fixes #494

#### :ghost: GIF
![](https://media.giphy.com/media/11YdnfyG6qvuWk/giphy.gif)
