### PR TITLE
Order process by end date

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
@@ -32,7 +32,6 @@ module Decidim
         end
       end
 
-
       private
 
       attr_reader :form

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_form.rb
@@ -29,10 +29,10 @@ module Decidim
 
       validate :slug, :slug_uniqueness
 
-      validates :hero_image, file_size: { less_than_or_equal_to: lambda { |_record| Decidim.maximum_attachment_size } }, file_content_type: { allow: ['image/jpeg', 'image/png'] }
-      validates :banner_image, file_size: { less_than_or_equal_to:lambda { |_record| Decidim.maximum_attachment_size } }, file_content_type: { allow: ['image/jpeg', 'image/png'] }
+      validates :hero_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+      validates :banner_image, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
 
-       private
+      private
 
       def slug_uniqueness
         return unless current_organization.participatory_processes.where(slug: slug).where.not(id: id).any?

--- a/decidim-admin/spec/features/admin_manages_participatory_process_admins_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_process_admins_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_process_admins_examples"
 
 describe "Admin manages participatory process admins", type: :feature do
   include_context "participatory process admin"

--- a/decidim-admin/spec/features/admin_manages_participatory_process_attachments_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_process_attachments_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_process_attachments_examples"
 
 describe "Admin manages participatory process attachments", type: :feature do
   include_context "participatory process admin"

--- a/decidim-admin/spec/features/admin_manages_participatory_process_categories_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_process_categories_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_process_categories_examples"
 
 describe "Admin manages participatory process categories", type: :feature do
   include_context "participatory process admin"

--- a/decidim-admin/spec/features/admin_manages_participatory_process_steps_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_process_steps_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_process_steps_examples"
 
 describe "Admin manages participatory process steps", type: :feature do
   include_context "participatory process admin"

--- a/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_processes_examples"
 
 describe "Admin manage participatory processes", type: :feature do
   include_context "participatory process admin"

--- a/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_user_groups_spec.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
 
 describe "Admin manage user groups", type: :feature do
   include_context "participatory process admin"
@@ -18,7 +17,6 @@ describe "Admin manage user groups", type: :feature do
     click_button "Verify", match: :first
 
     expect(page).not_to have_selector(".actions button", match: :first)
-    
     expect(page).to have_content("verified successfully")
   end
 end

--- a/decidim-admin/spec/features/participatory_process_admin_manages_participatory_process_admins_spec.rb
+++ b/decidim-admin/spec/features/participatory_process_admin_manages_participatory_process_admins_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_process_admins_examples"
 
 describe "Participatory process admin manages participatory process admins", type: :feature do
   include_context "participatory process admin"

--- a/decidim-admin/spec/features/participatory_process_admin_manages_participatory_process_attachments_spec.rb
+++ b/decidim-admin/spec/features/participatory_process_admin_manages_participatory_process_attachments_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_process_attachments_examples"
 
 describe "Participatory process admin manages participatory process attachments", type: :feature do
   include_context "participatory process admin"

--- a/decidim-admin/spec/features/participatory_process_admin_manages_participatory_process_steps_spec.rb
+++ b/decidim-admin/spec/features/participatory_process_admin_manages_participatory_process_steps_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_process_steps_examples"
 
 describe "Participatory process admin manages participatory process steps", type: :feature do
   include_context "participatory process admin"

--- a/decidim-admin/spec/features/participatory_process_admin_manages_participatory_processes_spec.rb
+++ b/decidim-admin/spec/features/participatory_process_admin_manages_participatory_processes_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_processes_examples"
 
 describe "Participatory process admin manages participatory processes", type: :feature do
   include_context "participatory process admin"

--- a/decidim-admin/spec/features/process_admin_manages_participatory_process_categories_spec.rb
+++ b/decidim-admin/spec/features/process_admin_manages_participatory_process_categories_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/participatory_admin_shared_context"
-require_relative "../shared/manage_process_categories_examples"
 
 describe "Admin manages participatory process categories", type: :feature do
   include_context "participatory process admin"

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -28,7 +28,7 @@ FactoryGirl.define do
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     budget { Faker::Number.number(8) }
-    feature { create(:budget_feature) }    
+    feature { create(:budget_feature) }
   end
 
   factory :order, class: Decidim::Budgets::Order do

--- a/decidim-budgets/spec/features/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/features/admin_manages_projects_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_projects_examples"
 
 describe "Admin manages projects", type: :feature do
   include_context "admin"

--- a/decidim-budgets/spec/features/process_admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/features/process_admin_manages_projects_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_projects_examples"
 
 describe "Process admin manages projects", type: :feature do
   include_context "admin"

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -11,22 +11,23 @@ module Decidim
 
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
-    helper_method :page, :participatory_processes, :promoted_participatory_processes, :users
+    helper_method :page, :promoted_participatory_processes, :participatory_processes, :users
 
     def page_finder
       @page_finder ||= Decidim::PageFinder.new(params[:id], current_organization)
     end
 
