### PR TITLE
Don't crash when a process admin role already exists. Closes #758

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process_admin.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process_admin.rb
@@ -26,6 +26,9 @@ module Decidim
 
         create_participatory_process_admin
         broadcast(:ok)
+      rescue ActiveRecord::RecordInvalid
+        form.errors.add(:email, :taken)
+        broadcast(:invalid)
       end
 
       private

--- a/decidim-admin/app/models/decidim/admin/participatory_process_user_role.rb
+++ b/decidim-admin/app/models/decidim/admin/participatory_process_user_role.rb
@@ -8,7 +8,7 @@ module Decidim
       belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: Decidim::ParticipatoryProcess
 
       ROLES = %w(admin).freeze
-      validates :role, inclusion: { in: ROLES }
+      validates :role, inclusion: { in: ROLES }, uniqueness: { scope: [:user, :participatory_process] }
     end
   end
 end

--- a/decidim-admin/spec/commands/create_participatory_process_admin_spec.rb
+++ b/decidim-admin/spec/commands/create_participatory_process_admin_spec.rb
@@ -30,6 +30,25 @@ describe Decidim::Admin::CreateParticipatoryProcessAdmin do
     end
   end
 
+  context "when a user and a role already exist" do
+    before do
+      create(
+        :participatory_process_user_role,
+        user: user,
+        role: :admin,
+        participatory_process: my_process
+      )
+    end
+
+    it "is not valid" do
+      form_errors = double
+      expect(form_errors).to receive(:add).with(:email, :taken)
+      expect(form).to receive(:errors).and_return(form_errors)
+
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
   context "when everything is ok" do
     it "creates the user role" do
       subject.call

--- a/decidim-admin/spec/models/participatory_process_user_role_spec.rb
+++ b/decidim-admin/spec/models/participatory_process_user_role_spec.rb
@@ -16,6 +16,23 @@ module Decidim
 
         it { is_expected.not_to be_valid }
       end
+
+      context "when a role already exists" do
+        let(:participatory_process_user_role) do
+          build(
+            :participatory_process_user_role,
+            role: existing_role.role,
+            user: existing_role.user,
+            participatory_process: existing_role.participatory_process
+          )
+        end
+
+        let!(:existing_role) do
+          create(:participatory_process_user_role, role: role)
+        end
+
+        it { is_expected.not_to be_valid }
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

There's a missing validation on the model (the database index exists), I didn't add it to the form because there's too much context related to the validation.

#### :pushpin: Related Issues
- Fixes #758