### PR TITLE
Add proposals toggles

### DIFF
--- a/decidim-admin/app/models/decidim/admin/abilities/base.rb
+++ b/decidim-admin/app/models/decidim/admin/abilities/base.rb
@@ -12,6 +12,10 @@ module Decidim
         def initialize(user, context)
           merge ::Decidim::Ability.new(user, context)
           merge ParticipatoryProcessAdmin.new(user, context)
+
+          Decidim.admin_abilities.each do |ability|
+            merge ability.constantize.new(user, context)
+          end
         end
       end
     end

--- a/decidim-core/app/controllers/concerns/decidim/needs_authorization.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_authorization.rb
@@ -26,6 +26,8 @@ module Decidim
 
       def ability_context
         {
+          current_settings: try(:current_settings),
+          feature_settings: try(:feature_settings),
           current_organization: try(:current_organization),
           current_feature: try(:current_feature)
         }

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 require "decidim/core/engine"
 require "decidim/core/version"
@@ -56,6 +57,13 @@ module Decidim
   # Exposes a configuration option: an Array of `cancancan`'s Ability classes
   # that will be automatically included to the base `Decidim::Ability` class.
   config_accessor :abilities do
+    []
+  end
+
+  # Exposes a configuration option: an Array of `cancancan`'s Ability classes
+  # that will be automatically included to the `Decidim::Admin::Abilities::Base`
+  # class.
+  config_accessor :admin_abilities do
     []
   end
 

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_answers_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_answers_controller.rb
@@ -7,10 +7,12 @@ module Decidim
         helper_method :proposal
 
         def edit
+          authorize! :update, proposal
           @form = form(Admin::ProposalAnswerForm).from_model(proposal)
         end
 
         def update
+          authorize! :update, proposal
           @form = form(Admin::ProposalAnswerForm).from_params(params)
 
           Admin::AnswerProposal.call(@form, proposal) do

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -8,10 +8,12 @@ module Decidim
         helper_method :proposals
 
         def new
+          authorize! :create, Proposal
           @form = form(Admin::ProposalForm).from_params({})
         end
 
         def create
+          authorize! :create, Proposal
           @form = form(Admin::ProposalForm).from_params(params)
 
           Admin::CreateProposal.call(@form) do

--- a/decidim-proposals/app/models/decidim/proposals/abilities/admin_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/admin_user.rb
@@ -17,6 +17,7 @@ module Decidim
 
           can :manage, Proposal
           cannot :create, Proposal unless can_create_proposal?
+          cannot :update, Proposal unless can_update_proposal?
         end
 
         private
@@ -32,6 +33,11 @@ module Decidim
         def can_create_proposal?
           current_settings.try(:creation_enabled?) &&
             feature_settings.try(:official_proposals_enabled)
+        end
+
+        def can_update_proposal?
+          current_settings.try(:proposal_answering_enabled) &&
+            feature_settings.try(:proposal_answering_enabled)
         end
       end
     end

--- a/decidim-proposals/app/models/decidim/proposals/abilities/admin_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/admin_user.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    module Abilities
+      # Defines the abilities related to proposals for a logged in admin user.
+      # Intended to be used with `cancancan`.
+      class AdminUser
+        include CanCan::Ability
+
+        attr_reader :user, :context
+
+        def initialize(user, context)
+          return unless user && user.role?(:admin)
+
+          @user = user
+          @context = context
+
+          can :manage, Proposal
+          cannot :create, Proposal unless can_create_proposal?
+        end
+
+        private
+
+        def current_settings
+          context.fetch(:current_settings, nil)
+        end
+
+        def feature_settings
+          context.fetch(:feature_settings, nil)
+        end
+
+        def can_create_proposal?
+          current_settings.try(:creation_enabled?) &&
+            feature_settings.try(:official_proposals_enabled)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
@@ -20,6 +20,7 @@ module Decidim
           end
 
           cannot :create, Proposal unless can_create_proposal?
