### PR TITLE
Strip HTML tags from LOPD text on registration

### DIFF
--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -56,7 +56,7 @@
             </div>
 
             <p class="lopd-text">
-              <%= translated_attribute(terms_and_conditions_page.content) %>
+              <%= strip_tags(translated_attribute(terms_and_conditions_page.content)) %>
             </p>
 
             <fieldset>


### PR DESCRIPTION
#### :tophat: What? Why?

We don't want to render that text with HTML tags in it.

