### PR TITLE
Fix attachment uploaders to prevent the file (potentially S3) on initialize

### DIFF
--- a/decidim-core/app/uploaders/decidim/attachment_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/attachment_uploader.rb
@@ -39,7 +39,8 @@ module Decidim
     #
     # Returns a Boolean.
     def image?(new_file)
-      new_file.content_type.start_with? "image"
+      content_type = model.try(:content_type) || new_file.content_type
+      content_type.to_s.start_with? "image"
     end
 
     # Copies the content type and file size to the model where this is mounted.


### PR DESCRIPTION
#### :tophat: What? Why?
Checking `new_file.content_type` on the `version` block was triggering calling S3, even on initialize. This fixes it!

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/xT8qBrtlhoV1wl7yUg/giphy.gif)