+          cannot :update, Proposal unless can_update_proposal?
         end
 
         private
@@ -40,6 +41,11 @@ module Decidim
           current_settings.try(:creation_enabled?) &&
             feature_settings.try(:official_proposals_enabled) &&
             participatory_processes.include?(current_feature.try(:participatory_process))
+        end
+
+        def can_update_proposal?
+          current_settings.try(:proposal_answering_enabled) &&
+            feature_settings.try(:proposal_answering_enabled)
         end
 
         def participatory_processes

--- a/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
@@ -39,7 +39,7 @@ module Decidim
         def can_create_proposal?
           current_settings.try(:creation_enabled?) &&
             feature_settings.try(:official_proposals_enabled) &&
-            paricipatory_processes.include?(current_feature)
+            participatory_processes.include?(current_feature.try(:participatory_process))
         end
 
         def participatory_processes

--- a/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    module Abilities
+      # Defines the abilities related to proposals for a logged in process admin user.
+      # Intended to be used with `cancancan`.
+      class ProcessAdminUser
+        include CanCan::Ability
+
+        attr_reader :user, :context
+
+        def initialize(user, context)
+          return unless user && !user.role?(:admin)
+
+          @user = user
+          @context = context
+
+          can :manage, Proposal do |proposal|
+            participatory_processes.include?(proposal.feature.participatory_process)
+          end
+
+          cannot :create, Proposal unless can_create_proposal?
+        end
+
+        private
+
+        def current_settings
+          context.fetch(:current_settings, nil)
+        end
+
+        def feature_settings
+          context.fetch(:feature_settings, nil)
+        end
+
+        def current_feature
+          context.fetch(:current_feature, nil)
+        end
+
+        def can_create_proposal?
+          current_settings.try(:creation_enabled?) &&
+            feature_settings.try(:official_proposals_enabled) &&
+            paricipatory_processes.include?(current_feature)
+        end
+
+        def participatory_processes
+          @participatory_processes ||= Decidim::Admin::ManageableParticipatoryProcessesForUser.for(@user)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -12,7 +12,7 @@
   </div>
 <% end %>
 
-<% if @form.scopes&.any? %>
+<% if @form.scopes&.any? && feature_settings.scoped_proposals_enabled %>
   <div class="field">
     <%= form.select :scope_id, @form.scopes.map{|s| [s.name, s.id]}, prompt: t(".select_a_scope") %>
   </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -9,7 +9,9 @@
     <tr>
       <th><%= t("models.proposal.fields.title", scope: "decidim.proposals") %></th>
       <th><%= t("models.proposal.fields.category", scope: "decidim.proposals") %></th>
-      <th><%= t("models.proposal.fields.scope", scope: "decidim.proposals") %></th>
+      <% if feature_settings.scoped_proposals_enabled %>
+        <th><%= t("models.proposal.fields.scope", scope: "decidim.proposals") %></th>
+      <% end %>
       <th><%= t("models.proposal.fields.state", scope: "decidim.proposals") %></th>
       <th class="actions"><%= t("actions.title", scope: "decidim.proposals") %></th>
     </tr>
@@ -25,11 +27,13 @@
             <%= translated_attribute proposal.category.name %>
           <% end %>
         </td>
-        <td>
-          <% if proposal.scope %>
-            <%= translated_attribute proposal.scope.name %>
-          <% end %>
-        </td>
+        <% if feature_settings.scoped_proposals_enabled %>
+          <td>
+            <% if proposal.scope %>
+              <%= translated_attribute proposal.scope.name %>
+            <% end %>
+          </td>
+        <% end %>
         <td>
           <%= humanize_proposal_state proposal.state %>
         </td>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -1,8 +1,10 @@
 <h2><%= t(".title") %></h2>
 
