### PR TITLE
Broadcast the new user on InviteUser command

### DIFF
--- a/decidim-core/app/commands/decidim/invite_user.rb
+++ b/decidim-core/app/commands/decidim/invite_user.rb
@@ -18,7 +18,7 @@ module Decidim
         invite_user
       end
 
-      broadcast(:ok)
+      broadcast(:ok, user)
     end
 
     private
@@ -35,7 +35,7 @@ module Decidim
     end
 
     def invite_user
-      Decidim::User.invite!(
+      @user = Decidim::User.invite!(
         {
           name: form.name,
           email: form.email.downcase,

--- a/decidim-core/spec/commands/decidim/invite_user_spec.rb
+++ b/decidim-core/spec/commands/decidim/invite_user_spec.rb
@@ -19,13 +19,19 @@ module Decidim
 
     context "when a user with the given email already exists" do
       before do
-        create(:user, email: form.email, organization: organization)
+        @user = create(:user, email: form.email, organization: organization)
       end
 
       it "does not create another user" do
         expect do
           command.call
         end.to_not change { User.count }
+      end
+
+      it "broadcasts ok and the user" do
+        expect do
+          command.call
+        end.to broadcast(:ok, @user)
       end
     end
 
@@ -42,6 +48,12 @@ module Decidim
         end.to change { User.count }.by(1)
 
         expect(invited_user.email).to eq(form.email)
+      end
+
+      it "broadcasts ok and the user" do
+        expect do
+          command.call
+        end.to broadcast(:ok)
       end
 
       it "sends an invitation email with the given instructions" do


### PR DESCRIPTION
#### :tophat: What? Why?
In order to use the `InviteUser` command, sometimes we need the invited user. This PR broadcasts it.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None