### PR TITLE
Add official organization images

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -24,7 +24,7 @@ module Decidim
 
         update_organization
 
-         if @organization.valid?
+        if @organization.valid?
           broadcast(:ok, @organization)
         else
           form.errors.add(:official_img_header, @organization.errors[:official_img_header]) if @organization.errors.include? :official_img_header
@@ -39,7 +39,7 @@ module Decidim
 
       def update_organization
         @organization.assign_attributes(attributes)
-        @organization.save! if @organization.valid?      
+        @organization.save! if @organization.valid?
       end
 
       def attributes
@@ -52,8 +52,8 @@ module Decidim
           logo: form.logo || organization.logo,
           favicon: form.favicon || organization.favicon,
           default_locale: form.default_locale,
-          official_img_header: form.official_img_header,
-          official_img_footer: form.official_img_footer,
+          official_img_header: form.official_img_header || organization.official_img_header,
+          official_img_footer: form.official_img_footer || organization.official_img_footer,
           official_url: form.official_url,
           show_statistics: form.show_statistics
         }

--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -23,7 +23,14 @@ module Decidim
         return broadcast(:invalid) if form.invalid?
 
         update_organization
-        broadcast(:ok)
+
+         if @organization.valid?
+          broadcast(:ok, @organization)
+        else
+          form.errors.add(:official_img_header, @organization.errors[:official_img_header]) if @organization.errors.include? :official_img_header
+          form.errors.add(:official_img_footer, @organization.errors[:official_img_footer]) if @organization.errors.include? :official_img_footer
+          broadcast(:invalid)
+        end
       end
 
       private
@@ -31,7 +38,8 @@ module Decidim
       attr_reader :form, :organization
 
       def update_organization
-        organization.update_attributes!(attributes)
+        @organization.assign_attributes(attributes)
+        @organization.save! if @organization.valid?      
       end
 
       def attributes
@@ -44,6 +52,9 @@ module Decidim
           logo: form.logo || organization.logo,
           favicon: form.favicon || organization.favicon,
           default_locale: form.default_locale,
+          official_img_header: form.official_img_header,
+          official_img_footer: form.official_img_footer,
+          official_url: form.official_url,
           show_statistics: form.show_statistics
         }
       end

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -15,6 +15,9 @@ module Decidim
       attribute :homepage_image
       attribute :logo
       attribute :favicon
+      attribute :official_url
+      attribute :official_img_header
+      attribute :official_img_footer
       attribute :show_statistics
 
       translatable_attribute :description, String
@@ -23,6 +26,9 @@ module Decidim
       validates :name, presence: true
       validates :default_locale, presence: true
       validates :default_locale, inclusion: { in: :available_locales }
+
+      validates :official_img_header, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
+      validates :official_img_footer, file_size: { less_than_or_equal_to: ->(_record) { Decidim.maximum_attachment_size } }, file_content_type: { allow: ["image/jpeg", "image/png"] }
 
       private
 

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -31,5 +31,23 @@
 </div>
 
 <div class="field">
+  <%= form.text_field :official_url %>
+</div>
+
+<div class="field">
+  <%= form.file_field :official_img_header %>
+  <% if current_organization.official_img_header? %>
+      <%= image_tag current_organization.official_img_header.url.to_s %>
+  <% end %>
+</div>
+
+<div class="field">
+  <%= form.file_field :official_img_footer %>
+  <% if current_organization.official_img_footer? %>
+      <%= image_tag current_organization.official_img_footer.url.to_s %>
+  <% end %>
+</div>
+
+<div class="field">
   <%= form.check_box :show_statistics %>
 </div>

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -40,6 +40,12 @@ module Decidim
             expect { command.call }.to broadcast(:invalid)
           end
 
+          it "adds errors to the form" do
+            expect(errors).to receive(:add).with(:official_img_header, "Image too big")
+            expect(errors).to receive(:add).with(:official_img_footer, "Image too big")
+            subject.call
+          end
+
           it "doesn't update the organization" do
             command.call
             organization.reload

--- a/decidim-admin/spec/commands/update_organization_spec.rb
+++ b/decidim-admin/spec/commands/update_organization_spec.rb
@@ -40,17 +40,31 @@ module Decidim
             expect { command.call }.to broadcast(:invalid)
           end
 
-          it "adds errors to the form" do
-            expect(errors).to receive(:add).with(:official_img_header, "Image too big")
-            expect(errors).to receive(:add).with(:official_img_footer, "Image too big")
-            subject.call
-          end
-
           it "doesn't update the organization" do
             command.call
             organization.reload
 
             expect(organization.name).not_to eq("My super organization")
