### PR TITLE
Show and mange the statistics at the home page.

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -42,7 +42,8 @@ module Decidim
           welcome_text: form.welcome_text,
           homepage_image: form.homepage_image || organization.homepage_image,
           logo: form.logo || organization.logo,
-          default_locale: form.default_locale
+          default_locale: form.default_locale,
+          show_statistics: form.show_statistics
         }
       end
     end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -14,6 +14,7 @@ module Decidim
       attribute :default_locale, String
       attribute :homepage_image
       attribute :logo
+      attribute :show_statistics
 
       translatable_attribute :description, String
       translatable_attribute :welcome_text, String

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -25,3 +25,8 @@
 <div class="field">
   <%= form.file_field :logo %>
 </div>
+
+
+<div class="field">
+  <%= form.check_box :show_statistics, label: t(".questions.show_statistics") %>
+</div>

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -27,5 +27,5 @@
 </div>
 
 <div class="field">
-  <%= form.check_box :show_statistics, label: t(".questions.show_statistics") %>
+  <%= form.check_box :show_statistics %>
 </div>

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -26,7 +26,6 @@
   <%= form.file_field :logo %>
 </div>
 
-
 <div class="field">
   <%= form.check_box :show_statistics, label: t(".questions.show_statistics") %>
 </div>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -14,8 +14,8 @@ en:
         homepage_image: Homepage image
         logo: Logo
         name: Name
-        welcome_text: Welcome text
         show_statistics: Show statistics
+        welcome_text: Welcome text
       participatory_process:
         banner_image: Banner image
         description: Description

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
         logo: Logo
         name: Name
         welcome_text: Welcome text
+        show_statistics: Show statistics
       participatory_process:
         banner_image: Banner image
         description: Description

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -17,7 +17,8 @@ module Decidim
               welcome_text_ca: "Hola",
               description_en: "My description",
               description_es: "Mi descripción",
-              description_ca: "La meva descripció"
+              description_ca: "La meva descripció",
+              show_statistics: false
             }
           }
         end

--- a/decidim-admin/spec/forms/organization_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_form_spec.rb
@@ -34,7 +34,8 @@ module Decidim
             "description_en" => description[:en],
             "description_es" => description[:es],
             "description_ca" => description[:ca],
-            "homepage_image" => Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "..", "decidim-dev", "spec", "support", "city.jpeg"), "image/jpeg")
+            "homepage_image" => Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "..", "decidim-dev", "spec", "support", "city.jpeg"), "image/jpeg"),
+            "show_statics" => false
           }
         }
       end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -28,6 +28,5 @@ module Decidim
     def users
       @users ||= Decidim::User.where(organization: current_organization)
     end
-    
   end
 end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -11,7 +11,7 @@ module Decidim
 
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
-    helper_method :page, :participatory_processes
+    helper_method :page, :participatory_processes, :users
 
     def page_finder
       @page_finder ||= Decidim::PageFinder.new(params[:id], current_organization)
@@ -20,5 +20,10 @@ module Decidim
     def participatory_processes
       @participatory_processes ||= current_organization.participatory_processes.includes(:active_step).published.promoted
     end
+
+    def users
+      @users ||= Decidim::User.where(organization: current_organization)
+    end
+    
   end
 end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -11,14 +11,18 @@ module Decidim
 
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
-    helper_method :page, :participatory_processes, :users
+    helper_method :page, :participatory_processes, :promoted_participatory_processes, :users
 
     def page_finder
       @page_finder ||= Decidim::PageFinder.new(params[:id], current_organization)
     end
 
+    def promoted_participatory_processes
+      @promoted_participatory_processes ||= participatory_processes.promoted
+    end
+
     def participatory_processes
-      @participatory_processes ||= current_organization.participatory_processes.includes(:active_step).published.promoted
+      @participatory_processes ||= current_organization.participatory_processes.includes(:active_step).published
     end
 
     def users

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -118,3 +118,26 @@
     </div>
   </div>
 </section>