-    def promoted_participatory_processes
-      @promoted_participatory_processes ||= participatory_processes.promoted
-    end
-
-    def participatory_processes
-      @participatory_processes ||= current_organization.participatory_processes.includes(:active_step).published
-    end
-
     def users
       @users ||= Decidim::User.where(organization: current_organization)
+    end
+
+    # This should be deleted once the statistics are done properly.
+    def participatory_processes
+      @processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new
+    end
+
+    def promoted_participatory_processes
+      @promoted_processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new | PromotedParticipatoryProcesses.new
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -9,9 +9,9 @@ module Decidim
 
     layout "layouts/decidim/participatory_process", only: [:show]
 
-    helper_method :participatory_processes, :promoted_processes
-
     skip_after_action :verify_participatory_process, only: [:index]
+
+    helper_method :participatory_processes, :promoted_participatory_processes
 
     def index
       authorize! :read, ParticipatoryProcess
@@ -24,11 +24,11 @@ module Decidim
     private
 
     def participatory_processes
-      @participatory_processes ||= current_organization.participatory_processes.includes(:active_step).published
+      @processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new
     end
 
-    def promoted_processes
-      @promoted_processes ||= participatory_processes.promoted
+    def promoted_participatory_processes
+      @promoted_processes ||= participatory_processes | PromotedParticipatoryProcesses.new
     end
   end
 end

--- a/decidim-core/app/queries/decidim/promoted_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/promoted_participatory_processes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Decidim
+  # This query filters processes so only promoted ones are returned.
+  class PromotedParticipatoryProcesses < Rectify::Query
+    def query
+      Decidim::ParticipatoryProcess.promoted
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/public_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/public_participatory_processes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Decidim
+  # This query adds some scopes so the processes are ready to be showed in a
+  # public view.
+  class PublicParticipatoryProcesses < Rectify::Query
+    def query
+      Decidim::ParticipatoryProcess.includes(:active_step).order("end_date ASC")
+    end
+  end
+end

--- a/decidim-core/app/views/decidim/participatory_processes/index.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for :meta_title, t(".title") %>
 
 <main class="wrapper">
-  <% if promoted_processes.any? %>
+  <% if promoted_participatory_processes.any? %>
     <section id ="highlighted-processes" class="row section">
       <h1 class="section-heading"><%= t(".promoted_processes", scope: "layouts") %></h1>
-      <%= render partial: "promoted_process", collection: promoted_processes, as: :promoted_process %>
+      <%= render partial: "promoted_process", collection: promoted_participatory_processes, as: :promoted_process %>
     </section>
   <% end %>
 

--- a/decidim-core/spec/controllers/pages_controller_spec.rb
+++ b/decidim-core/spec/controllers/pages_controller_spec.rb
@@ -6,9 +6,7 @@ module Decidim
     describe PagesController, type: :controller do
       let(:organization) { create :organization }
 
-      before do
-        @request.env["decidim.current_organization"] = organization
-      end
+      include_examples "with promoted participatory processes"
 
       context "when a template exists" do
         it "renders it" do

--- a/decidim-core/spec/controllers/participatory_processes_controller_spec.rb
+++ b/decidim-core/spec/controllers/participatory_processes_controller_spec.rb
@@ -12,9 +12,8 @@ module Decidim
       )
     end
 
-    before do
-      @request.env["decidim.current_organization"] = organization
-    end
+    include_examples "with participatory processes"
+    include_examples "with promoted participatory processes"
 
     describe "GET show" do
       context "when the process is unpublished" do

--- a/decidim-core/spec/shared/with_participatory_processes_examples.rb
+++ b/decidim-core/spec/shared/with_participatory_processes_examples.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+RSpec.shared_examples "with participatory processes" do
+  before do
+    @request.env["decidim.current_organization"] = organization
+  end
+
+  describe "helper methods" do
+    describe "participatory_processes" do
+      it "orders them by end_date" do
+        unpublished = create(
+          :participatory_process,
+          :unpublished,
+          organization: organization
+        )
+
+        last = create(
+          :participatory_process,
+          :published,
+          organization: organization,
+          end_date: nil
+        )
+
+        first = create(
+          :participatory_process,
+          :published,
+          organization: organization,
+          end_date: Time.current.advance(days: 10)
+        )
+
+        second = create(
+          :participatory_process,
+          :published,
+          organization: organization,
+          end_date: Time.current.advance(days: 20)
+        )
+
+        expect(controller.helpers.participatory_processes.count).to eq(3)
+        expect(controller.helpers.participatory_processes).not_to include(unpublished)
+        expect(controller.helpers.participatory_processes.first).to eq(first)
+        expect(controller.helpers.participatory_processes.to_a[1]).to eq(second)
+        expect(controller.helpers.participatory_processes.to_a.last).to eq(last)
+      end
+    end
+  end
+end
+
+RSpec.shared_examples "with promoted participatory processes" do
+  before do
+    @request.env["decidim.current_organization"] = organization
+  end
+  describe "helper methods" do
+    describe "promoted_participatory_processes" do
+      it "orders them by end_date" do
+        unpublished = create(
+          :participatory_process,
+          :unpublished,
+          :promoted,
+          organization: organization
+        )
+
+        unpromoted = create(
+          :participatory_process,
+          :unpublished,
+          organization: organization
+        )
+
+        last = create(
+          :participatory_process,
+          :published,
+          :promoted,
+          organization: organization,
+          end_date: nil
+        )
+
+        first = create(
+          :participatory_process,
+          :published,
+          :promoted,
+          organization: organization,
+          end_date: Time.current.advance(days: 10)
+        )
+
+        second = create(
+          :participatory_process,
+          :published,
+          :promoted,
+          organization: organization,
+          end_date: Time.current.advance(days: 20)
+        )
+
+        expect(controller.helpers.promoted_participatory_processes.count).to eq(3)
+        expect(controller.helpers.promoted_participatory_processes).not_to include(unpublished)
+        expect(controller.helpers.promoted_participatory_processes.first).to eq(first)
+        expect(controller.helpers.promoted_participatory_processes.to_a[1]).to eq(second)
+        expect(controller.helpers.promoted_participatory_processes.to_a.last).to eq(last)
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
@@ -2,7 +2,8 @@
 ENV["RAILS_ENV"] ||= "test"
 
 engine_name = ENV["ENGINE_NAME"]
