### PR TITLE
Replace `content_for` with `provide` when appropiate

### DIFF
--- a/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/dashboard/show.html.erb
@@ -1,3 +1,3 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t("decidim.admin.titles.dashboard") %></h2>
 <% end %>

--- a/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t "decidim.admin.titles.participatory_processes" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/scopes/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t "decidim.admin.titles.scopes" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/scopes/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/static_pages/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t "decidim.admin.titles.static_pages" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/static_pages/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/static_pages/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= link_to translated_attribute(@page.title), @page %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/user_groups/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t "decidim.admin.titles.user_groups" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t "decidim.admin.titles.users" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/decidim/admin/users/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/participatory_process.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= link_to translated_attribute(participatory_process.title), decidim_admin.participatory_process_path(participatory_process) %></h2>
   <h3 class="subheader"><%= translated_attribute(participatory_process.subtitle) %></h3>
 <% end %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t(".title")) %>
+<% provide(:title, t(".title")) %>
 
 <% if current_user.present? %>
   <div class="row column">

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, translated_attribute(project.title)) %>
+<% provide(:title, translated_attribute(project.title)) %>
 
 <div class="row column view-header">
   <% if current_user.present? %>

--- a/decidim-core/app/views/decidim/participatory_process_steps/index.html.erb
+++ b/decidim-core/app/views/decidim/participatory_process_steps/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :meta_title, t(".title") %>
+<% provide :meta_title, t(".title") %>
 
 <main class="steps">
   <div class="row column">

--- a/decidim-core/app/views/decidim/participatory_processes/index.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :meta_title, t(".title") %>
+<% provide :meta_title, t(".title") %>
 
 <main class="wrapper">
   <% if promoted_participatory_processes.any? %>

--- a/decidim-core/app/views/decidim/participatory_processes/show.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/show.html.erb
@@ -1,6 +1,6 @@
-<% content_for :meta_description, translated_attribute(current_participatory_process.short_description) %>
-<% content_for :meta_title, translated_attribute(current_participatory_process.title) %>
-<% content_for :meta_url, participatory_process_url(current_participatory_process) %>
+<% provide :meta_description, translated_attribute(current_participatory_process.short_description) %>
+<% provide :meta_title, translated_attribute(current_participatory_process.title) %>
+<% provide :meta_url, participatory_process_url(current_participatory_process) %>
 
 <div class="row column">
   <div class="row">

--- a/decidim-core/app/views/layouts/decidim/participatory_process.html.erb
+++ b/decidim-core/app/views/layouts/decidim/participatory_process.html.erb
@@ -1,5 +1,3 @@
-<% provide :meta_image_url, current_participatory_process.banner_image.url %>
-
 <%= render "layouts/decidim/application" do %>
   <div class="wrapper">
     <%= render partial: "layouts/decidim/process_header" %>
@@ -15,3 +13,5 @@
     </div>
   <% end %>
 <% end %>
+
+<% provide :meta_image_url, current_participatory_process.banner_image.url %>

--- a/decidim-core/app/views/layouts/decidim/participatory_process.html.erb
+++ b/decidim-core/app/views/layouts/decidim/participatory_process.html.erb
@@ -1,6 +1,4 @@
-<% content_for :meta_image_url do %>
-  <% current_participatory_process.banner_image.url %>
-<% end %>
+<% provide :meta_image_url, current_participatory_process.banner_image.url %>
 
 <%= render "layouts/decidim/application" do %>
   <div class="wrapper">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t(".title")) %>
+<% provide(:title, t(".title")) %>
 
 <% if Decidim.geocoder.present? %>
   <div class="row column">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, translated_attribute(meeting.title)) %>
+<% provide(:title, translated_attribute(meeting.title)) %>
 
 <div class="row column view-header">
   <h2 class="heading2"><%= translated_attribute meeting.title %></h2>

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:meta_title, translated_attribute(@page.title)) %>
+<% provide(:meta_title, translated_attribute(@page.title)) %>
 
 <div class="row column">
   <div class="row">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :meta_description, @proposal.body %>
-<% content_for :meta_title, @proposal.title %>
-<% content_for :meta_url, proposal_url(@proposal.id) %>
-<% content_for :twitter_handler, current_organization.twitter_handler %>
+<% provide :meta_description, @proposal.body %>
+<% provide :meta_title, @proposal.title %>
+<% provide :meta_url, proposal_url(@proposal.id) %>
+<% provide :twitter_handler, current_organization.twitter_handler %>
 
 <%= render partial: "votes_limit" %>
 <div class="row column view-header">

--- a/decidim-results/app/views/decidim/results/results/index.html.erb
+++ b/decidim-results/app/views/decidim/results/results/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t(".title")) %>
+<% provide(:title, t(".title")) %>
 
 <div class="row columns">
   <div class="title-action">

--- a/decidim-results/app/views/decidim/results/results/show.html.erb
+++ b/decidim-results/app/views/decidim/results/results/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, translated_attribute(result.title)) %>
+<% provide(:title, translated_attribute(result.title)) %>
 
 <div class="row column view-header">
   <h2 class="heading2"><%= translated_attribute result.title %></h2>

--- a/decidim-system/app/views/decidim/system/admins/edit.html.erb
+++ b/decidim-system/app/views/decidim/system/admins/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-system/app/views/decidim/system/admins/index.html.erb
+++ b/decidim-system/app/views/decidim/system/admins/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-system/app/views/decidim/system/admins/new.html.erb
+++ b/decidim-system/app/views/decidim/system/admins/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-system/app/views/decidim/system/admins/show.html.erb
+++ b/decidim-system/app/views/decidim/system/admins/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= link_to @admin.email, @admin %></h2>
 <% end %>
 

--- a/decidim-system/app/views/decidim/system/dashboard/show.html.erb
+++ b/decidim-system/app/views/decidim/system/dashboard/show.html.erb
@@ -1,3 +1,3 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t("decidim.system.titles.dashboard") %></h2>
 <% end %>

--- a/decidim-system/app/views/decidim/system/organizations/index.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= t ".title" %></h2>
 <% end %>
 

--- a/decidim-system/app/views/decidim/system/organizations/show.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %>
+<% provide :title do %>
   <h2><%= link_to @organization.name, @organization %></h2>
   <h3 class="subheader"><%= @organization.host %></h3>
   <p><%= translated_attribute @organization.description %></p>


### PR DESCRIPTION
#### :tophat: What? Why?
Using `provide` when there's only gonna be a single appearance of the content to be replaced guarantees that the view can resume streaming right back instead of waiting for potential more appearances, which effectively blocks streaming until the end of the page is reached.

This is especially relevant given that we're using `content_for` right in the title.

Documentation:

http://api.rubyonrails.org/classes/ActionView/Helpers/CaptureHelper.html

#### :pushpin: Related Issues
- https://github.com/AjuntamentdeBarcelona/decidim/pull/730

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/14aumMYgx9CvKw/giphy.gif)