+ <section class="extended">
+    <div class="wrapper-home">
+      <div class="row column text-center">
+        <h3 class="heading2"><%= t(".stats.headline") %></h3>
+      </div>
+      <div class="row">
+        <div class="columns small-centered mediumlarge-10 large-8">
+          <div class="home-pam">
+            <div class="home-pam__highlight">
+              <div class="home-pam__data">
+                <h4 class="home-pam__title"><%= t(".stats.users") %></h4>
+                <span class="home-pam__number"><%= participatory_processes.count %></span>
+              </div>
+              <div class="home-pam__data">
+                <h4 class="home-pam__title"><%= t(".stats.process") %></h4>
+                <span class="home-pam__number"><%= participatory_processes.count %></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -70,6 +70,7 @@
     </div>
   </div>
 </section>
+
 <section class="extended">
   <div class="wrapper-home home-section">
     <div class="row column text-center">
@@ -117,8 +118,9 @@
       </div>
     </div>
   </div>
-</section>               
-<% if current_organization.show_statistics %>
+</section>   
+
+<% if current_organization.show_statistics? %>
   <section class="extended">
     <div class="wrapper-home">
       <div class="row column text-center">

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -39,7 +39,7 @@
     <div class="row collapse">
       <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
                   large-up-4 card-grid">
-        <% participatory_processes.each do |process| %>
+        <% promoted_participatory_processes.each do |process| %>
           <div class="column">
             <article class="card card--process card--mini">
               <%= link_to participatory_process_path(process), class: "card__link" do %>
@@ -121,7 +121,7 @@
 </section>   
 
 <% if current_organization.show_statistics? %>
-  <section class="extended">
+  <section class="extended" id="statistics">
     <div class="wrapper-home">
       <div class="row column text-center">
         <h3 class="heading2"><%= t(".stats.headline", organization: current_organization.name) %></h3>
@@ -132,11 +132,11 @@
             <div class="home-pam__highlight">
               <div class="home-pam__data">
                 <h4 class="home-pam__title"><%= t(".stats.users") %></h4>
-                <span class="home-pam__number"><%= participatory_processes.count %></span>
+                <span class="home-pam__number users-count"><%= users.count %></span>
               </div>
               <div class="home-pam__data">
-                <h4 class="home-pam__title"><%= t(".stats.process") %></h4>
-                <span class="home-pam__number"><%= participatory_processes.count %></span>
+                <h4 class="home-pam__title"><%= t(".stats.processes") %></h4>
+                <span class="home-pam__number processes-count"><%= participatory_processes.count %></span>
               </div>
             </div>
           </div>

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -117,11 +117,12 @@
       </div>
     </div>
   </div>
-</section>
- <section class="extended">
+</section>               
+<% if current_organization.show_statistics %>
+  <section class="extended">
     <div class="wrapper-home">
       <div class="row column text-center">
-        <h3 class="heading2"><%= t(".stats.headline") %></h3>
+        <h3 class="heading2"><%= t(".stats.headline", organization: current_organization.name) %></h3>
       </div>
       <div class="row">
         <div class="columns small-centered mediumlarge-10 large-8">
@@ -141,3 +142,4 @@
       </div>
     </div>
   </section>
+<% end %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -164,11 +164,11 @@ en:
       proposals_explanation: Open space for citizen proposals about what kind of city we want to live in.
       register: Register
       see_all_processes: See all processes
-      welcome: Welcome to %{organization}!
       stats:
         headline: Current state of %{organization}
-        users: Users
         processes: Processes
+        users: Users
+      welcome: Welcome to %{organization}!
   views:
     pagination:
       first: "&laquo; First"

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -165,6 +165,10 @@ en:
       register: Register
       see_all_processes: See all processes
       welcome: Welcome to %{organization}!
+      stats:
+        headline: Current state of %{organization}
+        users: Users
+        processes: Processes
   views:
     pagination:
       first: "&laquo; First"

