### PR TITLE
Use step title instead of hardcoded title

### DIFF
--- a/decidim-core/app/views/decidim/participatory_process_steps/_participatory_process_step.html.erb
+++ b/decidim-core/app/views/decidim/participatory_process_steps/_participatory_process_step.html.erb
@@ -7,7 +7,7 @@
       <span class="timeline__date text-small">
         <%= participatory_process_step_dates(participatory_process_step) %>
       </span>
-      <h6 class="timeline__title heading6"><%= t('.info') %></h6>
+      <h6 class="timeline__title heading6"><%= translated_attribute(participatory_process_step.title) %></h6>
     </div>
     <div class="timeline__content">
       <%= translated_attribute(participatory_process_step.description).html_safe %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -88,8 +88,6 @@ en:
     participatory_process_steps:
       index:
         process_steps: Process steps
-      participatory_process_step:
-        info: Information
     participatory_processes:
       documents:
         related_documents: Related documents

--- a/decidim-core/spec/features/participatory_process_steps_spec.rb
+++ b/decidim-core/spec/features/participatory_process_steps_spec.rb
@@ -19,13 +19,16 @@ describe "Participatory Process Steps", type: :feature do
 
   context "when there are some processes with steps" do
     before do
-      create_list(:participatory_process_step, 3, participatory_process: participatory_process)
+      @steps = create_list(:participatory_process_step, 3, participatory_process: participatory_process)
       participatory_process.steps.first.update_attribute(:active, true)
       visit decidim.participatory_process_participatory_process_steps_path(participatory_process)
     end
 
     it "lists all the steps" do
       expect(page).to have_css(".timeline__item", count: 3)
+      @steps.each do |step|
+        expect(page).to have_content(/#{translated(step.title)}/i)
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
PR #518 added the steps view, but instead of showing the title of each step it showed a hardcoded title ("Information"). This PR removes the hardcoded value and shows the correct step title.

#### :pushpin: Related Issues
- Related to #518 
- Fixes #594 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/oiW0r8h.png)
