### PR TITLE
Fix faker version

### DIFF
--- a/lib/generators/decidim/templates/Gemfile.erb
+++ b/lib/generators/decidim/templates/Gemfile.erb
@@ -22,7 +22,7 @@ group :development do
   gem 'listen', '~> 3.0.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'faker', '~> 1.6.6'
+  gem 'faker', '~> <%= Gem::Specification.find_by_name("faker").version %>'
 end
 
 group :production do


### PR DESCRIPTION
#### :tophat: What? Why?
This ensures the generated app's `faker` version being used is the same as the app's, without explicitly setting it as runtime dependency.

This fixes staging environments.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/eXOVOJLkK6G7S/giphy.gif)
