### PR TITLE
Swap banner image for hero image tags on the process cards.

### DIFF
--- a/decidim-core/app/views/decidim/participatory_processes/_participatory_process.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_participatory_process.html.erb
@@ -1,7 +1,7 @@
 <div class="column">
   <article class="card card--process">
     <div class="card__image-top"
-      style="background-image:url(<%= participatory_process.banner_image.url %>)"></div>
+      style="background-image:url(<%= participatory_process.hero_image.url %>)"></div>
     <div class="card__content">
       <%= link_to participatory_process_path(participatory_process), class: "card__link" do %>
         <h4 class="card__title"><%= translated_attribute participatory_process.title %></h4>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes process cards that were showing the banner image instead of the hero

#### :pushpin: Related Issues
- Fixes #630

### :camera: Screenshots (optional)
![screen shot 2017-01-26 at 11 16 26](https://cloud.githubusercontent.com/assets/953911/22327722/f0982f86-e3b8-11e6-8585-22bcfed26970.png)

#### :ghost: GIF
![](https://media.giphy.com/media/4ujoqRRr0XNMk/giphy.gif)
