### PR TITLE
Update step title seeds.

### DIFF
--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -8,8 +8,6 @@
 
 <%= render partial: 'pages/home/extended' %>
 
-
-
 <% if current_organization.show_statistics? %>
   <%= render partial: 'pages/home/statistics' %>
 <% end %>

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -100,7 +100,7 @@ if !Rails.env.production? || ENV["SEED"]
 
   Decidim::ParticipatoryProcess.find_each do |process|
     Decidim::ParticipatoryProcessStep.create!(
-      title: Decidim::Faker::Localized.words(2),
+      title: Decidim::Faker::Localized.sentence(1, false, 2),
       short_description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
         Decidim::Faker::Localized.sentence(3)
       end,

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -100,7 +100,7 @@ if !Rails.env.production? || ENV["SEED"]
 
   Decidim::ParticipatoryProcess.find_each do |process|
     Decidim::ParticipatoryProcessStep.create!(
-      title: Decidim::Faker::Localized.sentence(5),
+      title: Decidim::Faker::Localized.words(2),
       short_description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
         Decidim::Faker::Localized.sentence(3)
       end,


### PR DESCRIPTION
#### :tophat: What? Why?
This PR update the current seeds to fill the current step title, with a maximum of 2 words, that should be the maximum in a real case, also with the change it does not break the design.

### :camera: Screenshots
![screen shot 2017-01-30 at 16 25 21](https://cloud.githubusercontent.com/assets/953911/22428887/05418d6c-e709-11e6-9189-014a42b0fbad.png)

#### :ghost: GIF
![](https://media.giphy.com/media/PjdafEeAKAT9S/giphy.gif)
