### PR TITLE
Add a weight field to features

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_feature.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_feature.rb
@@ -35,7 +35,8 @@ module Decidim
         @feature.update_attributes(
           name: form.name,
           settings: form.settings,
-          step_settings: form.step_settings
+          step_settings: form.step_settings,
+          weight: form.weight
         )
       end
 

--- a/decidim-admin/app/forms/decidim/admin/feature_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/feature_form.rb
@@ -14,6 +14,7 @@ module Decidim
 
       attribute :settings, Object
       attribute :manifest
+      attribute :weight, Integer, default: 0
 
       attribute :step_settings, Hash[String => Object]
       attribute :participatory_process

--- a/decidim-admin/app/views/decidim/admin/features/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_form.html.erb
@@ -1,5 +1,6 @@
 <div class="field">
   <%= form.translated :text_field, :name, autofocus: true %>
+  <%= form.number_field :weight %>
 
   <% if form.object.settings? %>
     <fieldset class="global-settings">

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
         parent: Parent
       feature:
         name: Name
+        weight: Weight
       organization:
         default_locale: Default locale
         description: Description

--- a/decidim-admin/spec/commands/update_feature_spec.rb
+++ b/decidim-admin/spec/commands/update_feature_spec.rb
@@ -15,6 +15,7 @@ module Decidim
             ca: "La meva funcionalitat",
             es: "Mi funcionalidad"
           },
+          weight: 3,
           invalid?: !valid,
           valid?: valid,
           settings: {
@@ -39,6 +40,7 @@ module Decidim
           }.to broadcast(:ok)
 
           expect(feature["name"]["en"]).to eq("My feature")
+          expect(feature.weight).to eq(3)
           expect(feature.settings.dummy_global_attribute_1).to eq(true)
           expect(feature.settings.dummy_global_attribute_2).to eq(false)
 

--- a/decidim-core/app/models/decidim/feature.rb
+++ b/decidim-core/app/models/decidim/feature.rb
@@ -11,6 +11,8 @@ module Decidim
 
     validates :participatory_process, presence: true
 
+    default_scope { order(arel_table[:weight].asc) }
+
     after_initialize :default_values
 
     # Public: Finds the manifest this feature is associated to.

--- a/decidim-core/db/migrate/20170125152026_add_weight_to_features.rb
+++ b/decidim-core/db/migrate/20170125152026_add_weight_to_features.rb
@@ -1,0 +1,5 @@
+class AddWeightToFeatures < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_features, :weight, :integer
+  end
+end

--- a/decidim-core/db/migrate/20170125152026_add_weight_to_features.rb
+++ b/decidim-core/db/migrate/20170125152026_add_weight_to_features.rb
@@ -1,5 +1,5 @@
 class AddWeightToFeatures < ActiveRecord::Migration[5.0]
   def change
-    add_column :decidim_features, :weight, :integer
+    add_column :decidim_features, :weight, :integer, default: 0
   end
 end


### PR DESCRIPTION
#### 🎩 What? Why?
This PR adds a weight field to features in order for the admin to control in which order are they displayed.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/pgFHbwbQWzpMQ/giphy.gif)
