### PR TITLE
Do not hardcode user's default locale in factory

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -92,7 +92,7 @@ FactoryGirl.define do
     password_confirmation "password1234"
     name                  { generate(:name) }
     organization
-    locale                "en"
+    locale                { I18n.default_locale }
     tos_agreement         "1"
     avatar                { test_file("avatar.svg", "image/svg+xml") }
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -92,7 +92,7 @@ FactoryGirl.define do
     password_confirmation "password1234"
     name                  { generate(:name) }
     organization
-    locale                { I18n.default_locale }
+    locale                { organization.default_locale }
     tos_agreement         "1"
     avatar                { test_file("avatar.svg", "image/svg+xml") }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Users default locale in factories is hardcoded. This PR changes it to `I18n.default_locale`, just like the organization factory does.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None
