### PR TITLE
Improve image too big error message

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
@@ -21,23 +21,25 @@ module Decidim
       # Returns nothing.
       def call
         return broadcast(:invalid) if form.invalid?
-        begin
-          update_participatory_process
-          broadcast(:ok)
+        update_participatory_process
 
-        rescue ActiveRecord::RecordInvalid => exception
-            byebug
-            form.errors.add(:hero_image, :invalid)
-            broadcast(:invalid)
+        if @participatory_process.valid?
+          broadcast(:ok, @participatory_process)
+        else
+          form.errors.add(:hero_image, @participatory_process.errors[:hero_image]) if @participatory_process.errors.include? :hero_image
+          form.errors.add(:banner_image, @participatory_process.errors[:banner_image]) if @participatory_process.errors.include? :banner_image
+          broadcast(:invalid)
         end
       end
+
 
       private
 
       attr_reader :form
 
       def update_participatory_process
-        @participatory_process.update_attributes!(attributes)
+        @participatory_process.assign_attributes(attributes)
+        @participatory_process.save! if @participatory_process.valid?
       end
 
       def attributes

--- a/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
@@ -21,9 +21,15 @@ module Decidim
       # Returns nothing.
       def call
         return broadcast(:invalid) if form.invalid?
+        begin
+          update_participatory_process
+          broadcast(:ok)
 
-        update_participatory_process
-        broadcast(:ok)
+        rescue ActiveRecord::RecordInvalid => exception
+            byebug
+            form.errors.add(:hero_image, :invalid)
+            broadcast(:invalid)
+        end
       end
 
       private

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -29,7 +29,10 @@ module Decidim
 
       validate :slug, :slug_uniqueness
 
-      private
+      validates :hero_image, file_size: { less_than_or_equal_to: 10.megabytes }, file_content_type: { allow: ['image/jpeg', 'image/png'] }
+      validates :banner_image, file_size: { less_than_or_equal_to: 10.megabytes }, file_content_type: { allow: ['image/jpeg', 'image/png'] }
+
+       private
 
       def slug_uniqueness
         return unless current_organization.participatory_processes.where(slug: slug).where.not(id: id).any?

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -29,8 +29,8 @@ module Decidim
 
       validate :slug, :slug_uniqueness
 
-      validates :hero_image, file_size: { less_than_or_equal_to: 10.megabytes }, file_content_type: { allow: ['image/jpeg', 'image/png'] }
-      validates :banner_image, file_size: { less_than_or_equal_to: 10.megabytes }, file_content_type: { allow: ['image/jpeg', 'image/png'] }
+      validates :hero_image, file_size: { less_than_or_equal_to: lambda { |_record| Decidim.maximum_attachment_size } }, file_content_type: { allow: ['image/jpeg', 'image/png'] }
+      validates :banner_image, file_size: { less_than_or_equal_to:lambda { |_record| Decidim.maximum_attachment_size } }, file_content_type: { allow: ['image/jpeg', 'image/png'] }
 
        private
 

--- a/decidim-admin/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_form_spec.rb
@@ -35,6 +35,7 @@ module Decidim
         }
       end
       let(:slug) { "slug" }
+      let(:attachement) { test_file("city.jpeg", "image/jpeg") }
       let(:attributes) do
         {
           "participatory_process" => {
@@ -50,15 +51,44 @@ module Decidim
             "short_description_en" => short_description[:en],
             "short_description_es" => short_description[:es],
             "short_description_ca" => short_description[:ca],
+            "hero_image" => attachement,
+            "banner_image" => attachement,
             "slug" => slug
           }
         }
+      end
+      before do
+        Decidim::AttachmentUploader.enable_processing = true
       end
 
       subject { described_class.from_params(attributes).with_context(current_organization: organization) }
 
       context "when everything is OK" do
         it { is_expected.to be_valid }
+      end
+
+      context "when hero_image is too big" do
+        before do
+          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
+          expect(subject.hero_image).to receive(:size).twice.and_return(6.megabytes)
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when banner_image is too big" do
+        before do
+          allow(Decidim).to receive(:maximum_attachment_size).and_return(5.megabytes)
+          expect(subject.banner_image).to receive(:size).twice.and_return(6.megabytes)
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when images are not the expected type" do
+        let(:attachement) { test_file("Exampledocument.pdf", "application/pdf") }
+
+        it { is_expected.not_to be_valid }
       end
 
       context "when some language in title is missing" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR handles the crash when uploading a file bigger in size than the allowed size (2000px) or weight (10MB) 

#### :pushpin: Related Issues
- Fixes #667

#### :clipboard: Subtasks
- [x] Move file size and type validations to form.
- [x] Create dimension validations on update and create command.
- [x] Add respective tests.

### :camera: Screenshots (optional)
<img width="976" alt="screen shot 2017-02-01 at 11 37 07" src="https://cloud.githubusercontent.com/assets/953911/22503610/cf3a173c-e872-11e6-9cbc-eb3fef7babe8.png">

#### :ghost: GIF
![](https://media.giphy.com/media/z28NwveUbzkxq/giphy.gif)
