### PR TITLE
Added missing javascript to display the floating budget bar

### DIFF
--- a/decidim-budgets/app/assets/javascripts/decidim/budgets/progressFixed.js.es6
+++ b/decidim-budgets/app/assets/javascripts/decidim/budgets/progressFixed.js.es6
@@ -1,0 +1,23 @@
+$(() => {
+  const checkProgressPosition = () => {
+    let progressFix = document.querySelector("[data-progressbox-fixed]"),
+      progressRef = document.querySelector("[data-progress-reference]"),
+      progressVisibleClass = "is-progressbox-visible";
+
+    if (!progressRef) {
+      return;
+    }
+
+    let progressPosition = progressRef.getBoundingClientRect().bottom;
+    if (progressPosition > 0) {
+      progressFix.classList.remove(progressVisibleClass);
+    } else {
+      progressFix.classList.add(progressVisibleClass);
+    }
+  }
+
+  window.addEventListener("scroll", checkProgressPosition);
+
+  window.DecidimBudgets = window.DecidimBudgets || {};
+  window.DecidimBudgets.checkProgressPosition = checkProgressPosition;
+});

--- a/decidim-budgets/app/assets/javascripts/decidim/budgets/projects.js.es6
+++ b/decidim-budgets/app/assets/javascripts/decidim/budgets/projects.js.es6
@@ -1,3 +1,4 @@
+// = require ./progressFixed
 // = require_self
 
 $(() => {

--- a/decidim-budgets/app/views/decidim/budgets/line_items/update_budget.js.erb
+++ b/decidim-budgets/app/views/decidim/budgets/line_items/update_budget.js.erb
@@ -19,3 +19,5 @@ if ($projectItem.length > 0) {
 if ($projectBudgetButton.length > 0) {
   $projectBudgetButton.html('<%= j(render partial: 'decidim/budgets/projects/project_budget_button', locals: { project: project }) %>');
 }
+
+window.DecidimBudgets.checkProgressPosition();


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the missing javascript code to display the budget
 progress bar while scrolling down the available budgets.

#### :pushpin: Related Issues
- Fixes #734

### :camera: Screenshots (optional)
![screen shot 2017-02-06 at 15 42 09](https://cloud.githubusercontent.com/assets/953911/22651290/d908662e-ec82-11e6-83bf-db9543721684.png)

#### :ghost: GIF
![](https://media.giphy.com/media/3o7TKLy0He9SYe8niE/giphy.gif)