-<div class="actions title">
-  <%= link_to t("actions.new", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), new_proposal_path, class: 'new' if can? :manage, current_feature %>
-</div>
+<% if feature_settings.official_proposals_enabled %>
+  <div class="actions title">
+    <%= link_to t("actions.new", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), new_proposal_path, class: 'new' if can? :manage, current_feature %>
+  </div>
+<% end %>
 
 <table class="stack">
   <thead>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -40,7 +40,7 @@
           <%= humanize_proposal_state proposal.state %>
         </td>
         <td class="actions">
-          <%= link_to t("actions.answer", scope: "decidim.proposals"), edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id) if can? :update, current_feature %>
+          <%= link_to t("actions.answer", scope: "decidim.proposals"), edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id) if can? :update, proposal %>
         </td>
       </tr>
     <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -12,7 +12,9 @@
     </div>
   </div>
 
-  <%= form.collection_radio_buttons :origin, [["all", t('.all')], ["official", t('.official')], ["citizenship", t('.citizenship')]], :first, :last, legend_title: t('.origin') %>
+  <% if feature_settings.official_proposals_enabled %>
+    <%= form.collection_radio_buttons :origin, [["all", t('.all')], ["official", t('.official')], ["citizenship", t('.citizenship')]], :first, :last, legend_title: t('.origin') %>
+  <% end %>
 
   <%= form.collection_radio_buttons :state, [["all", t('.all')], ["accepted", t('.accepted')], ["rejected", t('.rejected')]], :first, :last, legend_title: t('.state') %>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -24,7 +24,7 @@
     <%= form.collection_check_boxes :activity, [["voted", t('.voted')]], :first, :last, legend_title: t('.activity') %>
   <% end %>
 
-  <% if current_organization.scopes.any? %>
+  <% if current_organization.scopes.any? && feature_settings.scoped_proposals_enabled %>
     <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t('.scopes') %>
   <% end %>
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -16,7 +16,9 @@
     <%= form.collection_radio_buttons :origin, [["all", t('.all')], ["official", t('.official')], ["citizenship", t('.citizenship')]], :first, :last, legend_title: t('.origin') %>
   <% end %>
 
-  <%= form.collection_radio_buttons :state, [["all", t('.all')], ["accepted", t('.accepted')], ["rejected", t('.rejected')]], :first, :last, legend_title: t('.state') %>
+  <% if feature_settings.proposal_answering_enabled && current_settings.proposal_answering_enabled %>
+    <%= form.collection_radio_buttons :state, [["all", t('.all')], ["accepted", t('.accepted')], ["rejected", t('.rejected')]], :first, :last, legend_title: t('.state') %>
+  <% end %>
 
   <% if linked_classes_for(Decidim::Proposals::Proposal).any? %>
     <%= form.collection_radio_buttons :related_to, linked_classes_filter_values_for(Decidim::Proposals::Proposal), :first, :last, legend_title: t('.related_to') %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_tags.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_tags.html.erb
@@ -3,7 +3,7 @@
     <% if proposal.category.present? %>
       <li><%= link_to translated_attribute(proposal.category.name), decidim_proposals.proposals_path(filter: { category_id: proposal.category.id }) %></li>
     <% end %>
-    <% if proposal.scope.present? %>
+    <% if proposal.scope.present? && feature_settings.scoped_proposals_enabled %>
       <li><%= link_to proposal.scope.name, decidim_proposals.proposals_path(filter: { scope_id: [proposal.scope.id] }) %></li>
     <% end %>
   </ul>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/new.html.erb
@@ -24,7 +24,7 @@
             </div>
           <% end %>
 
-          <% if @form.scopes&.any? %>
+          <% if @form.scopes&.any? && feature_settings.scoped_proposals_enabled %>
             <div class="field">
               <%= form.select :scope_id, @form.scopes.map{|s| [s.name, s.id]}, prompt: t(".select_a_scope") %>
             </div>

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -16,8 +16,8 @@ module Decidim
 
       initializer "decidim_proposals.inject_abilities_to_user" do |_app|
         Decidim.configure do |config|
