### PR TITLE
Make registration errors more explicit

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -29,8 +29,8 @@ module Decidim
         end
 
         broadcast(:ok, @user)
-      rescue ActiveRecord::RecordInvalid
-        broadcast(:invalid)
+      rescue ActiveRecord::RecordInvalid => error
+        broadcast(:error, error.record)
       end
     end
 

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -37,9 +37,12 @@ module Decidim
             render :new
           end
 
-          on(:error) do
-            redirect_to decidim.new_user_registration_path
-            set_flash_message :alert, :failure, kind: @form.provider, reason: t("decidim.devise.omniauth_registrations.create.email_already_exists")
+          on(:error) do |user|
+            if user.errors[:email]
+              set_flash_message :alert, :failure, kind: @form.provider.capitalize, reason: t("decidim.devise.omniauth_registrations.create.email_already_exists")
+            end
+
+            render :new
           end
         end
       end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -19,8 +19,9 @@ module Decidim
     validates :organization, :name, presence: true
     validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
-    validate :all_roles_are_valid
     validates :avatar, file_size: { less_than_or_equal_to: 5.megabytes }
+    validates :email, uniqueness: { scope: :organization }
+    validate :all_roles_are_valid
     mount_uploader :avatar, Decidim::AvatarUploader
 
     # Public: Allows customizing the invitation instruction email content when

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -73,7 +73,7 @@ en:
           email_already_exists: Another account is using the same email address
         new:
           complete_profile: Complete profile
-          sign_up: Complete your profile
+          sign_up: Please complete your profile
           subtitle: Please fill in the following form in order to complete the sign up
           username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       registrations:

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -95,7 +95,7 @@ module Decidim
 
               it "doesn't link a previously existing user" do
                 user = create(:user, email: email, organization: organization)
-                expect { command.call }.to broadcast(:invalid)
+                expect { command.call }.to broadcast(:error)
 
                 expect(user.identities.length).to eq(0)
               end

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -83,7 +83,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
 
       after :each do
         OmniAuth.config.test_mode = false
-        OmniAuth.config.mock_auth[:twitter] = nil         
+        OmniAuth.config.mock_auth[:twitter] = nil
       end
 
       context "when the response doesn't include the email" do
@@ -93,14 +93,34 @@ describe "Authentication", type: :feature, perform_enqueued: true do
           click_link "Sign in with Twitter"
 
           expect(page).to have_content("Successfully")
-          expect(page).to have_content("Complete your profile")
+          expect(page).to have_content("Please complete your profile")
 
           within ".new_user" do
-            fill_in :user_email, with: "user@from-twitter.com"          
+            fill_in :user_email, with: "user@from-twitter.com"
             find("*[type=submit]").click
           end
 
           expect(page).to have_content("confirmation link")
+        end
+
+        context "and a user already exists with the given email" do
+          it "doesn't allow it" do
+            create(:user, :confirmed, email: "user@from-twitter.com", organization: organization)
+            find(".sign-up-link").click
+
+            click_link "Sign in with Twitter"
+
+            expect(page).to have_content("Successfully")
+            expect(page).to have_content("Please complete your profile")
+
+            within ".new_user" do
+              fill_in :user_email, with: "user@from-twitter.com"
+              find("*[type=submit]").click
+            end
+
+            expect(page).to have_content("Please complete your profile")
+            expect(page).to have_content("Another account is using the same email address")
+          end
         end
       end
 
@@ -136,7 +156,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
 
       after :each do
         OmniAuth.config.test_mode = false
-        OmniAuth.config.mock_auth[:google_oauth2] = nil         
+        OmniAuth.config.mock_auth[:google_oauth2] = nil
       end
 
       it "creates a new User" do
@@ -291,14 +311,14 @@ describe "Authentication", type: :feature, perform_enqueued: true do
 
     after :each do
       OmniAuth.config.test_mode = false
-      OmniAuth.config.mock_auth[:facebook] = nil         
+      OmniAuth.config.mock_auth[:facebook] = nil
     end
 
     describe "Sign in" do
       it "authenticates an existing User" do
         find(".sign-in-link").click
-        
-        click_link "Sign in with Facebook"   
+
+        click_link "Sign in with Facebook"
 
         expect(page).to have_content("Successfully")
         expect(page).to have_content(user.name)


### PR DESCRIPTION
#### :tophat: What? Why?
This makes registration messages more explicit by distinguishing different types of errors.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3o72Fc3UcPKgmPbDSU/giphy.gif)
