### PR TITLE
Add social media handlers

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -38,6 +38,10 @@ module Decidim
         {
           name: form.name,
           twitter_handler: form.twitter_handler,
+          facebook_handler: form.facebook_handler,
+          instagram_handler: form.instagram_handler,
+          youtube_handler: form.youtube_handler,
+          github_handler: form.github_handler,
           description: form.description,
           welcome_text: form.welcome_text,
           homepage_image: form.homepage_image || organization.homepage_image,

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -11,6 +11,10 @@ module Decidim
 
       attribute :name, String
       attribute :twitter_handler, String
+      attribute :facebook_handler, String
+      attribute :instagram_handler, String
+      attribute :youtube_handler, String
+      attribute :github_handler, String
       attribute :default_locale, String
       attribute :homepage_image
       attribute :logo

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -7,6 +7,22 @@
 </div>
 
 <div class="field">
+  <%= form.text_field :facebook_handler %>
+</div>
+
+<div class="field">
+  <%= form.text_field :instagram_handler %>
+</div>
+
+<div class="field">
+  <%= form.text_field :youtube_handler %>
+</div>
+
+<div class="field">
+  <%= form.text_field :github_handler %>
+</div>
+
+<div class="field">
   <%= form.translated :editor, :description %>
 </div>
 

--- a/decidim-admin/spec/forms/organization_form_spec.rb
+++ b/decidim-admin/spec/forms/organization_form_spec.rb
@@ -6,7 +6,11 @@ module Decidim
   module Admin
     describe OrganizationForm do
       let(:name) { "My super organization" }
-      let(:twitter_handler) { "My awesome handler" }
+      let(:twitter_handler) { "My twitter awesome handler" }
+      let(:facebook_handler) { "My facebook awesome handler" }
+      let(:instagram_handler) { "My instagram awesome handler" }
+      let(:youtube_handler) { "My youtube awesome handler" }
+      let(:github_handler) { "My github awesome handler" }
       let(:welcome_text) do
         {
           en: "Welcome",
@@ -35,7 +39,12 @@ module Decidim
             "description_es" => description[:es],
             "description_ca" => description[:ca],
             "homepage_image" => Rack::Test::UploadedFile.new(File.join(File.dirname(__FILE__), "..", "..", "..", "decidim-dev", "spec", "support", "city.jpeg"), "image/jpeg"),
-            "show_statics" => false
+            "show_statics" => false,
+            "twitter_handler" => twitter_handler,
+            "facebook_handler" => facebook_handler,
+            "instagram_handler" => instagram_handler,
+            "youtube_handler" => youtube_handler,
+            "github_handler" => github_handler
           }
         }
       end

--- a/decidim-core/app/views/layouts/decidim/_footer.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_footer.html.erb
@@ -11,6 +11,7 @@
             </ul>
             <% end %>
           </div>
+          <%= render partial: 'layouts/decidim/social_media_links' %>
         </div>
       </div>
       <div class="mini-footer">

--- a/decidim-core/app/views/layouts/decidim/_social_media_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_social_media_links.html.erb
@@ -24,7 +24,7 @@
     <% if current_organization.youtube_handler.present? %>
       <li>
         <a class="footer-social__icon" target="_blank" title="YouTube" href="https://www.youtube.com/<%= current_organization.youtube_handler %>">
-          <%= icon 'youtube', role: 'img', aria_label: 'Youtube' %>
+          <%= icon 'youtube', role: 'img', aria_label: 'YouTube' %>
         </a>
       </li>
     <% end %>

--- a/decidim-core/app/views/layouts/decidim/_social_media_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_social_media_links.html.erb
@@ -31,7 +31,7 @@
     <% if current_organization.github_handler.present? %>
       <li>
         <a class="footer-social__icon" target="_blank" title="GitHub" href="https://www.github.com/<%= current_organization.github_handler %>">
-          <%= icon 'github', role: 'img', aria_label: 'Github' %>
+          <%= icon 'github', role: 'img', aria_label: 'GitHub' %>
         </a>
       </li>
     <% end %>

