### PR TITLE
Do not let process admins manage users

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/users_controller.rb
@@ -7,17 +7,17 @@ module Decidim
     #
     class UsersController < Admin::ApplicationController
       def index
-        authorize! :index, User
+        authorize! :index, :admin_users
         @users = collection
       end
 
       def new
-        authorize! :new, User
+        authorize! :new, :admin_users
         @form = form(InviteAdminForm).instance
       end
 
       def create
-        authorize! :new, User
+        authorize! :new, :admin_users
 
         default_params = {
           organization: current_organization,
@@ -42,7 +42,7 @@ module Decidim
       end
 
       def resend_invitation
-        authorize! :invite, user
+        authorize! :invite, :admin_users
 
         InviteUserAgain.call(user, "invite_admin") do
           on(:ok) do
@@ -58,7 +58,7 @@ module Decidim
       end
 
       def destroy
-        authorize! :destroy, user
+        authorize! :destroy, :admin_users
 
         RemoveUserRole.call(user, "admin") do
           on(:ok) do

--- a/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/admin_user.rb
@@ -24,6 +24,7 @@ module Decidim
 
           can :manage, Feature
           can :read, :admin_dashboard
+          can :manage, :admin_users
           can :manage, Attachment
           can :manage, Scope
           can [:create, :index, :new, :read, :invite], User

--- a/decidim-admin/app/models/decidim/admin/abilities/participatory_process_admin.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/participatory_process_admin.rb
@@ -27,7 +27,7 @@ module Decidim
           cannot :create, ParticipatoryProcess
           cannot :destroy, ParticipatoryProcess
 
-          cannot :manage, User
+          cannot :manage, :admin_users
 
           can :manage, ParticipatoryProcessUserRole do |role|
             role.user != user

--- a/decidim-admin/app/models/decidim/admin/abilities/participatory_process_admin.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/participatory_process_admin.rb
@@ -27,6 +27,8 @@ module Decidim
           cannot :create, ParticipatoryProcess
           cannot :destroy, ParticipatoryProcess
 
+          cannot :manage, User
+
           can :manage, ParticipatoryProcessUserRole do |role|
             role.user != user
           end

--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar.html.erb
@@ -11,7 +11,7 @@
   <%= active_link_to t("menu.participatory_processes", scope: "decidim.admin"), decidim_admin.participatory_processes_path, active: :inclusive %>
   <%= active_link_to t("menu.static_pages", scope: "decidim.admin"), decidim_admin.static_pages_path, active: :inclusive if can? :read, Decidim::StaticPage %>
   <%= active_link_to t("menu.scopes", scope: "decidim.admin"), decidim_admin.scopes_path, active: :inclusive if can? :read, Decidim::Scope %>
-  <%= active_link_to t("menu.users", scope: "decidim.admin"), decidim_admin.users_path, active: :inclusive if can? :read, Decidim::User %>
+  <%= active_link_to t("menu.users", scope: "decidim.admin"), decidim_admin.users_path, active: :inclusive if can? :read, :admin_users %>
   <%= active_link_to t("menu.user_groups", scope: "decidim.admin"), decidim_admin.user_groups_path, active: :inclusive if can? :index, Decidim::UserGroup %>
   <%= active_link_to t("menu.settings", scope: "decidim.admin"), decidim_admin.edit_organization_path, active: :inclusive if can? :read, current_organization %>
 </nav>

--- a/decidim-admin/spec/models/abilities/admin_user_spec.rb
+++ b/decidim-admin/spec/models/abilities/admin_user_spec.rb
@@ -19,6 +19,7 @@ describe Decidim::Admin::Abilities::AdminUser do
   it { is_expected.to be_able_to(:manage, Decidim::ParticipatoryProcessStep) }
   it { is_expected.to be_able_to(:manage, Decidim::Attachment) }
   it { is_expected.to be_able_to(:manage, Decidim::Scope) }
+  it { is_expected.to be_able_to(:manage, :admin_users) }
 
   it { is_expected.to be_able_to(:create, Decidim::StaticPage) }
   it { is_expected.to be_able_to(:update, Decidim::StaticPage) }

--- a/decidim-admin/spec/models/abilities/participatory_process_admin_spec.rb
+++ b/decidim-admin/spec/models/abilities/participatory_process_admin_spec.rb
@@ -36,7 +36,7 @@ describe Decidim::Admin::Abilities::ParticipatoryProcessAdmin do
     it { is_expected.not_to be_able_to(:create, Decidim::ParticipatoryProcess) }
     it { is_expected.not_to be_able_to(:manage, unmanaged_process) }
 
-    it { is_expected.not_to be_able_to(:manage, Decidim::User) }
+    it { is_expected.not_to be_able_to(:manage, :admin_users) }
 
     it { is_expected.to be_able_to(:manage, user_process_step) }
     it { is_expected.not_to be_able_to(:manage, unmanaged_process_step) }

--- a/decidim-admin/spec/models/abilities/participatory_process_admin_spec.rb
+++ b/decidim-admin/spec/models/abilities/participatory_process_admin_spec.rb
@@ -36,6 +36,8 @@ describe Decidim::Admin::Abilities::ParticipatoryProcessAdmin do
     it { is_expected.not_to be_able_to(:create, Decidim::ParticipatoryProcess) }
     it { is_expected.not_to be_able_to(:manage, unmanaged_process) }
 
+    it { is_expected.not_to be_able_to(:manage, Decidim::User) }
+
     it { is_expected.to be_able_to(:manage, user_process_step) }
     it { is_expected.not_to be_able_to(:manage, unmanaged_process_step) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Process admins should not be able to manage admins. No link appears in the sidebar. Trying to access the section via URL redirects the user to the admin dashboard.

#### :pushpin: Related Issues
- Fixes #703 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/MROYdmQ.png)
