### PR TITLE
Add User Groups

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim.js.es6
@@ -4,6 +4,7 @@
 // = require svg4everybody.min
 // = require decidim/append_elements
 // = require decidim/inline_svg
+// = require decidim/user_registrations
 
 /* globals svg4everybody */
 

--- a/decidim-core/app/assets/javascripts/decidim/user_registrations.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/user_registrations.js.es6
@@ -1,0 +1,16 @@
+$(document).on('turbolinks:load', () => {
+  const $userRegistrationForm = $('.register-form');
+  const $userGroupFields = $userRegistrationForm.find('.user-group-fields');
+
+  $userGroupFields.hide();
+  
+  $userRegistrationForm.on('change', 'input[name="user[sign_up_as]"]', (event) => {
+    const value = event.target.value;
+
+    if (value === 'user') {
+      $userGroupFields.hide();
+    } else {
+      $userGroupFields.show();
+    }
+  });
+});

--- a/decidim-core/app/assets/javascripts/decidim/user_registrations.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/user_registrations.js.es6
@@ -1,16 +1,22 @@
 $(document).on('turbolinks:load', () => {
   const $userRegistrationForm = $('.register-form');
-  const $userGroupFields = $userRegistrationForm.find('.user-group-fields');
+  const $userGroupFields      = $userRegistrationForm.find('.user-group-fields');
+  const inputSelector         = 'input[name="user[sign_up_as]"]';
 
-  $userGroupFields.hide();
-  
-  $userRegistrationForm.on('change', 'input[name="user[sign_up_as]"]', (event) => {
-    const value = event.target.value;
-
+  const setGroupFieldsVisibility = (value) => {
     if (value === 'user') {
       $userGroupFields.hide();
     } else {
       $userGroupFields.show();
     }
+  }
+
+  setGroupFieldsVisibility($userRegistrationForm.find(inputSelector).val());
+  
+  $userRegistrationForm.on('change', inputSelector, (event) => {
+    const value = event.target.value;
+
+    setGroupFieldsVisibility(value);
   });
+
 });

--- a/decidim-core/app/commands/decidim/create_registration.rb
+++ b/decidim-core/app/commands/decidim/create_registration.rb
@@ -19,6 +19,8 @@ module Decidim
       return broadcast(:invalid) if form.invalid?
 
       create_user
+      create_user_group if form.is_user_group?
+
       broadcast(:ok, @user)
     end
 
@@ -33,6 +35,17 @@ module Decidim
                            password_confirmation: form.password_confirmation,
                            organization: form.current_organization,
                            tos_agreement: form.tos_agreement)
+    end
+
+    def create_user_group
+      UserGroupMembership.create!({
+        user: @user,
+        user_group: UserGroup.new({
+          name: form.user_group_name,
+          document_number: form.user_group_document_number,
+          phone: form.user_group_phone
+        })
+      })
     end
   end
 end

--- a/decidim-core/app/commands/decidim/create_registration.rb
+++ b/decidim-core/app/commands/decidim/create_registration.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module Decidim
+  # A command with all the business logic to create a user
+  class CreateRegistration < Rectify::Command
+    # Public: Initializes the command.
+    #
+    # form - A form object with the params.
+    def initialize(form)
+      @form = form
+    end
+
+    # Executes the command. Broadcasts these events:
+    #
+    # - :ok when everything is valid.
+    # - :invalid if the form wasn't valid and we couldn't proceed.
+    #
+    # Returns nothing.
+    def call
+      return broadcast(:invalid) if form.invalid?
+
+      create_user
+      broadcast(:ok, @user)
+    end
+
+    private
+
+    attr_reader :form
+
+    def create_user
+      @user = User.create!(email: form.email,
+                           name: form.name,
+                           password: form.password,
+                           password_confirmation: form.password_confirmation,
+                           organization: form.current_organization,
+                           tos_agreement: form.tos_agreement)
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -6,12 +6,39 @@ module Decidim
     class RegistrationsController < ::Devise::RegistrationsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+      include FormFactory
       helper Decidim::TranslationsHelper
       helper Decidim::OmniauthHelper
 
       layout "layouts/decidim/application"
       before_action :configure_permitted_parameters
 
+      def new
+        @form = form(RegistrationForm).from_params({})
+      end
+
+      def create
+        @form = form(RegistrationForm).from_params(params[:user])
+        
+        CreateRegistration.call(@form) do
+          on(:ok) do |user|
+            if user.active_for_authentication?
+              set_flash_message! :notice, :signed_up
+              sign_up(:user, user)
+              respond_with user, location: after_sign_up_path_for(user)
+            else
+              set_flash_message! :notice, :"signed_up_but_#{user.inactive_message}"
+              expire_data_after_sign_in!
+              respond_with user, location: after_inactive_sign_up_path_for(user)
+            end
+          end
+
+          on(:invalid) do
+            render :new
+          end
+        end
+      end
+      
       protected
 
       def configure_permitted_parameters

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -14,7 +14,11 @@ module Decidim
       before_action :configure_permitted_parameters
 
       def new
-        @form = form(RegistrationForm).from_params({})
+        @form = form(RegistrationForm).from_params({
+          user: {
+            sign_up_as: "user"
+          }
+        })
       end
 
       def create

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -14,16 +14,16 @@ module Decidim
       before_action :configure_permitted_parameters
 
       def new
-        @form = form(RegistrationForm).from_params({
+        @form = form(RegistrationForm).from_params(
           user: {
             sign_up_as: "user"
           }
-        })
+        )
       end
 
       def create
         @form = form(RegistrationForm).from_params(params[:user])
-        
+
         CreateRegistration.call(@form) do
           on(:ok) do |user|
             if user.active_for_authentication?
@@ -42,7 +42,7 @@ module Decidim
           end
         end
       end
-      
+
       protected
 
       def configure_permitted_parameters

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -26,8 +26,16 @@ module Decidim
     validates :user_group_document_number, presence: true, if: :is_user_group?
     validates :user_group_phone, presence: true, if: :is_user_group?
     
+    validate :email_unique_in_organization
+
     def is_user_group?
       sign_up_as == "user_group"
+    end
+
+    private
+
+    def email_unique_in_organization
+      errors.add :email, :taken if User.where(email: email, organization: current_organization).first.present?
     end
   end
 end

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A form object used to handle user registrations
+  class RegistrationForm < Form
+    mimic :user
+
+    attribute :name, String
+    attribute :email, String
+    attribute :password, String
+    attribute :password_confirmation, String
+    attribute :tos_agreement, Boolean
+
+    attribute :user_group_name, String
+    attribute :user_group_document_number, String
+    attribute :user_group_phone, String
+
+    validates :name, presence: true
+    validates :email, presence: true
+    validates :password, presence: true, confirmation: true
+    validates :tos_agreement, allow_nil: false, acceptance: true
+  end
+end

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -25,7 +25,7 @@ module Decidim
     validates :user_group_name, presence: true, if: :is_user_group?
     validates :user_group_document_number, presence: true, if: :is_user_group?
     validates :user_group_phone, presence: true, if: :is_user_group?
-    
+
     validate :email_unique_in_organization
 
     def is_user_group?

--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -5,6 +5,7 @@ module Decidim
   class RegistrationForm < Form
     mimic :user
 
+    attribute :sign_up_as, String
     attribute :name, String
     attribute :email, String
     attribute :password, String
@@ -15,9 +16,18 @@ module Decidim
     attribute :user_group_document_number, String
     attribute :user_group_phone, String
 
+    validates :sign_up_as, inclusion: { in: %w(user user_group) }
     validates :name, presence: true
     validates :email, presence: true
     validates :password, presence: true, confirmation: true
     validates :tos_agreement, allow_nil: false, acceptance: true
+
+    validates :user_group_name, presence: true, if: :is_user_group?
+    validates :user_group_document_number, presence: true, if: :is_user_group?
+    validates :user_group_phone, presence: true, if: :is_user_group?
+    
+    def is_user_group?
+      sign_up_as == "user_group"
+    end
   end
 end

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Decidim
-  # A UserGroup is an organizatio of citizens
+  # A UserGroup is an organization of citizens
   class UserGroup < ApplicationRecord
     has_many :users, through: :memberships, class_name: Decidim::User, foreign_key: :decidim_user_id
     has_many :memberships, class_name: Decidim::UserGroupMembership, foreign_key: :decidim_user_group_id

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A UserGroup is an organizatio of citizens
+  class UserGroup < ApplicationRecord
+    has_many :users, through: :memberships, class_name: Decidim::User, foreign_key: :decidim_user_id
+    has_many :memberships, class_name: Decidim::UserGroupMembership, foreign_key: :decidim_user_group_id
+
+    validates :name, presence: true
+    validates :document_number, presence: true
+    validates :phone, presence: true
+  end
+end

--- a/decidim-core/app/models/decidim/user_group_membership.rb
+++ b/decidim-core/app/models/decidim/user_group_membership.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A UserGroupMembership associate user with user groups
+  class UserGroupMembership < ApplicationRecord
+    belongs_to :user, class_name: Decidim::User, foreign_key: :decidim_user_id
+    belongs_to :user_group, class_name: Decidim::UserGroup, foreign_key: :decidim_user_group_id
+  end
+end

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -20,10 +20,7 @@
           <%= form_for(@form, as: resource_name, url: registration_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
             <fieldset class="text-center">
               <legend class="text-center heading5"><%= t(".sign_up_as.legend") %></legend>
-              <input type="radio" name="sign_up_as" value="user" id="sign_up_as_user" checked="">
-              <label for="sign_up_as_user"><%= t(".sign_up_as.user") %></label>
-              <input type="radio" name="sign_up_as" value="user_group" id="sign_up_as_user_group">
-              <label for="sign_up_as_user_group"><%= t(".sign_up_as.user_group") %></label>
+              <%= f.collection_radio_buttons :sign_up_as, [["user", t(".sign_up_as.user")], ["user_group", t(".sign_up_as.user_group") ]], :first, :last %>
             </fieldset>
 
             <div class="user-person">

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -41,16 +41,18 @@
               <%= f.password_field :password_confirmation, autocomplete: "off" %>
             </div>
 
-            <div class="field">
-              <%= f.text_field :user_group_name %>
-            </div>
+            <div class="user-group-fields">
+              <div class="field">
+                <%= f.text_field :user_group_name %>
+              </div>
 
-            <div class="field">
-              <%= f.text_field :user_group_document_number %>
-            </div>
+              <div class="field">
+                <%= f.text_field :user_group_document_number %>
+              </div>
 
-            <div class="field">
-              <%= f.text_field :user_group_phone %>
+              <div class="field">
+                <%= f.text_field :user_group_phone %>
+              </div>
             </div>
 
             <fieldset>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -17,7 +17,15 @@
     <div class="columns large-6 medium-10 medium-centered">
       <div class="card">
         <div class="card__content">
-          <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
+          <%= form_for(@form, as: resource_name, url: registration_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
+            <fieldset class="text-center">
+              <legend class="text-center heading5"><%= t(".sign_up_as.legend") %></legend>
+              <input type="radio" name="sign_up_as" value="user" id="sign_up_as_user" checked="">
+              <label for="sign_up_as_user"><%= t(".sign_up_as.user") %></label>
+              <input type="radio" name="sign_up_as" value="user_group" id="sign_up_as_user_group">
+              <label for="sign_up_as_user_group"><%= t(".sign_up_as.user_group") %></label>
+            </fieldset>
+
             <div class="user-person">
               <div class="field">
                 <%= f.text_field :name, help_text: t(".username_help") %>
@@ -34,6 +42,18 @@
 
             <div class="field">
               <%= f.password_field :password_confirmation, autocomplete: "off" %>
+            </div>
+
+            <div class="field">
+              <%= f.text_field :user_group_name %>
+            </div>
+
+            <div class="field">
+              <%= f.text_field :user_group_document_number %>
+            </div>
+
+            <div class="field">
+              <%= f.text_field :user_group_phone %>
             </div>
 
             <fieldset>

--- a/decidim-core/config/i18n-tasks.yml
+++ b/decidim-core/config/i18n-tasks.yml
@@ -92,6 +92,7 @@ ignore_unused:
   - devise.mailer.password_change.subject
   - activerecord.attributes.decidim/user.*
   - activerecord.models.decidim/user
+  - activemodel.attributes.user.*
   - booleans.*
   - errors.messages.file_size_is_less_than_or_equal_to
   - errors.messages.nesting_too_deep

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1,5 +1,11 @@
 ---
 en:
+  activemodel:
+    attributes:
+      user:
+        user_group_document_number: Organization document number
+        user_group_name: Organization name
+        user_group_phone: Organization phone
   activerecord:
     attributes:
       decidim/user:
@@ -62,8 +68,8 @@ en:
           sign_in: Log in
           sign_up: Sign up
           sign_up_as:
-            legend: Legend
-            user: User
+            legend: Sign up as
+            user: Individual
             user_group: Organization/Collective
           subtitle: Sign up to participate in discussions and support proposals.
           terms: the terms and conditions of use

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -61,6 +61,10 @@ en:
           already_have_an_account?: Already have an account?
           sign_in: Log in
           sign_up: Sign up
+          sign_up_as:
+            legend: Legend
+            user: User
+            user_group: Organization/Collective
           subtitle: Sign up to participate in discussions and support proposals.
           terms: the terms and conditions of use
           tos_agreement: By signing up you agree to %{link}.

--- a/decidim-core/db/migrate/20170119145359_create_user_groups.rb
+++ b/decidim-core/db/migrate/20170119145359_create_user_groups.rb
@@ -1,0 +1,11 @@
+class CreateUserGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :decidim_user_groups do |t|
+      t.string :name, null: false
+      t.string :document_number, null: false
+      t.string :phone, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/decidim-core/db/migrate/20170119150255_create_user_group_memberships.rb
+++ b/decidim-core/db/migrate/20170119150255_create_user_group_memberships.rb
@@ -1,0 +1,12 @@
+class CreateUserGroupMemberships < ActiveRecord::Migration[5.0]
+  def change
+    create_table :decidim_user_group_memberships do |t|
+      t.references :decidim_user, null: false, index: true
+      t.references :decidim_user_group, null: false, index: true
+
+      t.timestamps
+    end
+
+    add_index :decidim_user_group_memberships, [:decidim_user_id, :decidim_user_group_id], unique: true, name: "decidim_user_group_memberships_unique_user_and_group_ids"
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -113,6 +113,17 @@ FactoryGirl.define do
     end
   end
 
+  factory :user_group, class: Decidim::UserGroup do
+    name { Faker::Educator.course }
+    document_number { Faker::Number.number(8) + 'X' }
+    phone { Faker::PhoneNumber.phone_number }
+  end
+
+   factory :user_group_membership, class: Decidim::UserGroupMembership do
+    user
+    user_group
+  end
+
   factory :identity, class: Decidim::Identity do
     provider "facebook"
     sequence(:uid)

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -115,11 +115,11 @@ FactoryGirl.define do
 
   factory :user_group, class: Decidim::UserGroup do
     name { Faker::Educator.course }
-    document_number { Faker::Number.number(8) + 'X' }
+    document_number { Faker::Number.number(8) + "X" }
     phone { Faker::PhoneNumber.phone_number }
   end
 
-   factory :user_group_membership, class: Decidim::UserGroupMembership do
+  factory :user_group_membership, class: Decidim::UserGroupMembership do
     user
     user_group
   end

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Comments
+    describe CreateRegistration, :db do
+      describe "call" do
+        let(:organization) { create(:organization) }
+        let(:name) { "Username" }
+        let(:email) { "user@decidim.org" }
+        let(:password) { "password1234" }
+        let(:password_confirmation) { password }
+        let(:tos_agreement) { "1" }
+       
+        let(:form_params) do
+          {
+            "user" => {
+              "name" => name,
+              "email" => email,
+              "password" => password,
+              "password_confirmation" => password_confirmation,
+              "tos_agreement" => tos_agreement
+            }
+          }
+        end
+        let(:form) do
+          RegistrationForm.from_params(
+            form_params
+          ).with_context(
+            current_organization: organization
+          )
+        end
+        let(:command) { described_class.new(form) }
+
+        describe "when the form is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't create a user" do
+            expect do
+              command.call
+            end.to_not change { User.count }
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "creates a new user" do
+            expect(User).to receive(:create!).with({
+              name: form.name,
+              email: form.email,
+              password: form.password,
+              password_confirmation: form.password_confirmation,
+              tos_agreement: form.tos_agreement,
+              organization: organization
+            }).and_call_original
+            expect do
+              command.call
+            end.to change { User.count }.by(1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -6,20 +6,30 @@ module Decidim
     describe CreateRegistration, :db do
       describe "call" do
         let(:organization) { create(:organization) }
+
+        let(:sign_up_as) { "user" }
         let(:name) { "Username" }
         let(:email) { "user@decidim.org" }
         let(:password) { "password1234" }
         let(:password_confirmation) { password }
         let(:tos_agreement) { "1" }
+
+        let(:user_group_name) { nil }
+        let(:user_group_document_number) { nil }
+        let(:user_group_phone) { nil }
        
         let(:form_params) do
           {
             "user" => {
+              "sign_up_as" => sign_up_as,
               "name" => name,
               "email" => email,
               "password" => password,
               "password_confirmation" => password_confirmation,
-              "tos_agreement" => tos_agreement
+              "tos_agreement" => tos_agreement,
+              "user_group_name" => user_group_name,
+              "user_group_document_number" => user_group_document_number,
+              "user_group_phone" => user_group_phone
             }
           }
         end
@@ -65,6 +75,48 @@ module Decidim
             expect do
               command.call
             end.to change { User.count }.by(1)
+          end
+        end
+
+        describe "when the user is signing up as a user group" do
+          let(:sign_up_as) { "user_group" }
+
+          let(:user_group_name) { "My organization" }
+          let(:user_group_document_number) { "123456789Z" }
+          let(:user_group_phone) { "333-333-333" }
+
+          describe "when the form is not valid" do
+            before do
+              expect(form).to receive(:invalid?).and_return(true)
+            end
+
+            it "broadcasts invalid" do
+              expect { command.call }.to broadcast(:invalid)
+            end
+
+            it "doesn't create a user group" do
+              expect do
+                command.call
+              end.to_not change { UserGroup.count }
+            end
+          end
+
+          describe "when the form is valid" do
+            it "broadcasts ok" do
+              expect { command.call }.to broadcast(:ok)
+            end
+
+            it "creates a new user group" do
+              expect(UserGroup).to receive(:new).with({
+                name: form.user_group_name,
+                document_number: form.user_group_document_number,
+                phone: form.user_group_phone
+              }).and_call_original
+              expect do
+                command.call
+                expect(UserGroup.last.users.first).to eq(User.last)
+              end.to change { UserGroup.count }.by(1)
+            end
           end
         end
       end

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe Decidim::Devise::RegistrationsController, type: :controller do
+    let(:organization) { create(:organization) }
+    
+    before do
+      @request.env["decidim.current_organization"] = organization
+    end
+    
+    describe "POST create" do
+      let(:email) { "test@decidim.org" }
+      let(:params) do
+        {
+          user: {
+            sign_up_as: "user",
+            name: "User",
+            email: email,
+            password: "password1234",
+            password_confirmation: "password1234",            
+            tos_agreement: "1"
+          }
+        }
+      end
+      
+      context "when the user created is active for authentication" do
+        before do
+          expect_any_instance_of(Decidim::User)
+            .to receive(:active_for_authentication?)
+              .at_least(:once)
+              .and_return(true)
+          expect(controller).to receive(:sign_up).and_call_original
+        end
+
+        it "doesn't ask the user to confirm the email" do
+          post :create, params: params
+          expect(controller.flash.notice).not_to have_content("confirmation")
+        end
+      end
+
+      context "when the form is invalid" do
+        let(:email) { nil }
+
+        it "should render the new template" do
+          post :create, params: params        
+          expect(controller).to render_template "new"
+        end
+      end
+    end 
+  end
+end

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -149,6 +149,30 @@ describe "Authentication", type: :feature, perform_enqueued: true do
     end
   end
 
+  describe "Sign Up as a organization" do
+    it "creates a new User" do
+      find(".sign-up-link").click
+
+      within ".new_user" do
+        choose "Organization/Collective"
+
+        fill_in :user_email, with: "user@example.org"
+        fill_in :user_name, with: "Responsible Citizen"
+        fill_in :user_password, with: "123456"
+        fill_in :user_password_confirmation, with: "123456"
+
+        fill_in :user_user_group_name, with: "My organization"
+        fill_in :user_user_group_document_number, with: "12345678Z"
+        fill_in :user_user_group_phone, with: "333-333-3333"
+
+        check :user_tos_agreement
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_content("confirmation link")
+    end
+  end
+
   describe "Confirm email" do
     it "confirms the user" do
       create(:user, organization: organization)

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -6,9 +6,12 @@ module Decidim
     subject do
       described_class.from_params(
         attributes
+      ).with_context(
+        context
       )
     end
 
+    let(:organization) { create(:organization) }
     let(:sign_up_as) { "user" }
     let(:name) { "User" }
     let(:email) { "user@decidim.org" }
@@ -30,7 +33,13 @@ module Decidim
         tos_agreement: tos_agreement,
         user_group_name: user_group_name,
         user_group_document_number: user_group_document_number,
-        user_group_phone: user_group_phone
+        user_group_phone: user_group_phone,
+      }
+    end
+
+    let(:context) do
+      {
+        current_organization: organization
       }
     end
 
@@ -50,6 +59,11 @@ module Decidim
 
     context "when the email is not present" do
       let(:email) { nil }      
+      it { is_expected.to be_invalid }
+    end
+    
+    context "when the email already exists" do
+      let!(:user) { create(:user, organization: organization, email: email) }
       it { is_expected.to be_invalid }
     end
 

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -9,24 +9,38 @@ module Decidim
       )
     end
 
+    let(:sign_up_as) { "user" }
     let(:name) { "User" }
     let(:email) { "user@decidim.org" }
     let(:password) { "password1234" }
     let(:password_confirmation) { password }
     let(:tos_agreement) { "1" }
 
+    let(:user_group_name) { nil }
+    let(:user_group_document_number) { nil }
+    let(:user_group_phone) { nil }
+
     let(:attributes) do
       {
+        sign_up_as: sign_up_as,
         name: name,
         email: email,
         password: password,
         password_confirmation: password_confirmation,
-        tos_agreement: tos_agreement
+        tos_agreement: tos_agreement,
+        user_group_name: user_group_name,
+        user_group_document_number: user_group_document_number,
+        user_group_phone: user_group_phone
       }
     end
 
     context "when everything is OK" do
       it { is_expected.to be_valid }
+    end
+
+    context "when the sign_up_as is different from 'user' and 'user_group'" do
+      let(:sign_up_as) { "community" }      
+      it { is_expected.to be_invalid }
     end
 
     context "when the name is not present" do
@@ -52,6 +66,33 @@ module Decidim
     context "when the tos_agreement is not accepted" do
       let(:tos_agreement) { "0" }      
       it { is_expected.to be_invalid }
+    end
+
+    describe "when sign_up_as is 'user_group'" do
+      let(:sign_up_as) { "user_group" }
+
+      let(:user_group_name) { "My organization" }
+      let(:user_group_document_number) { "123456789Z" }
+      let(:user_group_phone) { "333-333-333" }
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when user_group_name is not present" do
+        let(:user_group_name) { nil }
+        it { is_expected.to be_invalid }
+      end
+
+      context "when user_group_document_number is not present" do
+        let(:user_group_document_number) { nil }        
+        it { is_expected.to be_invalid }
+      end
+
+      context "when user_group_phone is not present" do
+        let(:user_group_phone) { nil }        
+        it { is_expected.to be_invalid }
+      end
     end
   end
 end

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe RegistrationForm do
+    subject do
+      described_class.from_params(
+        attributes
+      )
+    end
+
+    let(:name) { "User" }
+    let(:email) { "user@decidim.org" }
+    let(:password) { "password1234" }
+    let(:password_confirmation) { password }
+    let(:tos_agreement) { "1" }
+
+    let(:attributes) do
+      {
+        name: name,
+        email: email,
+        password: password,
+        password_confirmation: password_confirmation,
+        tos_agreement: tos_agreement
+      }
+    end
+
+    context "when everything is OK" do
+      it { is_expected.to be_valid }
+    end
+
+    context "when the name is not present" do
+      let(:name) { nil }
+      it { is_expected.to be_invalid }
+    end
+
+    context "when the email is not present" do
+      let(:email) { nil }      
+      it { is_expected.to be_invalid }
+    end
+
+    context "when the password is not present" do
+      let(:password) { nil }      
+      it { is_expected.to be_invalid }
+    end
+
+    context "when the password confirmation is different from password" do
+      let(:password_confirmation) { "invalid" }      
+      it { is_expected.to be_invalid }
+    end
+
+    context "when the tos_agreement is not accepted" do
+      let(:tos_agreement) { "0" }      
+      it { is_expected.to be_invalid }
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/user_group_membership_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_membership_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe UserGroupMembership, :db do
+    subject { create(:user_group_membership) }
+
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+
+    it "has an association user" do
+      expect(subject.user).to be_a(Decidim::User)
+    end
+
+    it "has an association user group" do
+      expect(subject.user_group).to be_a(Decidim::UserGroup)
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/user_group_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  describe UserGroup, :db do
+    subject { create(:user_group) }
+
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+
+    it "has an association of users" do
+      subject.users << create(:user)
+      subject.users << create(:user)
+      expect(subject.users.count).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Users can sign up as an organization. I added more fields to the registration form which are only visible when the user chooses the 'Organization' option.

This will add a `UserGroupMembership` between the `User` created and the `UserGroup`. In the future we can add the option to invite users to an existing `UserGroup`.

This PR is just focused on the registration step.

#### :pushpin: Related Issues
- Partially implements #509 

#### :clipboard: Subtasks
- [x] Simple feature test
- [x] Modify registration template to handle both forms
- [x] Add command/form logic
- [x] Add nice javascript code
- [x] ~User groups administration~ (out of scope for this pr)

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/22144956/bf1d82b6-deff-11e6-94c5-13fd26d46a03.png)

#### :ghost: GIF
https://media.giphy.com/media/oebOcslmnSXMQ/giphy.gif