### PR TITLE
Add lopd warning to registrations form

### DIFF
--- a/decidim-core/app/assets/stylesheets/decidim/extras/_register_form.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/extras/_register_form.scss
@@ -1,0 +1,9 @@
+.lopd-text {
+  padding: 0.5rem;
+  border: 1px solid #e8e8e8;
+  margin: 1rem 0;
+  max-height: 10rem;
+  overflow: auto;
+  font-size: 0.8rem;
+  font-style: italic;
+}

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -9,6 +9,7 @@ module Decidim
       include FormFactory
       helper Decidim::TranslationsHelper
       helper Decidim::OmniauthHelper
+      helper_method :terms_and_conditions_page
 
       layout "layouts/decidim/application"
       before_action :configure_permitted_parameters
@@ -41,6 +42,12 @@ module Decidim
             render :new
           end
         end
+      end
+
+      private
+
+      def terms_and_conditions_page
+        @terms_and_conditions_page ||= Decidim::StaticPage.find_by_slug('terms-and-conditions')
       end
 
       protected

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -55,6 +55,10 @@
               </div>
             </div>
 
+            <p class="lopd-text">
+              <%= translated_attribute(terms_and_conditions_page.content) %>
+            </p>
+
             <fieldset>
               <div class="field">
                 <%= f.check_box :tos_agreement, label: t(".tos_agreement", link: link_to(t(".terms"), page_path("terms-and-conditions"))) %>

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -7,6 +7,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
 
   before do
     switch_to_host(organization.host)
+    create(:static_page, slug: "terms-and-conditions", organization: organization)
     visit decidim.root_path
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

I added the content of the `terms-and-conditions` static page to the form.

#### :pushpin: Related Issues
- Implments half #756 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/22595483/f02d1ece-ea27-11e6-8489-a065eace86f3.png)

#### :ghost: GIF
None