-          config.abilities += ["Decidim::Proposals::Abilities::AdminUser"]
-          config.abilities += ["Decidim::Proposals::Abilities::ProcessAdminUser"]
+          config.admin_abilities += ["Decidim::Proposals::Abilities::AdminUser"]
+          config.admin_abilities += ["Decidim::Proposals::Abilities::ProcessAdminUser"]
         end
       end
 

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -14,6 +14,13 @@ module Decidim
         root to: "proposals#index"
       end
 
+      initializer "decidim_proposals.inject_abilities_to_user" do |_app|
+        Decidim.configure do |config|
+          config.abilities += ["Decidim::Proposals::Abilities::AdminUser"]
+          config.abilities += ["Decidim::Proposals::Abilities::ProcessAdminUser"]
+        end
+      end
+
       def load_seed
         nil
       end

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -16,6 +16,9 @@ Decidim.register_feature(:proposals) do |feature|
   feature.settings(:global) do |settings|
     settings.attribute :vote_limit, type: :integer, default: 0
     settings.attribute :comments_always_enabled, type: :boolean, default: true
+    settings.attribute :proposal_answering_enabled, type: :boolean, default: true
+    settings.attribute :official_proposals_enabled, type: :boolean, default: true
+    settings.attribute :scoped_proposals_enabled, type: :boolean, default: true
   end
 
   feature.settings(:step) do |settings|
@@ -23,6 +26,7 @@ Decidim.register_feature(:proposals) do |feature|
     settings.attribute :votes_blocked, type: :boolean
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :creation_enabled, type: :boolean
+    settings.attribute :proposal_answering_enabled, type: :boolean, default: true
   end
 
   feature.register_resource do |resource|

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -130,7 +130,7 @@ describe "Proposals", type: :feature do
       let!(:proposal) { create(:proposal, feature: feature, scope: scope) }
 
       before do
-        feature.update_attributes(settings: { scoped_proposals_enabled: true})
+        feature.update_attributes(settings: { scoped_proposals_enabled: true } )
       end
 
       it "can be filtered by scope" do
@@ -144,7 +144,7 @@ describe "Proposals", type: :feature do
       let!(:proposal) { create(:proposal, feature: feature, scope: scope) }
 
       before do
-        feature.update_attributes(settings: { scoped_proposals_enabled: false})
+        feature.update_attributes(settings: { scoped_proposals_enabled: false } )
       end
 
       it "cannot be filtered by scope" do
@@ -325,7 +325,7 @@ describe "Proposals", type: :feature do
 
       context "when official_proposals setting is not enabled" do
         before do
-          feature.update_attributes(settings: { official_proposals_enabled: false})
+          feature.update_attributes(settings: { official_proposals_enabled: false } )
         end
 
         it "cannot be filtered by origin" do
@@ -338,7 +338,7 @@ describe "Proposals", type: :feature do
 
       context "when scoped_proposals setting is enabled" do
         before do
-          feature.update_attributes(settings: { scoped_proposals_enabled: true})
+          feature.update_attributes(settings: { scoped_proposals_enabled: true } )
         end
 
         it "cannot be filtered by scope" do
@@ -351,7 +351,7 @@ describe "Proposals", type: :feature do
 
       context "when scoped_proposals setting is not enabled" do
         before do
-          feature.update_attributes(settings: { scoped_proposals_enabled: false})
+          feature.update_attributes(settings: { scoped_proposals_enabled: false } )
         end
 
         it "cannot be filtered by scope" do
@@ -364,7 +364,7 @@ describe "Proposals", type: :feature do
 
       context "when proposal_answering feature setting is enabled" do
         before do
-          feature.update_attributes(settings: { proposal_answering_enabled: true})
+          feature.update_attributes(settings: { proposal_answering_enabled: true } )
         end
 
         context "when proposal_answering step setting is enabled" do
