### PR TITLE
Add full toolbar to static pages content

### DIFF
--- a/decidim-admin/app/views/decidim/admin/static_pages/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/_form.html.erb
@@ -9,5 +9,5 @@
 <% end %>
 
 <div class="field">
-  <%= form.translated :editor, :content %>
+  <%= form.translated :editor, :content, toolbar: :full %>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?

The static pages form content field was using the simple toolbar.

#### :pushpin: Related Issues
- Fixes #760 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
