### PR TITLE
Redirect to 404 when feature is not found

### DIFF
--- a/decidim-admin/config/routes.rb
+++ b/decidim-admin/config/routes.rb
@@ -27,7 +27,7 @@ Decidim::Admin::Engine.routes.draw do
         end
       end
 
-      get "/" => proc { raise "Feature not found" }, as: :manage_feature
+      get "/", to: redirect("/404"), as: :manage_feature
     end
 
     resources :static_pages

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -33,7 +33,7 @@ Decidim::Core::Engine.routes.draw do
       end
     end
 
-    get "/" => proc { raise "Feature not found" }, as: :feature
+    get "/", to: redirect("/404"), as: :feature
   end
 
   authenticate(:user) do


### PR DESCRIPTION
#### :tophat: What? Why?
Redirects the user to a 404 error page when the feature is not found. Note that, since the admin does not have a 404 page, the user is redirected to the main 404 error page when the error occurs inside the admin.

#### :pushpin: Related Issues
- Fixes #572

#### :clipboard: Subtasks
None