--- a/decidim-core/app/views/layouts/decidim/_social_media_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_social_media_links.html.erb
@@ -1,0 +1,39 @@
+<div class="medium-4 large-3 column main__footer__social">
+  <ul class="footer-social">
+    <% if current_organization.twitter_handler.present? %>
+      <li>
+        <a class="footer-social__icon" target="_blank" title="Twitter" href="https://twitter.com/<%= current_organization.twitter_handler %>">
+          <%= icon 'twitter', role: 'img', aria_label: 'Twitter' %>
+        </a>
+      </li>
+    <% end %>
+    <% if current_organization.facebook_handler.present? %>
+      <li>
+        <a class="footer-social__icon" target="_blank" title="Facebook" href="https://www.facebook.com/<%= current_organization.facebook_handler %>">
+          <%= icon 'facebook', role: 'img', aria_label: 'Facebook' %>
+        </a>
+      </li>
+    <% end %>
+    <% if current_organization.instagram_handler.present? %>
+      <li>
+        <a class="footer-social__icon" target="_blank" title="Instagram" href="https://www.instagram.com/<%= current_organization.instagram_handler %>">
+          <%= icon 'instagram', role: 'img', aria_label: 'Instagram' %>
+        </a>
+      </li>
+    <% end %>
+    <% if current_organization.youtube_handler.present? %>
+      <li>
+        <a class="footer-social__icon" target="_blank" title="YouTube" href="https://www.youtube.com/<%= current_organization.youtube_handler %>">
+          <%= icon 'youtube', role: 'img', aria_label: 'Youtube' %>
+        </a>
+      </li>
+    <% end %>
+    <% if current_organization.github_handler.present? %>
+      <li>
+        <a class="footer-social__icon" target="_blank" title="GitHub" href="https://www.github.com/<%= current_organization.github_handler %>">
+          <%= icon 'github', role: 'img', aria_label: 'Github' %>
+        </a>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/decidim-core/db/migrate/20170207091021_add_social_media_handlers_to_organization.rb
+++ b/decidim-core/db/migrate/20170207091021_add_social_media_handlers_to_organization.rb
@@ -1,0 +1,8 @@
+class AddSocialMediaHandlersToOrganization < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_organizations, :instagram_handler, :string
+    add_column :decidim_organizations, :facebook_handler, :string
+    add_column :decidim_organizations, :youtube_handler, :string
+    add_column :decidim_organizations, :github_handler, :string
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -5,6 +5,10 @@ if !Rails.env.production? || ENV["SEED"]
   organization = Decidim::Organization.create!(
     name: Faker::Company.name,
     twitter_handler: Faker::Hipster.word,
+    facebook_handler: Faker::Hipster.word,
+    instagram_handler: Faker::Hipster.word,
+    youtube_handler: Faker::Hipster.word,
+    github_handler: Faker::Hipster.word,
     host: ENV["DECIDIM_HOST"] || "localhost",
     welcome_text: Decidim::Faker::Localized.sentence(5),
     description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -32,6 +32,10 @@ FactoryGirl.define do
   factory :organization, class: Decidim::Organization do
     name { Faker::Company.unique.name }
     twitter_handler { Faker::Hipster.word }
+    facebook_handler { Faker::Hipster.word }
+    instagram_handler { Faker::Hipster.word }
+    youtube_handler { Faker::Hipster.word }
+    github_handler { Faker::Hipster.word }
     sequence(:host) { |n| "#{n}.lvh.me" }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
     welcome_text { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -23,7 +23,7 @@ describe "Homepage", type: :feature do
 
       it "includes links to them" do
         within ".main-footer" do
-          expect(page).to have_css("li a", count: 3)
+          expect(page).to have_css("ul.footer-nav li a", count: 3)
           static_pages.each do |static_page|
             expect(page).to have_content(static_page.title["en"])
           end
@@ -52,19 +52,19 @@ describe "Homepage", type: :feature do
 
       context "when organization show_statistics attribute is false" do
         let(:organization) { create(:organization, show_statistics: false) }
-        
+
         it "should not show the statistics block" do
           expect(page).not_to have_content("Current state of #{organization.name}")
         end
       end
-      
+
       context "when organization show_statistics attribute is true" do
         let(:organization) { create(:organization, show_statistics: true) }
 
         before do
           visit current_path
         end
-        
+
         it "should show the statistics block" do
           within "#statistics" do
             expect(page).to have_content("Current state of #{organization.name}")
@@ -76,12 +76,25 @@ describe "Homepage", type: :feature do
         it "should have the correct values for the statistics" do
           within ".users-count" do
             expect(page).to have_content("4")
-          end     
+          end
 
           within ".processes-count" do
             expect(page).to have_content("2")
-          end 
+          end
         end
+      end
+    end
+
+    describe "social links" do
+      before do
+        visit current_path
+      end
+
+      it "includes the linsk to social networks" do
+        expect(page).to have_xpath("//a[@href = 'https://twitter.com/#{organization.twitter_handler}']")
+        expect(page).to have_xpath("//a[@href = 'https://www.facebook.com/#{organization.facebook_handler}']")
+        expect(page).to have_xpath("//a[@href = 'https://www.youtube.com/#{organization.youtube_handler}']")
+        expect(page).to have_xpath("//a[@href = 'https://www.github.com/#{organization.github_handler}']")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

I added the remaining social media handlers: Facebook, Instagram, Youtube and Github. They can be configured in the organization settings.

The layout footer have a partial which includes links to those social networks.

#### :pushpin: Related Issues
- Implements #769 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/22685609/43fb1384-ed21-11e6-9dbf-5f13aff54196.png)
![image](https://cloud.githubusercontent.com/assets/106021/22685666/7afae9ae-ed21-11e6-9c6f-a8ae958d4b4a.png)

#### :ghost: GIF
![](https://media.giphy.com/media/ZdwMK4xJfX0lO/giphy.gif)
