### PR TITLE
Fix authorization by using decidim_form

### DIFF
--- a/decidim-core/app/helpers/decidim/authorization_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/authorization_form_helper.rb
@@ -19,7 +19,7 @@ module Decidim
       }
 
       options = default_options.merge(options)
-      decidim_form_for(record, options, &block)
+      form_for(record, options, &block)
     end
   end
 end

--- a/decidim-core/spec/helpers/decidim/authorization_form_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/authorization_form_helper_spec.rb
@@ -19,7 +19,7 @@ module Decidim
           url: "/authorizations"
         }
 
-        expect(helper).to receive(:decidim_form_for).with(record, options)
+        expect(helper).to receive(:form_for).with(record, options)
 
         helper.authorization_form_for(record) {|f| }
       end
@@ -34,7 +34,7 @@ module Decidim
           }
         }
 
-        expect(helper).to receive(:decidim_form_for).with(record, options)
+        expect(helper).to receive(:form_for).with(record, options)
 
         helper.authorization_form_for(record, html: { class: "custom_form" }) {|f| }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Don't use `decidim_form_for` in authorizations.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3o6MbgvmKoRDibkU8w/giphy.gif)
