### PR TITLE
Use the right title in the layout

### DIFF
--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -3,7 +3,7 @@ module Decidim
   # View helpers related to the layout.
   module LayoutHelper
     def decidim_page_title
-      title = content_for(:title)
+      title = content_for(:meta_title)
       title ? "#{title} - #{current_organization.name}" : current_organization.name
     end
 

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -1,4 +1,5 @@
-<% content_for(:title, translated_attribute(@page.title)) %>
+<% content_for(:meta_title, translated_attribute(@page.title)) %>
+
 <div class="row column">
   <div class="row">
     <div class="columns medium-7 mediumlarge-8">


### PR DESCRIPTION
#### :tophat: What? Why?
This uses `meta_title` instead of `title` in the layout.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/r691I7NJAxAFG/giphy.gif)