@@ -444,7 +444,7 @@ describe "Proposals", type: :feature do
 
       context "when proposal_answering feature setting is not enabled" do
         before do
-          feature.update_attributes(settings: { proposal_answering_enabled: false})
+          feature.update_attributes(settings: { proposal_answering_enabled: false } )
         end
 
         it "cannot be filtered by state" do

--- a/decidim-proposals/spec/features/proposals_spec.rb
+++ b/decidim-proposals/spec/features/proposals_spec.rb
@@ -285,6 +285,32 @@ describe "Proposals", type: :feature do
     end
 
     context "when filtering" do
+      context "when official_proposals setting is enabled" do
+        before do
+          feature.update_attributes(settings: { official_proposals_enabled: true})
+        end
+
+        it "cannot be filtered by origin" do
+          within "form.new_filter" do
+            visit_feature
+            expect(page).to have_content(/Origin/i)
+          end
+        end
+      end
+
+      context "when official_proposals setting is not enabled" do
+        before do
+          feature.update_attributes(settings: { official_proposals_enabled: false})
+        end
+
+        it "cannot be filtered by origin" do
+          within "form.new_filter" do
+            visit_feature
+            expect(page).not_to have_content("Origin")
+          end
+        end
+      end
+
       context "when scoped_proposals setting is enabled" do
         before do
           feature.update_attributes(settings: { scoped_proposals_enabled: true})

--- a/decidim-proposals/spec/models/decidim/proposals/abilities/admin_user_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/abilities/admin_user_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Decidim::Proposals::Abilities::AdminUser do
+  let(:user) { build(:user, :admin) }
+  let(:context) { {} }
+
+  subject { described_class.new(user, context) }
+
+  context "when the user is not an admin" do
+    let(:user) { build(:user) }
+
+    it "doesn't have any permission" do
+      expect(subject.permissions[:can]).to be_empty
+      expect(subject.permissions[:cannot]).to be_empty
+    end
+  end
+
+  it { is_expected.to be_able_to(:manage, Decidim::Proposals::Proposal) }
+
+  context "when creation is disabled" do
+    let(:context) do
+      {
+        current_settings: double(creation_enabled?: false),
+        feature_settings: double(official_proposals_enabled: true)
+      }
+    end
+
+    it { is_expected.not_to be_able_to(:create, Decidim::Proposals::Proposal) }
+  end
+
+  context "when official proposals are disabled" do
+    let(:context) do
+      {
+        current_settings: double(creation_enabled?: true),
+        feature_settings: double(official_proposals_enabled: false)
+      }
+    end
+
+    it { is_expected.not_to be_able_to(:create, Decidim::Proposals::Proposal) }
+  end
+end

--- a/decidim-proposals/spec/models/decidim/proposals/abilities/admin_user_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/abilities/admin_user_spec.rb
@@ -39,4 +39,24 @@ describe Decidim::Proposals::Abilities::AdminUser do
 
     it { is_expected.not_to be_able_to(:create, Decidim::Proposals::Proposal) }
   end
+
+  context "when proposal_answering is disabled in step level" do
+    let(:context) do
+      {
+        current_settings: double(proposal_answering_enabled: false)
+      }
+    end
+
+    it { is_expected.not_to be_able_to(:update, Decidim::Proposals::Proposal) }
+  end
+
+  context "when proposal_answering is disabled in feature level" do
+    let(:context) do
+      {
+        feature_settings: double(proposal_answering_enabled: false)
+      }
+    end
+
+    it { is_expected.not_to be_able_to(:update, Decidim::Proposals::Proposal) }
+  end
 end

