### PR TITLE
Add password length validation to registration form

### DIFF
--- a/decidim-core/app/forms/decidim/registration_form.rb
+++ b/decidim-core/app/forms/decidim/registration_form.rb
@@ -19,7 +19,7 @@ module Decidim
     validates :sign_up_as, inclusion: { in: %w(user user_group) }
     validates :name, presence: true
     validates :email, presence: true
-    validates :password, presence: true, confirmation: true
+    validates :password, presence: true, confirmation: true, length: { in: Decidim::User.password_length }
     validates :tos_agreement, allow_nil: false, acceptance: true
 
     validates :user_group_name, presence: true, if: :is_user_group?


### PR DESCRIPTION
#### :tophat: What? Why?

The password length validation was missing in registration form.

#### :pushpin: Related Issues
- Fixes #768 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
