### PR TITLE
Move current participatory process to a concern

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/needs_participatory_process.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_participatory_process.rb
@@ -12,19 +12,14 @@ module Decidim
 
     included do
       after_action :verify_participatory_process
-      helper_method :current_participatory_process, :participatory_process
-
-      def participatory_process
-        current_participatory_process
-      end
+      helper_method :current_participatory_process
 
       # Public: Finds the current Participatory Process given this controller's
       # context.
       #
       # Returns the current ParticipatoryProcess.
       def current_participatory_process
-        @current_participatory_process ||=
-          current_organization.participatory_processes.find_by(id: params[:participatory_process_id] || params[:id])
+        @current_participatory_process ||= current_organization.participatory_processes.find_by(id: params[:participatory_process_id] || params[:id])
       end
 
       private

--- a/decidim-core/app/controllers/concerns/decidim/needs_participatory_process.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_participatory_process.rb
@@ -12,7 +12,11 @@ module Decidim
 
     included do
       after_action :verify_participatory_process
-      helper_method :current_participatory_process
+      helper_method :current_participatory_process, :participatory_process
+
+      def participatory_process
+        current_participatory_process
+      end
 
       # Public: Finds the current Participatory Process given this controller's
       # context.
@@ -20,13 +24,13 @@ module Decidim
       # Returns the current ParticipatoryProcess.
       def current_participatory_process
         @current_participatory_process ||=
-          current_organization.participatory_processes.find_by(id: params[:participatory_process_id])
+          current_organization.participatory_processes.find_by(id: params[:participatory_process_id] || params[:id])
       end
 
       private
 
       def verify_participatory_process
-        raise ActionController::RoutingError, "Not Found" unless current_participatory_process
+        raise ActionController::RoutingError, "Participatory process not found." unless current_participatory_process
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/participatory_process_steps_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_process_steps_controller.rb
@@ -7,19 +7,10 @@ module Decidim
   class ParticipatoryProcessStepsController < ApplicationController
     helper_method :participatory_process, :current_participatory_process
     layout "layouts/decidim/participatory_process", only: [:index]
+    include NeedsParticipatoryProcess
 
     def index
       authorize! :read, ParticipatoryProcess
-    end
-
-    private
-
-    def current_participatory_process
-      participatory_process
-    end
-
-    def participatory_process
-      @participatory_process ||= ParticipatoryProcess.find(params[:participatory_process_id])
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -18,7 +18,7 @@ module Decidim
     end
 
     def show
-      authorize! :read, participatory_process
+      authorize! :read, current_participatory_process
     end
 
     private

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -5,9 +5,13 @@ module Decidim
   # A controller that holds the logic to show ParticipatoryProcesses in a
   # public layout.
   class ParticipatoryProcessesController < ApplicationController
-    helper_method :participatory_processes, :participatory_process, :promoted_processes, :current_participatory_process
+    include NeedsParticipatoryProcess
 
     layout "layouts/decidim/participatory_process", only: [:show]
+
+    helper_method :participatory_processes, :promoted_processes
+
+    skip_after_action :verify_participatory_process , only: [:index]
 
     def index
       authorize! :read, ParticipatoryProcess
@@ -18,14 +22,6 @@ module Decidim
     end
 
     private
-
-    def current_participatory_process
-      participatory_process
-    end
-
-    def participatory_process
-      @participatory_process ||= ParticipatoryProcess.find(params[:id])
-    end
 
     def participatory_processes
       @participatory_processes ||= current_organization.participatory_processes.includes(:active_step).published

--- a/decidim-core/app/views/decidim/participatory_process_steps/_timeline.html.erb
+++ b/decidim-core/app/views/decidim/participatory_process_steps/_timeline.html.erb
@@ -1,6 +1,6 @@
 <ol class="timeline">
   <% past_step = true %>
-  <% participatory_process.steps.each do |step| %>
+  <% current_participatory_process.steps.each do |step| %>
     <%= render step, step_status_class: step_class(step, past_step)  %>
     <% past_step = false if step.active? %>
   <% end %>

--- a/decidim-core/app/views/decidim/participatory_processes/show.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/show.html.erb
@@ -3,18 +3,18 @@
     <div class="columns medium-7 mediumlarge-8">
       <div class="section">
         <div class="lead">
-          <%== translated_attribute(participatory_process.short_description) %>
+          <%== translated_attribute(current_participatory_process.short_description) %>
         </div>
-        <%== translated_attribute(participatory_process.description) %>
+        <%== translated_attribute(current_participatory_process.description) %>
       </div>
     </div>
   </div>
 </div>
-<% if participatory_process.attachments.any? %>
+<% if current_participatory_process.attachments.any? %>
   <div class="row attachments">
     <div class="columns large-8">
-      <%= render partial: "documents", locals: { documents: participatory_process.documents } %>
-      <%= render partial: "photos", locals: { photos: participatory_process.photos } %>
+      <%= render partial: "documents", locals: { documents: current_participatory_process.documents } %>
+      <%= render partial: "photos", locals: { photos: current_participatory_process.photos } %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
Implements https://github.com/AjuntamentdeBarcelona/decidim/issues/551

#### :clipboard: Subtasks
- [x] Remove duplicity at controllers, use a concern instead
- [x] Remove `participatory_processs` method to only use `current_participatory_process`

#### :ghost: GIF
![](https://media.giphy.com/media/QH0vkcwYwjEPu/giphy.gif)
