### PR TITLE
Add Features menu for mobile/tablets

### DIFF
--- a/decidim-core/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_process_header.html.erb
@@ -20,7 +20,7 @@
     <div class="row column">
       <div class="process-nav">
         <button class="process-nav__trigger hide-for-medium"  data-toggle="process-nav-content">
-          <%= icon "caret-bottom", class: "icon--small process-nav__trigger__icon", aria_label: "Desplegar", role: "img" %>
+          <%= icon "caret-bottom", class: "icon--small process-nav__trigger__icon", aria_label: t('.unfold'), role: "img" %>
           <div class="process-nav__link">
             <%  if self.try(:current_feature) %>
                 <%= feature_icon(current_feature) %>

--- a/decidim-core/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_process_header.html.erb
@@ -19,17 +19,29 @@
   <% if current_participatory_process.features.any? %>
     <div class="row column">
       <div class="process-nav">
-        <div class="row column process-nav__content">
+        <button class="process-nav__trigger hide-for-medium"  data-toggle="process-nav-content">
+          <%= icon "caret-bottom", class: "icon--small process-nav__trigger__icon", aria_label: "Desplegar", role: "img" %>
+          <div class="process-nav__link">
+            <%  if self.try(:current_feature) %>
+                <%= feature_icon(current_feature) %>
+                <%= translated_attribute(current_feature.name) %>
+            <% else %>
+                <%= icon "process" %>
+                <%= t ".process_menu_item" %>
+            <% end %>
+          </div>
+        </button>
+
+        <div class="row column process-nav__content" id="process-nav-content" data-toggler=".is-active">
           <ul>
-            <li>
+            <li class="<% is_active_link?(decidim.participatory_process_path, :inclusive) %>is-active<% end %>">
               <%= active_link_to decidim.participatory_process_path(current_participatory_process), active: :exact, class: "process-nav__link", class_active: "is-active" do %>
                 <%= icon "process" %>
                 <%= t ".process_menu_item" %>
               <% end %>
             </li>
-
             <% current_participatory_process.features.each do |feature| %>
-              <li>
+              <li class="<% is_active_link?(decidim.feature_path, :inclusive) %>is-active<% end %>">
                 <%= active_link_to decidim.feature_path(current_participatory_process, feature), class: "process-nav__link", active: :inclusive, class_active: "is-active" do %>
                   <%= feature_icon(feature) %>
 

--- a/decidim-core/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_process_header.html.erb
@@ -21,7 +21,7 @@
       <div class="process-nav">
         <button class="process-nav__trigger hide-for-medium"  data-toggle="process-nav-content">
           <%= icon "caret-bottom", class: "icon--small process-nav__trigger__icon", aria_label: t('.unfold'), role: "img" %>
-          <div class="process-nav__link">
+            <div class="process-nav__link">
             <%  if self.try(:current_feature) %>
                 <%= feature_icon(current_feature) %>
                 <%= translated_attribute(current_feature.name) %>
@@ -29,20 +29,22 @@
                 <%= icon "process" %>
                 <%= t ".process_menu_item" %>
             <% end %>
-          </div>
+            </div>
         </button>
         <div class="row column process-nav__content" id="process-nav-content" data-toggler=".is-active">
           <ul>
-            <li class="<%= "is-active" if is_active_link?(decidim.participatory_process_path, :inclusive) %>">
+            <li class="<%= "is-active" if is_active_link?(decidim.participatory_process_path(current_participatory_process), :exclusive) %>">
               <%= active_link_to decidim.participatory_process_path(current_participatory_process), active: :exact, class: "process-nav__link", class_active: "is-active" do %>
                 <%= icon "process" %>
                 <%= t ".process_menu_item" %>
               <% end %>
             </li>
+
             <% current_participatory_process.features.each do |feature| %>
-              <li class="<%= "is-active" if is_active_link?(decidim.feature_path, :inclusive) %>">
+              <li class="<%= "is-active" if is_active_link?(decidim.feature_path(current_participatory_process, feature), :inclusive) %>">
                 <%= active_link_to decidim.feature_path(current_participatory_process, feature), class: "process-nav__link", active: :inclusive, class_active: "is-active" do %>
                   <%= feature_icon(feature) %>
+
                   <%= translated_attribute(feature.name) %>
                 <% end %>
               </li>

--- a/decidim-core/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_process_header.html.erb
@@ -31,7 +31,6 @@
             <% end %>
           </div>
         </button>
-
         <div class="row column process-nav__content" id="process-nav-content" data-toggler=".is-active">
           <ul>
             <li class="<% is_active_link?(decidim.participatory_process_path, :inclusive) %>is-active<% end %>">
@@ -44,7 +43,6 @@
               <li class="<% is_active_link?(decidim.feature_path, :inclusive) %>is-active<% end %>">
                 <%= active_link_to decidim.feature_path(current_participatory_process, feature), class: "process-nav__link", active: :inclusive, class_active: "is-active" do %>
                   <%= feature_icon(feature) %>
-
                   <%= translated_attribute(feature.name) %>
                 <% end %>
               </li>

--- a/decidim-core/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_process_header.html.erb
@@ -33,14 +33,14 @@
         </button>
         <div class="row column process-nav__content" id="process-nav-content" data-toggler=".is-active">
           <ul>
-            <li class="<% is_active_link?(decidim.participatory_process_path, :inclusive) %>is-active<% end %>">
+            <li class="<%= "is-active" if is_active_link?(decidim.participatory_process_path, :inclusive) %>">
               <%= active_link_to decidim.participatory_process_path(current_participatory_process), active: :exact, class: "process-nav__link", class_active: "is-active" do %>
                 <%= icon "process" %>
                 <%= t ".process_menu_item" %>
               <% end %>
             </li>
             <% current_participatory_process.features.each do |feature| %>
-              <li class="<% is_active_link?(decidim.feature_path, :inclusive) %>is-active<% end %>">
+              <li class="<%= "is-active" if is_active_link?(decidim.feature_path, :inclusive) %>">
                 <%= active_link_to decidim.feature_path(current_participatory_process, feature), class: "process-nav__link", active: :inclusive, class_active: "is-active" do %>
                   <%= feature_icon(feature) %>
                   <%= translated_attribute(feature.name) %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -168,6 +168,7 @@ en:
           take_part: Take part
       process_header:
         process_menu_item: The process
+        unfold: Unfold
       process_header_steps:
         step: Step %{current} of %{total}
         view_steps: View steps


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the code on process_header to display Features menu(Proposals, Meetings, etc.) on mobile/tablet devices.

#### :pushpin: Related Issues
- Fixes #682

### :camera: Screenshots (optional)
![screen shot 2017-01-31 at 10 54 22](https://cloud.githubusercontent.com/assets/953911/22460212/2acfa226-e7a4-11e6-8c6e-f65844a75187.png)

#### :ghost: GIF
![](https://media.giphy.com/media/fRrta5TB32PD2/giphy.gif)
