### PR TITLE
Use HTML email always

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/action_mailer.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/action_mailer.rb
@@ -20,7 +20,7 @@ module MailerHelpers
   end
 
   def last_email_body
-    (last_email.body || last_email.html_part.body).encoded
+    last_email.html_part.body.encoded
   end
 
   def last_email_link

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/action_mailer.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/action_mailer.rb
@@ -20,7 +20,7 @@ module MailerHelpers
   end
 
   def last_email_body
-    last_email.html_part.body.encoded
+    (last_email.try(:html_part).try(:body) || last_email.body).encoded
   end
 
   def last_email_link


### PR DESCRIPTION
#### :tophat: What? Why?
Always use HTML part in emails to parse the content.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None