### PR TITLE
Translation and locale fixes

### DIFF
--- a/decidim-budgets/config/i18n-tasks.yml
+++ b/decidim-budgets/config/i18n-tasks.yml
@@ -2,3 +2,4 @@ base_locale: en
 locales: [en]
 ignore_unused:
 - "decidim.features.budgets.name"
+- "activemodel.attributes.project.*"

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -1,5 +1,15 @@
 ---
 en:
+  activemodel:
+    attributes:
+      project:
+        budget: Budget
+        decidim_category_id: Category
+        decidim_scope_id: Scope
+        description: Description
+        proposal_ids: Related proposals
+        short_description: Short description
+        title: Title
   decidim:
     budgets:
       actions:
@@ -36,14 +46,17 @@ en:
             title: Title
       projects:
         budget_confirm:
-          are_you_sure: Do you agree? Once you have confirmed your vote, you can not change it.
+          are_you_sure: Do you agree? Once you have confirmed your vote, you can not
+            change it.
           cancel: Cancel
           confirm: Confirm
           description: These are the projects you have chosen to be part of the budget.
           title: Confirm vote
         budget_excess:
           close: Close
-          description: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description: This project exceeds the maximum budget and can not be added.
+            If you want, you can delete a project you have already selected to add,
+            or make your vote with your preferences.
           ok: OK
           title: Maximum budget exceeded
         budget_summary:
@@ -51,9 +64,12 @@ en:
           assigned: 'Assigned:'
           cancel_order: delete your vote and start over
           checked_out:
-            description: You've already voted for the budget. If you've changed your mind, you can %{cancel_link}.
+            description: You've already voted for the budget. If you've changed your
+              mind, you can %{cancel_link}.
             title: Budget vote completed
-          description: "What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget."
+          description: What projects do you think we should allocate budget for? Assign
+            at least %{minimum_budget} to the projects you want and vote with your
+            preferences to define the budget.
           title: You decide the budget
         count:
           projects_count:

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -30,7 +30,7 @@ module Decidim
         tabs_panels = content_tag(:ul, class: "tabs", id: "#{name}-tabs", data: { tabs: true }) do
           locales.each_with_index.inject("".html_safe) do |string, (locale, index)|
             string + content_tag(:li, class: tab_element_class_for("title", index)) do
-              title = I18n.with_locale(locale){ I18n.t(locale, scope: "locales") }
+              title = I18n.with_locale(locale){ I18n.t("name", scope: "locale") }
               element_class = ""
               element_class += "alert" if error?(name_with_locale(name, locale))
               content_tag(:a, title, href: "##{name}-panel-#{index}", class: element_class)

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
@@ -67,7 +67,7 @@ module TranslationHelpers
   def fill_in_i18n_fields(field, tab_selector, localized_values)
     localized_values.each do |locale, value|
       within tab_selector do
-        click_link I18n.with_locale(locale){ I18n.t(locale, scope: "locales") }
+        click_link I18n.with_locale(locale){ I18n.t("name", scope: "locale") }
       end
       yield "#{field}_#{locale}", value
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes several issues related to translations.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
- [x] The locale on the admin fields is wrong
- [x] Missing admin on budgets

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/l0Ex0g98aVovPdfTa/giphy.gif)
