### PR TITLE
Admin can verify user groups

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require_dependency "decidim/admin/application_controller"
 
 module Decidim
   module Admin

--- a/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/user_groups_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require_dependency "decidim/admin/application_controller"
+
+module Decidim
+  module Admin
+    # Controller that allows managing user groups at the admin panel.
+    #
+    class UserGroupsController < ApplicationController
+      def index
+        authorize! :index, UserGroup
+        @user_groups = collection
+      end
+
+      def verify
+        @user_group = collection.find(params[:id])
+        authorize! :verify, @user_group
+
+        @user_group.verify!
+
+        flash[:notice] = I18n.t("user_groups.verify.success", scope: "decidim.admin")
+        redirect_to decidim_admin.user_groups_path
+      end
+
+      private
+
+      def collection
+        UserGroup
+          .includes(:memberships)
+          .where(decidim_user_group_memberships: { decidim_user_id: current_organization.users })
+      end
+    end
+  end
+end

--- a/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
@@ -31,6 +31,8 @@ module Decidim
           can [:destroy], [User] do |user_to_destroy|
             user != user_to_destroy
           end
+
+          can [:index, :verify], UserGroup
         end
       end
     end

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title do %>
+  <h2><%= t "decidim.admin.titles.user_groups" %></h2>
+<% end %>
+
+<table class="stack user-groups">
+  <thead>
+    <tr>
+      <th><%= t("models.user_group.fields.name", scope: "decidim.admin") %></th>
+      <th><%= t("models.user_group.fields.document_number", scope: "decidim.admin") %></th>
+      <th><%= t("models.user_group.fields.phone", scope: "decidim.admin") %></th>
+      <th><%= t("models.user_group.fields.users_count", scope: "decidim.admin") %></th>
+      <th><%= t("models.user_group.fields.created_at", scope: "decidim.admin") %></th>
+      <th class="actions"><%= t("actions.title", scope: "decidim.admin") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @user_groups.each do |user_group| %>
+      <tr data-user-group-id="<%= user_group.id %>">
+        <td><%= user_group.name %></td>
+        <td><%= user_group.document_number %></td>
+        <td><%= user_group.phone %></td>
+        <td><%= user_group.users.size %></td>
+        <td><%= l user_group.created_at, format: :short %></td>
+        <td class="actions">
+          <% if can?(:verify, user_group) && !user_group.verified? %>
+            <%= button_to t("actions.verify", scope: "decidim.admin"), decidim_admin.verify_user_group_path(user_group), method: :put %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
@@ -12,6 +12,7 @@
   <%= active_link_to t("menu.static_pages", scope: "decidim.admin"), decidim_admin.static_pages_path, active: :inclusive if can? :read, Decidim::StaticPage %>
   <%= active_link_to t("menu.scopes", scope: "decidim.admin"), decidim_admin.scopes_path, active: :inclusive if can? :read, Decidim::Scope %>
   <%= active_link_to t("menu.users", scope: "decidim.admin"), decidim_admin.users_path, active: :inclusive if can? :read, Decidim::User %>
+  <%= active_link_to t("menu.user_groups", scope: "decidim.admin"), decidim_admin.user_groups_path, active: :inclusive if can? :index, Decidim::UserGroup %>
   <%= active_link_to t("menu.settings", scope: "decidim.admin"), decidim_admin.edit_organization_path, active: :inclusive if can? :read, current_organization %>
 </nav>
 

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -66,6 +66,7 @@ en:
         resend_invitation: Resend invitation
         title: Actions
         unpublish: Unpublish
+        verify: Verify
       categories:
         create:
           error: There was an error creating this category.
@@ -137,6 +138,7 @@ en:
         scopes: Scopes
         settings: Settings
         static_pages: Pages
+        user_groups: User groups
         users: Admin users
       models:
         category:
@@ -184,6 +186,13 @@ en:
             last_sign_in_at: Last sign in date
             name: Name
           name: User
+        user_group:
+          fields:
+            created_at: Created at
+            document_number: Document number
+            name: Name
+            phone: Phone
+            users_count: Users count
       organization:
         edit:
           title: Edit organization
