### PR TITLE
Add missing translations

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_process_header_steps.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_process_header_steps.html.erb
@@ -13,7 +13,7 @@
             <% past_step = false if step.active? %>
           <% end %>
         </ol>
-        <span class="phase-current">Fase <%= participatory_process.active_step.position + 1 %> de <%= current_participatory_process.steps.count %></span>
+        <span class="phase-current"><%= t(".step", current: (participatory_process.active_step.position + 1), total: current_participatory_process.steps.count) %></span>
       </div>
       <div>
         <span class="phase-title"><%= translated_attribute participatory_process.active_step.title %></span>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
       process_header:
         process_menu_item: The process
       process_header_steps:
+        step: Step %{current} of %{total}
         view_steps: View steps
       user_menu:
         admin_dashboard: Admin dashboard

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -3,7 +3,11 @@ en:
   activemodel:
     attributes:
       proposal:
-        user_group_id: "Create proposal as"
+        body: Body
+        category: Category
+        scope: Scope
+        title: Title
+        user_group_id: Create proposal as
   decidim:
     features:
       proposals:


### PR DESCRIPTION
#### :tophat: What? Why?

I just realised that there was a text in Catalan and we weren't providing the keys to translate the proposal model, so it was using the default (the proposal form in Catalan had some stuff in English).

