### PR TITLE
Don't delegate file type to file, instead use the extension

### DIFF
--- a/decidim-core/app/models/decidim/participatory_process_attachment.rb
+++ b/decidim-core/app/models/decidim/participatory_process_attachment.rb
@@ -26,7 +26,7 @@ module Decidim
     # Which kind of file this is.
     #
     # Returns String.
-    def file_extension
+    def file_type
       file.url&.split(".").last&.downcase
     end
 

--- a/decidim-core/app/models/decidim/participatory_process_attachment.rb
+++ b/decidim-core/app/models/decidim/participatory_process_attachment.rb
@@ -26,8 +26,8 @@ module Decidim
     # Which kind of file this is.
     #
     # Returns String.
-    def file_type
-      file.file.extension
+    def file_extension
+      file.url&.split(".").last&.downcase
     end
 
     # The URL to download the file.


### PR DESCRIPTION
#### :tophat: What? Why?
This uses the file stored extension instead of the delegating to the underlying file. Doing this, we spare a `HEAD` request when using S3, as we don't have the make the roundtrip to the server to get that information.

#### :pushpin: Related Issues
* https://github.com/HospitaletDeLlobregat/decidim-hospitalet/pull/45

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/4pGNTdHmQ5Vv2/giphy.gif)