@@ -295,7 +304,11 @@ en:
         participatory_processes: Participatory processes
         scopes: Scopes
         static_pages: Pages
+        user_groups: User groups
         users: Users
+      user_groups:
+        verify:
+          success: The user group was verified successfully.
       users:
         create:
           error: There was an error when inviting this user.

--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -38,6 +38,12 @@ Decidim::Admin::Engine.routes.draw do
       end
     end
 
+    resources :user_groups, only: [:index] do
+      member do
+        put :verify
+      end
+    end
+
     root to: "dashboard#show"
   end
 end

--- a/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manage user groups", type: :feature do
+  let(:organization) { create(:organization) }
+  let!(:user_groups) { create_list(:user_group_membership, 10, user: create(:user, organization: organization)) }
+
+  it "verify a user group" do
+    visit decidim_admin.user_groups_path
+
+    click_button "Verify", match: :first
+
+    within "table.user-groups tr:first" do
+      expect(page).not_to have_content("Verify")
+    end
+  end
+end

--- a/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
@@ -2,18 +2,23 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require_relative "../shared/participatory_admin_shared_context"
 
 describe "Admin manage user groups", type: :feature do
-  let(:organization) { create(:organization) }
+  include_context "participatory process admin"
   let!(:user_groups) { create_list(:user_group_membership, 10, user: create(:user, organization: organization)) }
 
-  it "verify a user group" do
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
     visit decidim_admin.user_groups_path
+  end
 
+  it "verify a user group" do
     click_button "Verify", match: :first
 
-    within "table.user-groups tr:first" do
-      expect(page).not_to have_content("Verify")
-    end
+    expect(page).not_to have_selector(".actions button", match: :first)
+    
+    expect(page).to have_content("verified successfully")
   end
 end

--- a/decidim-admin/spec/models/abilities/admin_user_spec.rb
+++ b/decidim-admin/spec/models/abilities/admin_user_spec.rb
@@ -32,6 +32,9 @@ describe Decidim::Admin::Abilities::AdminUser do
   it { is_expected.to be_able_to(:read, Decidim::User) }
   it { is_expected.to be_able_to(:invite, Decidim::User) }
 
+  it { is_expected.to be_able_to(:index, Decidim::UserGroup) }  
+  it { is_expected.to be_able_to(:verify, Decidim::UserGroup) }  
+
   context "when a page is a default one" do
     let(:page) { build(:static_page, :default) }
     let(:form) { Decidim::Admin::StaticPageForm.new(slug: page.slug) }

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -9,5 +9,10 @@ module Decidim
     validates :name, presence: true
     validates :document_number, presence: true
     validates :phone, presence: true
+
+    # Public: Mark the user group as verified
+    def verify!
+      update_attribute(:verified, true)
+    end
   end
 end

--- a/decidim-core/db/migrate/20170120120733_add_user_groups_verified.rb
+++ b/decidim-core/db/migrate/20170120120733_add_user_groups_verified.rb
@@ -1,0 +1,5 @@
+class AddUserGroupsVerified < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_user_groups, :verified, :boolean, default: false
+  end
+end

--- a/decidim-core/spec/models/decidim/user_group_spec.rb
+++ b/decidim-core/spec/models/decidim/user_group_spec.rb
@@ -14,5 +14,12 @@ module Decidim
       subject.users << create(:user)
       expect(subject.users.count).to eq(2)
     end
+
+    describe "#verify!" do
+      it "mark the user group as verified" do
+        subject.verify!
+        expect(subject).to be_verified
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

An admin should be able to verify registered user groups.

#### :pushpin: Related Issues
- Continues #509 implementation

#### :clipboard: Subtasks
- [x] Simple feature test
- [x] Verify user groups through administration

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/22151009/656a75ae-df1c-11e6-9391-b4b18d158e95.png)


#### :ghost: GIF
![](https://media.giphy.com/media/l0Exk8EUzSLsrErEQ/giphy.gif)
