### PR TITLE
Fix proposals performance

### DIFF
--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -11,7 +11,7 @@ module Decidim
 
       feature_manifest_name "proposals"
 
-      has_many :votes, foreign_key: "decidim_proposal_id", class_name: ProposalVote, dependent: :destroy
+      has_many :votes, foreign_key: "decidim_proposal_id", class_name: ProposalVote, dependent: :destroy, counter_cache: "proposal_votes_count"
 
       validates :title, :body, presence: true
 
@@ -30,7 +30,7 @@ module Decidim
       #
       # Returns Boolean.
       def voted_by?(user)
-        votes.any? { |vote| vote.author == user }
+        votes.where(author: user).any?
       end
 
       # Public: Checks if the organization has given an answer for the proposal.

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_vote_button.html.erb
@@ -1,5 +1,5 @@
 <% if current_user %>
-  <% if proposal.voted_by? current_user %>
+  <% if @voted_proposals ? @voted_proposals.include?(proposal.id) : proposal.voted_by?(current_user) %>
     <% if vote_limit_enabled? %>
       <%= button_to t('.already_voted'), proposal_proposal_vote_path(proposal_id: proposal, from_proposals_list: from_proposals_list), method: :delete, remote: true, data: { disable: true }, class: "card__button button #{vote_button_classes(from_proposals_list)} success" %>
     <% else %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
@@ -1,6 +1,6 @@
 <span class="<%= votes_count_classes(from_proposals_list)[:number] %>">
-  <%= proposal.votes.size %>
+  <%= proposal.proposal_votes_count %>
 </span>
 <span class="<%= votes_count_classes(from_proposals_list)[:label]  %>">
-  <%= t('.count', count: proposal.votes.size) %>
+  <%= t('.count', count: proposal.proposal_votes_count) %>
 </span>

--- a/decidim-proposals/db/migrate/20170205082832_add_index_to_decidim_proposals_proposals_proposal_votes_count.rb
+++ b/decidim-proposals/db/migrate/20170205082832_add_index_to_decidim_proposals_proposals_proposal_votes_count.rb
@@ -1,0 +1,7 @@
+class AddIndexToDecidimProposalsProposalsProposalVotesCount < ActiveRecord::Migration[5.0]
+  def change
+    add_index :decidim_proposals_proposals, :proposal_votes_count
+    add_index :decidim_proposals_proposals, :created_at
+    add_index :decidim_proposals_proposals, :state
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This adds three missing indexes needed to speed up proposal loading. It also fixes the votes lookup (we were loading all the votes and their authors for a proposal) by trading it by an (apparent) N+1.

It applies https://github.com/AjuntamentdeBarcelona/decidim/pull/786 and fixed #793 as well.

#### :pushpin: Related Issues
- Fixes #793

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/26xBwYrIXjIlDjr7G/source.gif)
