### PR TITLE
Remove short description from projects

### DIFF
--- a/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/create_project.rb
@@ -33,7 +33,6 @@ module Decidim
             category: @form.category,
             feature: @form.current_feature,
             title: @form.title,
-            short_description: @form.short_description,
             description: @form.description,
             budget: @form.budget
           )

--- a/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/admin/update_project.rb
@@ -37,7 +37,6 @@ module Decidim
             scope: form.scope,
             category: form.category,
             title: form.title,
-            short_description: form.short_description,
             description: form.description,
             budget: form.budget
           )

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -8,7 +8,6 @@ module Decidim
         include TranslationsHelper
 
         translatable_attribute :title, String
-        translatable_attribute :short_description, String
         translatable_attribute :description, String
         attribute :budget, Integer
         attribute :decidim_scope_id, Integer

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -16,7 +16,6 @@ module Decidim
         attribute :proposal_ids, Array[Integer]
 
         validates :title, translatable_presence: true
-        validates :short_description, translatable_presence: true
         validates :description, translatable_presence: true
         validates :budget, presence: true, numericality: { greater_than: 0 }
 

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_form.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_form.html.erb
@@ -3,10 +3,6 @@
 </div>
 
 <div class="field" >
-  <%= form.translated :editor, :short_description %>
-</div>
-
-<div class="field" >
   <%= form.translated :editor, :description %>
 </div>
 

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -27,12 +27,8 @@
   </div>
   <div class="columns mediumlarge-8 mediumlarge-pull-4">
     <div class="section">
-      <%== translated_attribute project.short_description %>
-      <%= render partial: "tags", locals: { project: project } %>
-    </div>
-    <div class="section">
-      <h3 class="section-heading"><%= t(".project_description") %></h3>
       <%== translated_attribute project.description %>
+      <%= render partial: "tags", locals: { project: project } %>
     </div>
     <%= linked_resources_for project, :proposals, "included_proposals" %>
   </div>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -97,7 +97,6 @@ en:
           added: Added
         show:
           budget: Budget
-          project_description: Project description
           view_all_projects: View all projects
     features:
       budgets:

--- a/decidim-budgets/db/migrate/20170207101750_remove_short_description_from_decidim_projects.rb
+++ b/decidim-budgets/db/migrate/20170207101750_remove_short_description_from_decidim_projects.rb
@@ -1,0 +1,5 @@
+class RemoveShortDescriptionFromDecidimProjects < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :decidim_budgets_projects, :short_description
+  end
+end

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -47,9 +47,6 @@ Decidim.register_feature(:budgets) do |feature|
           description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(3)
           end,
-          short_description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-            Decidim::Faker::Localized.paragraph(3)
-          end,
           budget: Faker::Number.number(8)
         )
         Decidim::Attachment.create!(

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -26,7 +26,6 @@ FactoryGirl.define do
   factory :project, class: Decidim::Budgets::Project do
     title { Decidim::Faker::Localized.sentence(3) }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
-    short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     budget { Faker::Number.number(8) }
     feature { create(:budget_feature) }
   end

--- a/decidim-budgets/spec/commands/create_project_spec.rb
+++ b/decidim-budgets/spec/commands/create_project_spec.rb
@@ -21,7 +21,6 @@ describe Decidim::Budgets::Admin::CreateProject do
       :invalid? => invalid,
       title: {en: "title"},
       description: {en: "description"},
-      short_description: {en: "short_description"},
       budget: 10_000_000,
       proposal_ids: proposals.map(&:id),
       scope: scope,

--- a/decidim-budgets/spec/commands/update_project_spec.rb
+++ b/decidim-budgets/spec/commands/update_project_spec.rb
@@ -21,7 +21,6 @@ describe Decidim::Budgets::Admin::UpdateProject do
       :invalid? => invalid,
       title: {en: "title"},
       description: {en: "description"},
-      short_description: {en: "short_description"},
       budget: 10_000_000,
       proposal_ids: proposals.map(&:id),
       scope: scope,

--- a/decidim-budgets/spec/forms/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/project_form_spec.rb
@@ -18,9 +18,6 @@ describe Decidim::Budgets::Admin::ProjectForm do
   let(:description) do
     Decidim::Faker::Localized.sentence(3)
   end
-  let(:short_description) do
-    Decidim::Faker::Localized.sentence(3)
-  end
   let(:budget) { Faker::Number.number(8) }
   let(:scope) { create :scope, organization: organization }
   let(:scope_id) { scope.id }
@@ -32,7 +29,6 @@ describe Decidim::Budgets::Admin::ProjectForm do
       decidim_category_id: category_id,
       title_en: title[:en],
       description_en: description[:en],
-      short_description_en: short_description[:en],
       budget: budget
     }
   end
@@ -49,12 +45,6 @@ describe Decidim::Budgets::Admin::ProjectForm do
 
   describe "when description is missing" do
     let(:description) { { en: nil } }
-
-    it { is_expected.not_to be_valid }
-  end
-
-  describe "when short_description is missing" do
-    let(:short_description) { { en: nil } }
 
     it { is_expected.not_to be_valid }
   end

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -50,13 +50,6 @@ RSpec.shared_examples "manage projects" do
         ca: "El meu projecte"
       )
       fill_in_i18n_editor(
-        :project_short_description,
-        "#short_description-tabs",
-        en: "Short description",
-        es: "Descripción corta",
-        ca: "Descripció curta"
-      )
-      fill_in_i18n_editor(
         :project_description,
         "#description-tabs",
         en: "A longer description",


### PR DESCRIPTION
#### :tophat: What? Why?
This removes the short description from Projects - they weren't used for much.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/26gssIytJvy1b1THO/source.gif)
