### PR TITLE
Use a timestamp instead of a boolean column to verify user groups

### DIFF
--- a/decidim-admin/db/migrate/20170128112958_change_user_groups_verified_to_timestamp.rb
+++ b/decidim-admin/db/migrate/20170128112958_change_user_groups_verified_to_timestamp.rb
@@ -1,0 +1,9 @@
+class ChangeUserGroupsVerifiedToTimestamp < ActiveRecord::Migration[5.0]
+  def change
+    ActiveRecord::Base.transaction do
+      add_column :decidim_user_groups, :verified_at, :datetime
+      ActiveRecord::Base.connection.execute("UPDATE decidim_user_groups SET verified_at = '#{Time.current.to_s(:db)}' WHERE verified = 't'")
+      remove_column :decidim_user_groups, :verified
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/user_group.rb
+++ b/decidim-core/app/models/decidim/user_group.rb
@@ -12,11 +12,16 @@ module Decidim
     validates :avatar, file_size: { less_than_or_equal_to: 5.megabytes }
     mount_uploader :avatar, Decidim::AvatarUploader
 
-    scope :verified, -> { where(verified: true) }
+    scope :verified, -> { where.not(verified_at: nil) }
 
     # Public: Mark the user group as verified
     def verify!
-      update_attribute(:verified, true)
+      update_attribute(:verified_at, Time.current)
+    end
+
+    # Public: Checks if the user group is verified.
+    def verified?
+      verified_at.present?
     end
   end
 end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -51,7 +51,7 @@ if !Rails.env.production? || ENV["SEED"]
         name: Faker::Company.name,
         document_number: Faker::Number.number(10),
         phone: Faker::PhoneNumber.phone_number,
-        verified: true
+        verified_at: Time.current
       )
 
       Decidim::UserGroupMembership.create!(
@@ -62,8 +62,7 @@ if !Rails.env.production? || ENV["SEED"]
       user_group = Decidim::UserGroup.create!(
         name: Faker::Company.name,
         document_number: Faker::Number.number(10),
-        phone: Faker::PhoneNumber.phone_number,
-        verified: false
+        phone: Faker::PhoneNumber.phone_number
       )
 
       Decidim::UserGroupMembership.create!(

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -124,7 +124,7 @@ FactoryGirl.define do
     avatar { test_file("avatar.svg", "image/svg+xml") }
 
     trait :verified do
-      verified { true }
+      verified_at { Time.current }
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

It's always a good practice to store this kind of flags as a timestamp (plus we need it to import data from decidim.barcelona).

#### :ghost: GIF
![](https://i.imgur.com/DAgVJSH.gif)