### PR TITLE
Use check_authorization to verify the actions have been authorized.

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/user_profile.rb
+++ b/decidim-core/app/controllers/concerns/decidim/user_profile.rb
@@ -18,6 +18,7 @@ module Decidim
       helper_method :available_authorization_handlers,
                     :user_groups
 
+      before_action :current_user
       authorize_resource :current_user
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Closes #822.

authorize_resource is too clever and tries to load an instance of the
given class instead of calling the method on the controller.

Since we don't care to load the resource via CanCan, check_authorization
is enough.