--- a/decidim-proposals/spec/models/decidim/proposals/abilities/process_admin_user_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/abilities/process_admin_user_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Decidim::Proposals::Abilities::ProcessAdminUser do
+  let(:user) { build(:user) }
+  let(:user_process) { create :participatory_process, organization: user.organization }
+  let(:context) { {} }
+
+  subject { described_class.new(user, context) }
+
+  context "when the user is an admin" do
+    let(:user) { build(:user, :admin) }
+
+    it "doesn't have any permission" do
+      expect(subject.permissions[:can]).to be_empty
+      expect(subject.permissions[:cannot]).to be_empty
+    end
+  end
+
+  it { is_expected.to be_able_to(:manage, Decidim::Proposals::Proposal) }
+
+  context "when creation is disabled" do
+    let(:context) do
+      {
+        current_settings: double(creation_enabled?: false),
+        feature_settings: double(official_proposals_enabled: true)
+      }
+    end
+
+    it { is_expected.not_to be_able_to(:create, Decidim::Proposals::Proposal) }
+  end
+
+  context "when official proposals are disabled" do
+    let(:context) do
+      {
+        current_settings: double(creation_enabled?: true),
+        feature_settings: double(official_proposals_enabled: false)
+      }
+    end
+
+    it { is_expected.not_to be_able_to(:create, Decidim::Proposals::Proposal) }
+  end
+end

--- a/decidim-proposals/spec/models/decidim/proposals/abilities/process_admin_user_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/abilities/process_admin_user_spec.rb
@@ -40,4 +40,24 @@ describe Decidim::Proposals::Abilities::ProcessAdminUser do
 
     it { is_expected.not_to be_able_to(:create, Decidim::Proposals::Proposal) }
   end
+
+  context "when proposal_answering is disabled in step level" do
+    let(:context) do
+      {
+        current_settings: double(proposal_answering_enabled: false)
+      }
+    end
+
+    it { is_expected.not_to be_able_to(:update, Decidim::Proposals::Proposal) }
+  end
+
+  context "when proposal_answering is disabled in feature level" do
+    let(:context) do
+      {
+        feature_settings: double(proposal_answering_enabled: false)
+      }
+    end
+
+    it { is_expected.not_to be_able_to(:update, Decidim::Proposals::Proposal) }
+  end
 end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -15,7 +15,7 @@ RSpec.shared_examples "manage proposals" do
   context "creation" do
     context "when official_proposals setting is enabled" do
       before do
-        current_feature.update_attributes(settings: { official_proposals_enabled: true})
+        current_feature.update_attributes(settings: { official_proposals_enabled: true } )
       end
 
       context "when creation is enabled" do
@@ -31,7 +31,7 @@ RSpec.shared_examples "manage proposals" do
 
         context "when scoped_proposals setting is enabled" do
           before do
-            current_feature.update_attributes(settings: { scoped_proposals_enabled: true})
+            current_feature.update_attributes(settings: { scoped_proposals_enabled: true } )
           end
 
           it "can be filtered by scope" do
@@ -45,7 +45,7 @@ RSpec.shared_examples "manage proposals" do
 
         context "when scoped_proposals setting is not enabled" do
           before do
-            current_feature.update_attributes(settings: { scoped_proposals_enabled: false})
+            current_feature.update_attributes(settings: { scoped_proposals_enabled: false } )
           end
 
           it "cannot be filtered by scope" do
@@ -87,7 +87,7 @@ RSpec.shared_examples "manage proposals" do
 
     context "when official_proposals setting is disabled" do
       before do
-        current_feature.update_attributes(settings: { official_proposals_enabled: false})
+        current_feature.update_attributes(settings: { official_proposals_enabled: false } )
       end
 
       it "cannot create a new proposal" do
@@ -99,7 +99,7 @@ RSpec.shared_examples "manage proposals" do
 
   context "when the proposal_answering feature setting is enabled" do
     before do
-      current_feature.update_attributes(settings: { proposal_answering_enabled: true})
+      current_feature.update_attributes(settings: { proposal_answering_enabled: true } )
     end
 
     context "when the proposal_answering step setting is enabled" do
