### PR TITLE
Disable scroll wheel on maps

### DIFF
--- a/decidim-meetings/app/assets/javascripts/decidim/meetings/map.js.es6.erb
+++ b/decidim-meetings/app/assets/javascripts/decidim/meetings/map.js.es6.erb
@@ -63,6 +63,8 @@ const loadMap = (mapId, meetingsData, hereAppId, hereAppCode) => {
     map.fitWorld();
   }
 
+  map.scrollWheelZoom.disable();
+
   return map;
 };
 


### PR DESCRIPTION
#### :tophat: What? Why?
Scroll wheel on maps shouldn't be enabled, as the scrollwheel is being used to... scroll!

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/26BRERwHtgJTf7rTG/giphy.gif)