-dummy_app_path = File.expand_path(File.join(Dir.pwd, "spec", "#{engine_name}_dummy_app"))
+engine_spec_dir = File.join(Dir.pwd, "spec")
+dummy_app_path = File.expand_path(File.join(engine_spec_dir, "#{engine_name}_dummy_app"))
 
 if ENV["CI"]
   require "simplecov"
@@ -52,6 +53,8 @@ require "db-query-matchers"
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/rspec_support/**/*.rb"].each { |f| require f }
+Dir["#{engine_spec_dir}/support/**/*.rb"].each { |f| require f }
+Dir["#{engine_spec_dir}/shared/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.color = true

--- a/decidim-meetings/spec/features/admin_manages_meetings_attachments_spec.rb
+++ b/decidim-meetings/spec/features/admin_manages_meetings_attachments_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_attachments_examples"
 
 describe "Admin manages meetings attachments", type: :feature do
   include_context "admin"

--- a/decidim-meetings/spec/features/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/features/admin_manages_meetings_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_meetings_examples"
 
 describe "Admin manages meetings", type: :feature do
   include_context "admin"

--- a/decidim-meetings/spec/features/process_admin_manages_meetings_attachments_spec.rb
+++ b/decidim-meetings/spec/features/process_admin_manages_meetings_attachments_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_attachments_examples"
 
 describe "Process admin manages meetings attachments", type: :feature do
   include_context "admin"

--- a/decidim-meetings/spec/features/process_admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/features/process_admin_manages_meetings_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_meetings_examples"
 
 describe "Process admin manages meetings", type: :feature do
   include_context "admin"

--- a/decidim-proposals/spec/commands/decidim/proposals/admin_create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin_create_proposal_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "spec_helper"
-require_relative "../../../shared/create_proposal_examples"
 
 module Decidim
   module Proposals

--- a/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "spec_helper"
-require_relative "../../../shared/create_proposal_examples"
 
 module Decidim
   module Proposals

--- a/decidim-proposals/spec/features/admin_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/features/admin_manages_proposals_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_proposals_examples"
 
 describe "Admin manages proposals", type: :feature do
   include_context "admin"

--- a/decidim-proposals/spec/features/process_admin_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/features/process_admin_manages_proposals_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_proposals_examples"
 
 describe "Process admin manages proposals", type: :feature do
   include_context "admin"

--- a/decidim-proposals/spec/forms/decidim/proposals/admin_proposal_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin_proposal_form_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "spec_helper"
-require_relative "../../../shared/proposal_form_examples"
 
 module Decidim
   module Proposals

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_form_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "spec_helper"
-require_relative "../../../shared/proposal_form_examples"
 
 module Decidim
   module Proposals

--- a/decidim-results/spec/features/admin_manages_results_spec.rb
+++ b/decidim-results/spec/features/admin_manages_results_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_results_examples"
 
 describe "Admin manages results", type: :feature do
   include_context "admin"

--- a/decidim-results/spec/features/process_admin_manages_results_spec.rb
+++ b/decidim-results/spec/features/process_admin_manages_results_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require_relative "../shared/admin_shared_context"
-require_relative "../shared/manage_results_examples"
 
 describe "Process admin manages results", type: :feature do
   include_context "admin"

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 Decidim.configure do |config|
   config.application_name = "My Application Name"


### PR DESCRIPTION
#### :tophat: What? Why?

Order processes by end date both at the home page & at the process index. I also made a but of gardening since I was tired of having to require shared examples each time, now they are always required at `base_spec_helper`.

#### :pushpin: Related Issues
- Fixes #716 