@@ -186,7 +186,7 @@ RSpec.shared_examples "manage proposals" do
 
   context "when the proposal_answering feature setting is disabled" do
     before do
-      current_feature.update_attributes(settings: { proposal_answering_enabled: false })
+      current_feature.update_attributes(settings: { proposal_answering_enabled: false } )
     end
 
     it "cannot answer a proposal" do

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -12,29 +12,59 @@ RSpec.shared_examples "manage proposals" do
     end
   end
 
-  it "creates a new proposal" do
-    find(".actions .new").click
+  context "creation" do
+    context "when scoped_proposals setting is enabled" do
+      before do
+        current_feature.update_attributes(settings: { scoped_proposals_enabled: true})
+      end
 
-    within ".new_proposal" do
-      fill_in :proposal_title, with: "Make decidim great again"
-      fill_in :proposal_body, with: "Decidim is great but it can be better"
-      select category.name["en"], from: :proposal_category_id
-      select scope.name, from: :proposal_scope_id
+      it "can be filtered by scope" do
+        find(".actions .new").click
 
-      find("*[type=submit]").click
+        within "form" do
+          expect(page).to have_content(/Scope/i)
+        end
+      end
     end
 
-    within ".flash" do
-      expect(page).to have_content("successfully")
+    context "when scoped_proposals setting is not enabled" do
+      before do
+        current_feature.update_attributes(settings: { scoped_proposals_enabled: false})
+      end
+
+      it "cannot be filtered by scope" do
+        find(".actions .new").click
+
+        within "form" do
+          expect(page).not_to have_content(/Scope/i)
+        end
+      end
     end
 
-    within "table" do
-      proposal = Decidim::Proposals::Proposal.last
+    it "creates a new proposal" do
+      find(".actions .new").click
 
-      expect(page).to have_content("Make decidim great again")
-      expect(proposal.body).to eq("Decidim is great but it can be better")
-      expect(proposal.category).to eq(category)
-      expect(proposal.scope).to eq(scope)
+      within ".new_proposal" do
+        fill_in :proposal_title, with: "Make decidim great again"
+        fill_in :proposal_body, with: "Decidim is great but it can be better"
+        select category.name["en"], from: :proposal_category_id
+        select scope.name, from: :proposal_scope_id
+
+        find("*[type=submit]").click
+      end
+
+      within ".flash" do
+        expect(page).to have_content("successfully")
+      end
+
+      within "table" do
+        proposal = Decidim::Proposals::Proposal.last
+
+        expect(page).to have_content("Make decidim great again")
+        expect(proposal.body).to eq("Decidim is great but it can be better")
+        expect(proposal.category).to eq(category)
+        expect(proposal.scope).to eq(scope)
+      end
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Adds some toggles to proposals to enable/disable filters and features. See related issues and subtasks to see what this PR is doing.

#### :pushpin: Related Issues
- Fixes #834
- Fixes #835 
- Fixes #836

#### :clipboard: Subtasks
- [x] Add toggle for scopes (#835)
- [x] Do not let users filter by scope if disabled (#835)
- [x] Do not let admins relate proposals and scopes when disabled (#835)
- [x] Do not let users relate proposals and scopes when disabled (#835)
- [x] Hide scope in index and show views when disabled (#835)
- [x] Public views specs (#835)
- [x] Admin views specs (#835)
- [x] Add toggle for official proposals (#834)
- [x] Do not let users filter by origin if disabled (#834)
- [x] Do not let admins create proposals when disabled (#834)
- [x] Public views specs (#834)
- [x] Admin views specs (#834)
- [x] Modify admin abilities && add specs (#834)
- [x] Modify process admin abilities && add specs (#834)
- [x] Add toggle for proposal answering, on feature & step level (#836)
- [x] Do not let users filter by state when feature is disabled (#836)
- [x] Do not let admins answer proposals when disabled (#836)
- [x] Public views specs (#836)
- [x] Admin views specs (#836)