### PR TITLE
Add missing locales to authentication

### DIFF
--- a/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -16,12 +16,12 @@
           <%= form_for(@form, as: resource_name, url: omniauth_registrations_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help"), label: t(".name") %>
+                <%= f.text_field :name, help_text: t(".username_help"), label: t(".username_help") %>
               </div>
             </div>
 
             <div class="field">
-              <%= f.email_field :email, label: t(".email") %>
+              <%= f.email_field :email %>
             </div>
 
             <%= f.hidden_field :uid %>

--- a/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -16,12 +16,12 @@
           <%= form_for(@form, as: resource_name, url: omniauth_registrations_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t("devise.registrations.new.username_help") %>
+                <%= f.text_field :name, help_text: t(".username_help"), label: t(".name") %>
               </div>
             </div>
 
             <div class="field">
-              <%= f.email_field :email %>
+              <%= f.email_field :email, label: t(".email") %>
             </div>
 
             <%= f.hidden_field :uid %>

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -25,33 +25,33 @@
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help") %>
+                <%= f.text_field :name, help_text: t(".username_help"), label: t("devise.registrations.new.name")  %>
               </div>
             </div>
 
             <div class="field">
-              <%= f.email_field :email %>
+              <%= f.email_field :email, label: t("devise.registrations.new.email") %>
             </div>
 
             <div class="field">
-              <%= f.password_field :password, autocomplete: "off" %>
+              <%= f.password_field :password, autocomplete: "off", label: t("devise.registrations.new.password") %>
             </div>
 
             <div class="field">
-              <%= f.password_field :password_confirmation, autocomplete: "off" %>
+              <%= f.password_field :password_confirmation, autocomplete: "off", label: t("devise.registrations.new.password_confirmation") %>
             </div>
 
             <div class="user-group-fields">
               <div class="field">
-                <%= f.text_field :user_group_name %>
+                <%= f.text_field :user_group_name, label: t("devise.registrations.new.user_group_name") %>
               </div>
 
               <div class="field">
-                <%= f.text_field :user_group_document_number %>
+                <%= f.text_field :user_group_document_number, label: t("devise.registrations.new.user_group_document_number")%>
               </div>
 
               <div class="field">
-                <%= f.text_field :user_group_phone %>
+                <%= f.text_field :user_group_phone, label: t("devise.registrations.new.user_group_phone") %>
               </div>
             </div>
 

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -38,7 +38,7 @@
             </div>
 
             <div class="field">
-              <%= f.password_field :password_confirmation%>
+              <%= f.password_field :password_confirmation %>
             </div>
 
             <div class="user-group-fields">
@@ -47,7 +47,7 @@
               </div>
 
               <div class="field">
-                <%= f.text_field :user_group_document_number%>
+                <%= f.text_field :user_group_document_number %>
               </div>
 
               <div class="field">

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -25,33 +25,33 @@
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help"), label: t("devise.registrations.new.name")  %>
+                <%= f.text_field :name, help_text: t(".username_help") %>
               </div>
             </div>
 
             <div class="field">
-              <%= f.email_field :email, label: t("devise.registrations.new.email") %>
+              <%= f.email_field :email %>
             </div>
 
             <div class="field">
-              <%= f.password_field :password, autocomplete: "off", label: t("devise.registrations.new.password") %>
+              <%= f.password_field :password, autocomplete: "off" %>
             </div>
 
             <div class="field">
-              <%= f.password_field :password_confirmation, autocomplete: "off", label: t("devise.registrations.new.password_confirmation") %>
+              <%= f.password_field :password_confirmation%>
             </div>
 
             <div class="user-group-fields">
               <div class="field">
-                <%= f.text_field :user_group_name, label: t("devise.registrations.new.user_group_name") %>
+                <%= f.text_field :user_group_name %>
               </div>
 
               <div class="field">
-                <%= f.text_field :user_group_document_number, label: t("devise.registrations.new.user_group_document_number")%>
+                <%= f.text_field :user_group_document_number%>
               </div>
 
               <div class="field">
-                <%= f.text_field :user_group_phone, label: t("devise.registrations.new.user_group_phone") %>
+                <%= f.text_field :user_group_phone %>
               </div>
             </div>
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -3,21 +3,13 @@ en:
   activemodel:
     attributes:
       user:
-        user_group_document_number: Organization document number
-        user_group_name: Organization name
-        user_group_phone: Organization phone
-  activerecord:
-    attributes:
-      decidim/user:
-        current_password: Current password
         email: Email
         name: Username
         password: Password
         password_confirmation: Password confirmation
-        remember_me: Remember me
-        tos_agreement: Terms & conditions
-    models:
-      decidim/user: User
+        user_group_document_number: Organization document number
+        user_group_name: Organization name
+        user_group_phone: Organization phone
   booleans:
     'false': 'No'
     'true': 'Yes'
@@ -60,24 +52,18 @@ en:
           email_already_exists: Another account is using the same email address
         new:
           complete_profile: Complete profile
-          email: Email
-          name: Username
           sign_up: Complete your profile
           subtitle: Please fill in the following form in order to complete the sign up
           username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       registrations:
         new:
           already_have_an_account?: Already have an account?
-          email: Email
-          name: Username
-          password: Password
-          password_confirmation: Password confirmation
           sign_in: Log in
           sign_up: Sign up
           sign_up_as:
             legend: Sign up as
             user: Individual
-            user_group: Organization/
+            user_group: Organization/Collective
           subtitle: Sign up to participate in discussions and support proposals.
           terms: the terms and conditions of use
           tos_agreement: By signing up you agree to %{link}.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -62,6 +62,9 @@ en:
           complete_profile: Complete profile
           sign_up: Complete your profile
           subtitle: Please fill in the following form in order to complete the sign up
+          name: Username
+          email: Email
+          username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       registrations:
         new:
           already_have_an_account?: Already have an account?
@@ -70,7 +73,14 @@ en:
           sign_up_as:
             legend: Sign up as
             user: Individual
-            user_group: Organization/Collective
+            user_group: Organization/
+          name: Username
+          email: Email
+          password: Password
+          password_confirmation: Password confirmation
+          user_group_document_number: Organization document number
+          user_group_name: Organization name
+          user_group_phone: Organization phone
           subtitle: Sign up to participate in discussions and support proposals.
           terms: the terms and conditions of use
           tos_agreement: By signing up you agree to %{link}.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -60,30 +60,30 @@ en:
           email_already_exists: Another account is using the same email address
         new:
           complete_profile: Complete profile
+          email: Email
+          name: Username
           sign_up: Complete your profile
           subtitle: Please fill in the following form in order to complete the sign up
-          name: Username
-          email: Email
           username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       registrations:
         new:
           already_have_an_account?: Already have an account?
+          email: Email
+          name: Username
+          password: Password
+          password_confirmation: Password confirmation
           sign_in: Log in
           sign_up: Sign up
           sign_up_as:
             legend: Sign up as
             user: Individual
             user_group: Organization/
-          name: Username
-          email: Email
-          password: Password
-          password_confirmation: Password confirmation
-          user_group_document_number: Organization document number
-          user_group_name: Organization name
-          user_group_phone: Organization phone
           subtitle: Sign up to participate in discussions and support proposals.
           terms: the terms and conditions of use
           tos_agreement: By signing up you agree to %{link}.
+          user_group_document_number: Organization document number
+          user_group_name: Organization name
+          user_group_phone: Organization phone
           username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       sessions:
         new:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -67,9 +67,6 @@ en:
           subtitle: Sign up to participate in discussions and support proposals.
           terms: the terms and conditions of use
           tos_agreement: By signing up you agree to %{link}.
-          user_group_document_number: Organization document number
-          user_group_name: Organization name
-          user_group_phone: Organization phone
           username_help: Public name that appears on your posts. With the aim of guaranteeing the anonymity, can be any name.
       sessions:
         new:


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds some missing locales tags and labels where missing on the authentication process.

#### :pushpin: Related Issues
- Fixes #579, #580 

#### :clipboard: Subtasks
- [x] Add locales to Sing up form
- [x] Add locales to Oauth profile completion.


#### :ghost: GIF
![](https://media.giphy.com/media/iUFgLi6nkFmFy/giphy.gif)