+          end
+        end
+
+        describe "when the organization is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(false)
+            expect(organization).to receive(:valid?).at_least(:once).and_return(false)
+            organization.errors.add(:official_img_header, "Image too big")
+            organization.errors.add(:official_img_footer, "Image too big")
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "adds errors to the form" do
+            command.call
+
+            expect(form.errors[:official_img_header]).not_to be_empty
+            expect(form.errors[:official_img_footer]).not_to be_empty
           end
         end
 

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -13,8 +13,8 @@ module Decidim
     validates :name, :host, uniqueness: true
 
     mount_uploader :homepage_image, Decidim::HomepageImageUploader
-    mount_uploader :official_img_header, Decidim::OfficialImageUploader
-    mount_uploader :official_img_footer, Decidim::OfficialImageUploader
+    mount_uploader :official_img_header, Decidim::OfficialImageHeaderUploader
+    mount_uploader :official_img_footer, Decidim::OfficialImageFooterUploader
     mount_uploader :logo, Decidim::OrganizationLogoUploader
     mount_uploader :favicon, Decidim::OrganizationFaviconUploader
 

--- a/decidim-core/app/models/decidim/organization.rb
+++ b/decidim-core/app/models/decidim/organization.rb
@@ -13,6 +13,8 @@ module Decidim
     validates :name, :host, uniqueness: true
 
     mount_uploader :homepage_image, Decidim::HomepageImageUploader
+    mount_uploader :official_img_header, Decidim::OfficialImageUploader
+    mount_uploader :official_img_footer, Decidim::OfficialImageUploader
     mount_uploader :logo, Decidim::OrganizationLogoUploader
     mount_uploader :favicon, Decidim::OrganizationFaviconUploader
 

--- a/decidim-core/app/uploaders/decidim/official_image_footer_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/official_image_footer_uploader.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Decidim
+  # This class deals with uploading hero images to ParticipatoryProcesses.
+  class OfficialImageFooterUploader < ImageUploader
+    include CarrierWave::MiniMagick
+    process resize_to_limit: [150, 45]
+
+    def max_image_height_or_width
+      200
+    end
+  end
+end

--- a/decidim-core/app/uploaders/decidim/official_image_footer_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/official_image_footer_uploader.rb
@@ -6,7 +6,7 @@ module Decidim
     process resize_to_limit: [150, 45]
 
     def max_image_height_or_width
-      200
+      300
     end
   end
 end

--- a/decidim-core/app/uploaders/decidim/official_image_header_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/official_image_header_uploader.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 module Decidim
   # This class deals with uploading hero images to ParticipatoryProcesses.
-  class OfficialImageUploader < ImageUploader
+  class OfficialImageHeaderUploader < ImageUploader
     include CarrierWave::MiniMagick
+    process resize_to_limit: [40, 40]
 
     def max_image_height_or_width
-      250
+      200
     end
   end
 end

--- a/decidim-core/app/uploaders/decidim/official_image_header_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/official_image_header_uploader.rb
@@ -6,7 +6,7 @@ module Decidim
     process resize_to_limit: [40, 40]
 
     def max_image_height_or_width
-      200
+      300
     end
   end
 end

--- a/decidim-core/app/uploaders/decidim/official_image_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/official_image_uploader.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Decidim
+  # This class deals with uploading hero images to ParticipatoryProcesses.
+  class OfficialImageUploader < ImageUploader
+    include CarrierWave::MiniMagick
+
+    def max_image_height_or_width
+      250
+    end
+  end
+end

--- a/decidim-core/app/views/layouts/decidim/_footer.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_footer.html.erb
@@ -1,7 +1,7 @@
         </main>
       </div><!-- /.footer-separator -->
       <div class="main-footer">
-       <% if current_organization.official_img_footer %>
+       <% if current_organization.official_img_footer? %>
             <%= link_to  current_organization.official_url, class: "main-footer__badge" do %>
               <%= image_tag current_organization.official_img_footer.url.to_s , alt: current_organization.name %>
             <% end %>

--- a/decidim-core/app/views/layouts/decidim/_footer.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_footer.html.erb
@@ -1,6 +1,11 @@
         </main>
       </div><!-- /.footer-separator -->
       <div class="main-footer">
+       <% if current_organization.official_img_footer %>
+            <%= link_to  current_organization.official_url, class: "main-footer__badge" do %>
+              <%= image_tag current_organization.official_img_footer.url.to_s , alt: current_organization.name %>
+            <% end %>
+          <% end %>
         <div class="row">
           <div class="medium-8 large-6 large-offset-3 column main__footer__nav">
             <% if current_organization.static_pages.any? %>

