### PR TITLE
Use settings instead of a hardcoded value to enable comments

### DIFF
--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -25,16 +25,6 @@ module Decidim
         author&.avatar&.url || ActionController::Base.helpers.asset_path("decidim/default-avatar.svg")
       end
 
-      # Public: Canpeople comment on this proposal?
-      #
-      # Until we have a way to store options fore features and its resources we
-      # assume all proposals can be commented.
-      #
-      # Returns Boolean
-      def commentable?
-        true
-      end
-
       # Public: Check if the user has voted the proposal
       #
       # Returns Boolean

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -54,7 +54,7 @@
 </div>
 
 <%= content_for :expanded do %>
-  <% if @proposal.commentable? %>
+  <% if feature_settings.comments_always_enabled || current_settings.comments_enabled %>
     <%= comments_for @proposal, arguable: true, votable: true %>
   <% end %>
 <% end %>

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -22,6 +22,14 @@ Decidim.register_feature(:proposals) do |feature|
     resource.template = "decidim/proposals/proposals/linked_proposals"
   end
 
+  feature.settings(:global) do |settings|
+    settings.attribute :comments_always_enabled, type: :boolean, default: true
+  end
+
+  feature.settings(:step) do |settings|
+    settings.attribute :comments_enabled, type: :boolean, default: true
+  end
+
   feature.seeds do
     Decidim::ParticipatoryProcess.all.each do |process|
       next unless process.steps.any?


### PR DESCRIPTION
#### :tophat: What? Why?

We were using a method at `Proposal` to check if we should enable comments instead of using the settings.

#### :pushpin: Related Issues
- Related to #553

#### :ghost: GIF
![](https://i.imgur.com/WLy2ISz.gif)