### PR TITLE
Fix problems with order selector and history

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim.js.es6
@@ -1,6 +1,7 @@
 // = require decidim/foundation
 // = require modernizr
 // = require svg4everybody.min
+// = require decidim/history
 // = require decidim/append_elements
 // = require decidim/user_registrations
 

--- a/decidim-core/app/assets/javascripts/decidim/form_filter.component.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/form_filter.component.js.es6
@@ -6,8 +6,6 @@
  * @augments Component
  */
 ((exports) => {
-  const { pushState, registerCallback, unregisterCallback } = exports.Decidim.History;
-
   class FormFilterComponent {
     mounted;
     $form;
@@ -29,7 +27,7 @@
       if (this.mounted) {
         this.mounted = false;
         this.$form.off('change', 'input, select', this._onFormChange);
-        unregisterCallback(`filters-${this.$form.attr('id')}`)
+        exports.Decidim.History.unregisterCallback(`filters-${this.$form.attr('id')}`)
       }
     }
 
@@ -42,7 +40,7 @@
       if (this.$form.length > 0 && !this.mounted) {
         this.mounted = true;
         this.$form.on('change', 'input, select', this._onFormChange);
-        registerCallback(`filters-${this.$form.attr('id')}`, () => {
+        exports.Decidim.History.registerCallback(`filters-${this.$form.attr('id')}`, () => {
           this._onPopState();
         });
       }
@@ -143,7 +141,7 @@
       const currentOrder = this._parseLocationOrderValue();
 
       this.$form.find('input.order_filter').val(currentOrder);
-      
+
       if (filterParams) {
         const fieldIds = Object.keys(filterParams);
 
@@ -190,9 +188,10 @@
         newUrl = `${formAction}&${params}`;
       }
 
-      pushState(newUrl);
+      exports.Decidim.History.pushState(newUrl);
     }
   }
 
+  exports.Decidim = exports.Decidim || {};
   exports.Decidim.FormFilterComponent = FormFilterComponent;
 })(window);

--- a/decidim-core/app/assets/javascripts/decidim/form_filter.component.test.js
+++ b/decidim-core/app/assets/javascripts/decidim/form_filter.component.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions */
 require('jquery');
+require('./history.js.es6');
 require('./form_filter.component.js.es6');
 
 const { Decidim: { FormFilterComponent } } = window;
@@ -31,9 +32,6 @@ describe('FormFilterComponent', () => {
       </form>
     `;
     $('body').append(form);
-    window.history = {
-      pushState: sinon.stub()
-    };
     subject = new FormFilterComponent($(document).find('form'));
   });
 
@@ -64,10 +62,6 @@ describe('FormFilterComponent', () => {
       expect(subject.mounted).to.be.truthy;
     });
 
-    it('mounts the component', () => {
-      expect(window.onpopstate).to.equal(subject._onPopState);
-    });
-
     it('binds the form change event', () => {
       expect(subject.$form.on).to.have.been.calledWith('change', 'input, select', subject._onFormChange);
     });
@@ -84,13 +78,6 @@ describe('FormFilterComponent', () => {
 
         expect(stub).to.have.been.calledOnce;
       })
-
-      it('sets the onpopostate callback', () => {
-        sinon.stub(subject.$form, 'serialize').returns('order_start_time=desc')
-        $(selector).find('input[name=order_start_time][value=desc]').trigger('change');
-
-        expect(window.history.pushState).to.have.been.calledWith(null, null, '/filters?order_start_time=desc');
-      });
     });
 
     describe('onpopstate event', () => {
@@ -138,10 +125,6 @@ describe('FormFilterComponent', () => {
 
     it('unbinds the form change event', () => {
       expect(subject.$form.off).to.have.been.calledWith('change', 'input, select', subject._onFormChange);
-    });
-
-    it('removes the onpopostate callback', () => {
-      expect(window.onpopstate).not.to.exist;
     });
   });
 

--- a/decidim-core/app/assets/javascripts/decidim/history.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/history.js.es6
@@ -1,0 +1,35 @@
+/* eslint-disable no-prototype-builtins, no-restricted-syntax */
+// require self
+
+((exports) => {
+  let callbacks = {};
+
+  exports.onpopstate = () => {
+    for (let callbackId in callbacks) {
+      if (callbacks.hasOwnProperty(callbackId)) {
+        callbacks[callbackId]();
+      }
+    }
+  };
+
+  const registerCallback = (callbackId, callback) => {
+    callbacks[callbackId] = callback;
+  };
+
+  const unregisterCallback = (callbackId) => {
+    callbacks[callbackId] = null;
+  }
+
+  const pushState = (url) => {
+    if (window.history) {
+      window.history.pushState(null, null, url);
+    }
+  };
+
+  exports.Decidim = exports.Decidim || {};
+  exports.Decidim.History = {
+    registerCallback,
+    unregisterCallback,
+    pushState
+  };
+})(window);

--- a/decidim-core/app/assets/javascripts/decidim/history.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/history.js.es6
@@ -1,4 +1,4 @@
-/* eslint-disable no-prototype-builtins, no-restricted-syntax */
+/* eslint-disable no-prototype-builtins, no-restricted-syntax, no-param-reassign */
 // require self
 
 ((exports) => {

--- a/decidim-core/app/assets/javascripts/decidim/orders.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/orders.js.es6
@@ -1,9 +1,28 @@
 // = require_self
 
 $(() => {
+  const { pushState, registerCallback } = Decidim.History;
+
   $(document).on("click", ".order-by a", (event) => {
     const $target = $(event.target);
 
     $target.parents('.menu').find('a:first').text($target.text());
+
+    pushState($target.attr('href'));
   })
+
+  registerCallback("orders", () => {
+    const url = window.location.toString();
+    const match = url.match(/order=([^&]*)/);
+    const $orderMenu = $('.order-by .menu');
+    let order = $orderMenu.find('.menu a:first').data('order');
+
+    if (match) {
+      order = match[1];
+    }
+
+    const linkText = $orderMenu.find(`.menu a[data-order="${order}"]`).text();
+
+    $orderMenu.find('a:first').text(linkText);
+  });
 });

--- a/decidim-core/app/assets/javascripts/decidim/orders.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/orders.js.es6
@@ -1,7 +1,7 @@
 // = require_self
 
 $(() => {
-  const { pushState, registerCallback } = Decidim.History;
+  const { pushState, registerCallback } = window.Decidim.History;
 
   $(document).on("click", ".order-by a", (event) => {
     const $target = $(event.target);

--- a/decidim-core/app/helpers/decidim/orders_helper.rb
+++ b/decidim-core/app/helpers/decidim/orders_helper.rb
@@ -22,7 +22,7 @@ module Decidim
     # options - An optional hash of options
     #         * i18n_scope - The scope of the i18n translations
     def order_link(order, options = {})
-      link_to t("#{options[:i18n_scope]}.#{order}"), url_for(params.to_unsafe_h.merge(order: order)), remote: true
+      link_to t("#{options[:i18n_scope]}.#{order}"), url_for(params.to_unsafe_h.merge(page: nil,order: order)), data: { order: order }, remote: true 
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

There was a few minor bugs for the order/filter behavior:

- The order selector was including the the current url page param. I reset the page param so whenever the order is changed the page is reset.

- The order selector wasn't updating the page history. I created a small object `History` to handle the history push and pop states. It's shared between the order and filter components. When a new url is popped out I update the order selector and the filter form so the back button works as expected.

#### :pushpin: Related Issues
- Fixes #793 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
![](https://media.giphy.com/media/l0Exf7JMMf4Lv5TUI/source.gif)