--- a/decidim-core/db/migrate/20170119150649_add_show_statistics_to_organization.rb
+++ b/decidim-core/db/migrate/20170119150649_add_show_statistics_to_organization.rb
@@ -1,0 +1,5 @@
+class AddShowStatisticsToOrganization < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_organizations, :show_statistics, :boolean, default: false
+  end 
+end

--- a/decidim-core/db/migrate/20170119150649_add_show_statistics_to_organization.rb
+++ b/decidim-core/db/migrate/20170119150649_add_show_statistics_to_organization.rb
@@ -1,5 +1,5 @@
 class AddShowStatisticsToOrganization < ActiveRecord::Migration[5.0]
   def change
-    add_column :decidim_organizations, :show_statistics, :boolean, default: false
+    add_column :decidim_organizations, :show_statistics, :boolean, default: true
   end 
 end

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -35,5 +35,51 @@ describe "Homepage", type: :feature do
         expect(page).to have_i18n_content(static_page.content, locale: "en")
       end
     end
+
+    describe "statistics" do
+      let!(:users) { create_list(:user, 4, :confirmed, organization: organization) }
+      let!(:participatory_process){
+          create_list(
+            :participatory_process,
+            2,
+            :published,
+            organization: organization,
+            description: { en: "Description", ca: "Descripció", es: "Descripción" },
+            short_description: { en: "Short description", ca: "Descripció curta", es: "Descripción corta" }
+          )
+      }
+
+      context "when organization show_statistics attribute is false" do
+        let(:organization) { create(:organization, show_statistics: false) }
+        it "should not show the statistics block" do
+          expect(page).to_not have_content("Current state of #{organization.name}")
+        end
+      end
+      
+      context "when organization show_statistics attribute is true" do
+        let(:organization) { create(:organization, show_statistics: true) }
+
+        before do
+          visit current_path
+        end
+        
+        it "should show the statistics block" do
+          within "#statistics" do
+            expect(page).to have_content("Current state of #{organization.name}")
+            expect(page).to have_content("PROCESSES")
+            expect(page).to have_content("USERS")
+          end
+        end
+
+        it "should have the correct values for the statistics" do
+          within ".users-count" do
+            expect(page).to have_content("4")
+          end     
+          within ".processes-count" do
+            expect(page).to have_content("2")
+          end 
+        end
+      end
+    end
   end
 end

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -51,6 +51,7 @@ describe "Homepage", type: :feature do
 
       context "when organization show_statistics attribute is false" do
         let(:organization) { create(:organization, show_statistics: false) }
+        
         it "should not show the statistics block" do
           expect(page).to_not have_content("Current state of #{organization.name}")
         end
@@ -75,6 +76,7 @@ describe "Homepage", type: :feature do
           within ".users-count" do
             expect(page).to have_content("4")
           end     
+
           within ".processes-count" do
             expect(page).to have_content("2")
           end 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds to the homepage of Decidim some stats about it's current usage.

At the moment we only can show users and processes, because the other engines are not connected ( I guess it's a bad idea to create dependency between them ).

Also I added an option on the admin panel to show or not them at the home page.

#### :pushpin: Related Issues
- Related to #422

#### :clipboard: Subtasks
- [x] Show stats as the desing require.
- [x] Create the migration and add to controller the respective fields.
- [x] Basic control of the show behavior of stats on the admin panel.
- [x] Test it.

### :camera: Screenshots (optional)
![Home](https://cloud.githubusercontent.com/assets/953911/22143537/a9f88160-defa-11e6-9f0c-b02e1f371868.png)
![Admin](https://cloud.githubusercontent.com/assets/953911/22143538/aa007ab4-defa-11e6-915e-1b5e5d41e4a2.png)

#### :ghost: GIF
![](https://media.giphy.com/media/rK0DqYU6Vesda/giphy.gif)
