### PR TITLE
Add `no-js` class on the `html` tag to prevent flickering

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="no-js">
   <head>
     <title><%= decidim_page_title %></title>
     <%= csrf_meta_tags %>


### PR DESCRIPTION
#### :tophat: What? Why?
Putting a `no-js` class on the `html` tag just before foundation renders makes sure dropdowns and other dynamic elements stay hidden until the very last moment. If not present, they will render for a brief moment just before being hidden, causing a very annoying reflow.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/kaFDOyMAODdL2/giphy.gif)
