### PR TITLE
Social network login improvements

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -31,8 +31,6 @@ module Decidim
         broadcast(:ok, @user)
       rescue ActiveRecord::RecordInvalid
         broadcast(:invalid)
-      rescue ActiveRecord::RecordNotUnique
-        broadcast(:error)
       end
     end
 

--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -45,6 +45,7 @@ module Decidim
                            name: form.name,
                            password: generated_password,
                            password_confirmation: generated_password,
+                           confirmed_at: Time.current,
                            organization: form.current_organization,
                            tos_agreement: "1")
 

--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -28,7 +28,9 @@ module Decidim
         end
 
         broadcast(:ok, @user)
-      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+      rescue ActiveRecord::RecordInvalid
+        broadcast(:invalid)
+      rescue ActiveRecord::RecordNotUnique
         broadcast(:error)
       end
     end

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -19,7 +19,7 @@ module Decidim
         params[:user] = user_params_from_oauth_hash if request.env["omniauth.auth"].present?
         @form = form(OmniauthRegistrationForm).from_params(params[:user])
 
-        CreateOmniauthRegistration.call(@form) do
+        CreateOmniauthRegistration.call(@form, verified_email) do
           on(:ok) do |user|
             if user.active_for_authentication?
               sign_in_and_redirect user, event: :authentication
@@ -70,19 +70,25 @@ module Decidim
 
       private
 
+      def oauth_data
+        return {} unless request.env["omniauth.auth"]
+
+        @oauth_data ||= request.env["omniauth.auth"].slice(:provider, :uid, :info)
+      end
+
       # Private: Create form params from omniauth hash
       # Since we are using trusted omniauth data we are generating a valid signature.
       def user_params_from_oauth_hash
-        oauth_data = request.env["omniauth.auth"].slice(:provider, :uid, :info)
-
         {
           provider: oauth_data[:provider],
           uid: oauth_data[:uid],
-          email: oauth_data[:info][:email],
-          email_verified: oauth_data[:info][:verified],
           name: oauth_data[:info][:name],
           oauth_signature: OmniauthRegistrationForm.create_signature(oauth_data[:provider], oauth_data[:uid])
         }
+      end
+
+      def verified_email
+        @verified_email ||= oauth_data.dig(:info, :email)
       end
     end
   end

--- a/decidim-core/app/forms/decidim/omniauth_registration_form.rb
+++ b/decidim-core/app/forms/decidim/omniauth_registration_form.rb
@@ -6,7 +6,6 @@ module Decidim
     mimic :user
 
     attribute :email, String
-    attribute :email_verified, Boolean
     attribute :name, String
     attribute :provider, String
     attribute :uid, String

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -8,6 +8,7 @@ module Decidim
     has_many :static_pages, foreign_key: "decidim_organization_id", class_name: Decidim::StaticPage, inverse_of: :organization
     has_many :scopes, -> { order(name: :asc) }, foreign_key: "decidim_organization_id", class_name: Decidim::Scope, inverse_of: :organization
     has_many :admins, -> { where("roles @> ?", "{admin}") }, foreign_key: "decidim_organization_id", class_name: Decidim::User
+    has_many :users, foreign_key: "decidim_organization_id", class_name: Decidim::User
 
     validates :name, :host, uniqueness: true
 

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -70,11 +70,20 @@ module Decidim
               password: "abcde1234",
               password_confirmation: "abcde1234",
               tos_agreement: "1",
+              confirmed_at: anything,
               organization: organization
             }).and_call_original
+
             expect do
               command.call
             end.to change { User.count }.by(1)
+          end
+
+          it "confirms the new user" do
+            command.call
+
+            user = User.find_by_email(form.email)
+            expect(user).to be_confirmed
           end
 
           it "creates a new identity" do

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -4,13 +4,13 @@ require "spec_helper"
 module Decidim
   describe Decidim::Devise::OmniauthRegistrationsController, type: :controller do
     let(:organization) { create(:organization) }
-    
+
     before do
       @request.env["decidim.current_organization"] = organization
     end
-    
+
     describe "POST create" do
-      context "when the email address is already used" do
+      context "when the unverified email address is already in use" do
         let(:provider) { "facebook" }
         let(:uid) { "12345" }
         let(:email) { "user@from-facebook.com" }
@@ -28,12 +28,12 @@ module Decidim
           }
         end
 
-        it "redirects to new user registration path" do  
-          expect(subject).to redirect_to(new_user_registration_path)
-        end
-
         it "doesn't create a new user" do
           expect(User.count).to eq(1)
+        end
+
+        it "doesn't log in" do
+          expect(controller.user_signed_in?).to be_falsey
         end
       end
     end

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -36,8 +36,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
           uid: '123545',
           info: {
             email: "user@from-facebook.com",
-            name: "Facebook User",
-            verified: verified
+            name: "Facebook User"
           }
         })
       }

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -48,30 +48,17 @@ describe "Authentication", type: :feature, perform_enqueued: true do
 
       after :each do
         OmniAuth.config.test_mode = false
-        OmniAuth.config.mock_auth[:facebook] = nil         
+        OmniAuth.config.mock_auth[:facebook] = nil
       end
 
       context "when the user has confirmed the email in facebook" do
         it "creates a new User without sending confirmation instructions" do
           find(".sign-up-link").click
 
-          click_link "Sign in with Facebook"   
+          click_link "Sign in with Facebook"
 
           expect(page).to have_content("Successfully")
-          expect(page).not_to have_content("Complete your profile")
-          expect(page).not_to have_content("confirmation link")
-        end
-      end
-
-      context "when the user has not confirmed the email in facebook" do
-        let(:verified) { false }
-
-        it "creates a new User" do
-          find(".sign-up-link").click
-
-          click_link "Sign in with Facebook"   
-
-          expect(page).to have_content("confirmation link")        
+          expect_user_logged
         end
       end
     end
@@ -103,7 +90,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
         it "redirects the user to a finish signup page" do
           find(".sign-up-link").click
 
-          click_link "Sign in with Twitter"   
+          click_link "Sign in with Twitter"
 
           expect(page).to have_content("Successfully")
           expect(page).to have_content("Complete your profile")
@@ -123,9 +110,9 @@ describe "Authentication", type: :feature, perform_enqueued: true do
         it "creates a new User" do
           find(".sign-up-link").click
 
-          click_link "Sign in with Twitter"   
+          click_link "Sign in with Twitter"
 
-          expect(page).to have_content("confirmation link")        
+          expect_user_logged
         end
       end
     end
@@ -155,9 +142,9 @@ describe "Authentication", type: :feature, perform_enqueued: true do
       it "creates a new User" do
         find(".sign-up-link").click
 
-        click_link "Sign in with Google"   
+        click_link "Sign in with Google"
 
-        expect(page).to have_content("confirmation link")        
+        expect_user_logged
       end
     end
   end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/helpers.rb
@@ -31,6 +31,10 @@ module Decidim::FeatureTestHelpers
       yield
     end
   end
+
+  def expect_user_logged
+    expect(page).to have_css(".topbar__user__logged")
+  end
 end
 
 def stripped(text)


### PR DESCRIPTION
#### :tophat: What? Why?
Since social network's oauth information only include *verified emails*, we can now do several improvements like:

- [x] Auto-confirming users logged via social networks
- [x] Auto-linking users *using only the verified emails*

We won't perform auto-linking if the user is asked for an email directly on the form.

#### :pushpin: Related Issues
- Fixes #546

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/26BRuuMVNwGyT0KiY/giphy.gif)
