### PR TITLE
Fix double requests for filters

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/filters.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/filters.js.es6
@@ -2,9 +2,7 @@
 // = require ./form_filter.component
 // = require_self
 
-// Initializes the form filter. We're unmounting the component before
-// changing the page so that we stop listening to events and we don't bind
-// multiple times when re-visiting the page.
+// Initializes the form filter.
 ((exports) => {
   const { Decidim: { FormFilterComponent } } = exports;
 

--- a/decidim-core/app/assets/javascripts/decidim/filters.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/filters.js.es6
@@ -1,3 +1,4 @@
+/* eslint-disable no-invalid-this */
 // = require ./form_filter.component
 // = require_self
 
@@ -6,9 +7,12 @@
 // multiple times when re-visiting the page.
 ((exports) => {
   const { Decidim: { FormFilterComponent } } = exports;
-  const formFilter = new FormFilterComponent('form.new_filter');
 
   $(() => {
-    formFilter.mountComponent();
+    $('form.new_filter').each(function () {
+      const formFilter = new FormFilterComponent($(this));
+
+      formFilter.mountComponent();
+    })
   });
 })(window);

--- a/decidim-core/app/assets/javascripts/decidim/form_filter.component.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/form_filter.component.js.es6
@@ -127,7 +127,7 @@
         // Iterate the filter params and set the correct form values
         fieldIds.forEach((fieldId) => {
           let field = null;
-          
+
           // Since we are using Ruby on Rails generated forms the field ids for a
           // checkbox or a radio button has the following form: filter_${key}_${value}
           field = this.$form.find(`input#filter_${fieldId}_${filterParams[fieldId]}`);
@@ -138,7 +138,7 @@
             // If the field is not a checkbox neither a radio it means is a input or a select.
             // Ruby on Rails ensure the ids are constructed like this: filter_${key}
             field = this.$form.find(`input#filter_${fieldId},select#filter_${fieldId}`);
-            
+
             if (field.length > 0) {
               field.val(filterParams[fieldId]);
             }
@@ -154,12 +154,13 @@
      * @private
      * @returns {Void} - Returns nothing.
      */
-    _onFormChange() {
+    _onFormChange(event) {
+      const $form = $(event.target).parents('form');
+      const formAction = $form.attr('action');
+      const params = $form.serialize();
       let newUrl = '';
-      const formAction = this.$form.attr('action');
-      const params = this.$form.serialize();
 
-      this.$form.submit();
+      $form.submit();
 
       if (formAction.indexOf('?') < 0) {
         newUrl = `${formAction}?${params}`;

--- a/decidim-core/app/assets/javascripts/decidim/form_filter.component.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/form_filter.component.js.es6
@@ -10,8 +10,8 @@
     mounted;
     $form;
 
-    constructor(selector) {
-      this.$form = $(selector);
+    constructor($form) {
+      this.$form = $form;
       this.mounted = false;
 
       this._onFormChange = this._onFormChange.bind(this);
@@ -154,13 +154,12 @@
      * @private
      * @returns {Void} - Returns nothing.
      */
-    _onFormChange(event) {
-      const $form = $(event.target).parents('form');
-      const formAction = $form.attr('action');
-      const params = $form.serialize();
+    _onFormChange() {
+      const formAction = this.$form.attr('action');
+      const params = this.$form.serialize();
       let newUrl = '';
 
-      $form.submit();
+      this.$form.submit();
 
       if (formAction.indexOf('?') < 0) {
         newUrl = `${formAction}?${params}`;

--- a/decidim-core/app/assets/javascripts/decidim/form_filter.component.test.js
+++ b/decidim-core/app/assets/javascripts/decidim/form_filter.component.test.js
@@ -34,7 +34,7 @@ describe('FormFilterComponent', () => {
     window.history = {
       pushState: sinon.stub()
     };
-    subject = new FormFilterComponent(selector);
+    subject = new FormFilterComponent($(document).find('form'));
   });
 
   it('exists', () => {

--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -11,7 +11,7 @@ module Decidim
     # Returns the filter resource form wrapped in a div
     def filter_form_for(filter)
       content_tag :div, class: "filters" do
-        form_for filter, builder: FilterFormBuilder, url: url_for, as: :filter, method: :get, remote: true do |form|
+        form_for filter, builder: FilterFormBuilder, url: url_for, as: :filter, method: :get, remote: true, html: { id: nil } do |form|
           yield form
         end
       end

--- a/decidim-core/app/helpers/decidim/filters_helper.rb
+++ b/decidim-core/app/helpers/decidim/filters_helper.rb
@@ -10,12 +10,11 @@ module Decidim
     #
     # Returns the filter resource form wrapped in a div
     def filter_form_for(filter)
-      filters_container = content_tag :div, class: "filters" do
+      content_tag :div, class: "filters" do
         form_for filter, builder: FilterFormBuilder, url: url_for, as: :filter, method: :get, remote: true do |form|
           yield form
         end
       end
-      filters_container + javascript_include_tag("decidim/filters")
     end
   end
 end

--- a/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/filters_helper_spec.rb
@@ -9,7 +9,7 @@ module Decidim
         def self.model_name
           ActiveModel::Name.new(self, nil, "dummy")
         end
-        
+
         include ActiveModel::Model
       end.new
     end
@@ -30,11 +30,11 @@ module Decidim
         helper.filter_form_for(filter) do
         end
       end
-      
+
       it "calls form_for helper with specific arguments" do
         expect(helper)
           .to receive(:form_for)
-          .with(filter, { builder: FilterFormBuilder, url: helper.url_for, as: :filter, method: :get, remote: true }, any_args)
+          .with(filter, { builder: FilterFormBuilder, url: helper.url_for, as: :filter, method: :get, remote: true, html: { id: nil } }, any_args)
 
         helper.filter_form_for(filter) do
         end

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -11,3 +11,5 @@
     <%= render partial: "meetings" %>
   </div>
 </div>
+
+<%= javascript_include_tag("decidim/filters") %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -22,3 +22,4 @@
 </div>
 
 <%= render partial: "decidim/shared/login_modal" %>
+<%= javascript_include_tag("decidim/filters") %>


### PR DESCRIPTION
#### :tophat: What? Why?

Fix the double requests in filters caused by including the `filters_form_for` twice.

#### :pushpin: Related Issues
- Related to #532 
- Fixes #625 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
