### PR TITLE
Don't include layout on API controllers

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -42,7 +42,7 @@ module Decidim
 
       initializer "decidim.action_controller" do |_app|
         ActiveSupport.on_load :action_controller do
-          helper Decidim::LayoutHelper
+          helper Decidim::LayoutHelper if respond_to?(:helper)
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Due to the fact that `Rails 5`'s controllers were split in two (API and Base), we can't safely assume all controllers have the `helper` method.

Because of that, we need to check it on boot time - otherwise New Relic (and potentially other integrations) fails.

#### :pushpin: Related Issues
- Related to https://github.com/weppos/breadcrumbs_on_rails/issues/92

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/IRei50IubzMqs/giphy.gif)
