### PR TITLE
Update simplecov version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,7 +480,7 @@ GEM
       sprockets-rails
       tilt
     searchlight (4.1.0)
-    simplecov (0.12.0)
+    simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)


### PR DESCRIPTION
#### :tophat: What? Why?
Updates simplecov to the latest version. This gem was raising some deprecation warnings under Ruby 2.4.0, this new version should fix them.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None