--- a/decidim-core/app/views/layouts/decidim/_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_header.html.erb
@@ -19,7 +19,7 @@
             creates a sticky footer-->
         <!-- Topbar -->
         <div class="title-bar">
-          <% if current_organization.official_img_header %>
+          <% if current_organization.official_img_header? %>
             <%= link_to  current_organization.official_url, class: "logo-cityhall" do %>
               <%= image_tag current_organization.official_img_header.url.to_s , alt: current_organization.name %>
             <% end %>

--- a/decidim-core/app/views/layouts/decidim/_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_header.html.erb
@@ -19,6 +19,11 @@
             creates a sticky footer-->
         <!-- Topbar -->
         <div class="title-bar">
+          <% if current_organization.official_img_header %>
+            <%= link_to  current_organization.official_url, class: "logo-cityhall" do %>
+              <%= image_tag current_organization.official_img_header.url.to_s , alt: current_organization.name %>
+            <% end %>
+          <% end %>
           <div class="row column topbar">
             <div class="logo-wrapper">
               <%= render partial: "layouts/decidim/logo", locals: { organization: current_organization } %>

--- a/decidim-core/db/migrate/20170207093048_add_organization_logo_and_url.rb
+++ b/decidim-core/db/migrate/20170207093048_add_organization_logo_and_url.rb
@@ -1,0 +1,7 @@
+class AddOrganizationLogoAndUrl < ActiveRecord::Migration[5.0]
+   def change
+    add_column :decidim_organizations, :official_img_header, :string
+    add_column :decidim_organizations, :official_img_footer, :string
+    add_column :decidim_organizations, :official_url, :string
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -39,6 +39,9 @@ FactoryGirl.define do
     favicon { test_file("icon.png", "image/png") }
     default_locale I18n.default_locale
     available_locales Decidim.available_locales
+    official_img_header { test_file("avatar.jpg", "image/jpeg") }
+    official_img_footer { test_file("avatar.jpg", "image/jpeg") }
+    official_url  { Faker::Internet.url }
   end
 
   factory :participatory_process, class: Decidim::ParticipatoryProcess do

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -4,11 +4,17 @@ require "spec_helper"
 
 describe "Homepage", type: :feature do
   context "when there's an organization" do
-    let(:organization) { create(:organization) }
+    let(:official_url) { "http://mytesturl.me" }
+    let(:organization) { create(:organization, official_url: official_url) }
 
     before do
       switch_to_host(organization.host)
       visit decidim.root_path
+    end
+
+    it "includes the official organization links and images" do
+      expect(page).to have_selector("a.logo-cityhall[href='#{official_url}']")
+      expect(page).to have_selector("a.main-footer__badge[href='#{official_url}']")
     end
 
     it "welcomes the user" do
@@ -52,19 +58,19 @@ describe "Homepage", type: :feature do
 
       context "when organization show_statistics attribute is false" do
         let(:organization) { create(:organization, show_statistics: false) }
-        
+
         it "should not show the statistics block" do
           expect(page).not_to have_content("Current state of #{organization.name}")
         end
       end
-      
+
       context "when organization show_statistics attribute is true" do
         let(:organization) { create(:organization, show_statistics: true) }
 
         before do
           visit current_path
         end
-        
+
         it "should show the statistics block" do
           within "#statistics" do
             expect(page).to have_content("Current state of #{organization.name}")
@@ -76,11 +82,11 @@ describe "Homepage", type: :feature do
         it "should have the correct values for the statistics" do
           within ".users-count" do
             expect(page).to have_content("4")
-          end     
+          end
 
           within ".processes-count" do
             expect(page).to have_content("2")
-          end 
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the needed fields at organization to upload the two official images ( header and footer) files and the respective link.

#### :pushpin: Related Issues
- Fixes #753

#### :clipboard: Subtasks
- [x] Create the migration
- [x] Add behavior on forms, commands and controllers
- [x] Add tests

### :camera: Screenshots (optional)
<img width="1315" alt="screen shot 2017-02-07 at 15 45 38" src="https://cloud.githubusercontent.com/assets/953911/22695974/df9c224e-ed4c-11e6-933f-212d7834800a.png">

<img width="1401" alt="screen shot 2017-02-07 at 15 45 07" src="https://cloud.githubusercontent.com/assets/953911/22695993/e99ba986-ed4c-11e6-8490-609ba1a194e1.png">

#### :ghost: GIF
![](https://media.giphy.com/media/ANbD1CCdA3iI8/giphy.gif)
