### PR TITLE
Fix the hero image to be displayed on all browsers.

### DIFF
--- a/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
@@ -13,7 +13,7 @@
     </div>
     <div class="columns mediumlarge-8 large-6 card--process__column">
       <div class="card--full__image"
-           style="background-image:url(<%= promoted_process.hero_image.url %>">
+           style="background-image:url(<%= promoted_process.hero_image.url %>")>
         <div class="card__content row collapse">
           <div class="large-6 large-offset-6 columns">
             <%= link_to participatory_process_path(promoted_process), class: "button expanded button--sc" do %>

--- a/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_promoted_process.html.erb
@@ -13,7 +13,7 @@
     </div>
     <div class="columns mediumlarge-8 large-6 card--process__column">
       <div class="card--full__image"
-           style="background-image:url(<%= promoted_process.hero_image.url %>")>
+           style="background-image:url(<%= promoted_process.hero_image.url %>)">
         <div class="card__content row collapse">
           <div class="large-6 large-offset-6 columns">
             <%= link_to participatory_process_path(promoted_process), class: "button expanded button--sc" do %>

--- a/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
+++ b/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
@@ -8,8 +8,7 @@
           <div class="column">
             <article class="card card--process card--mini">
               <%= link_to participatory_process_path(process), class: "card__link" do %>
-                <div class="card__image-top"
-                     style="background-image:url(<%= process.hero_image.url %>)"></div>
+                <div class="card__image-top" style="background-image:url(<%= process.hero_image.url %>)"></div>
               <% end %>
               <div class="card__content">
                 <%= link_to participatory_process_path(process), class: "card__link" do %>

--- a/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
+++ b/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
@@ -8,7 +8,8 @@
           <div class="column">
             <article class="card card--process card--mini">
               <%= link_to participatory_process_path(process), class: "card__link" do %>
-                <div class="card__image-top" style="background-image:url(<%= process.hero_image.url %>)"></div>
+                <div class="card__image-top"
+                     style="background-image:url(<%= process.hero_image.url %>)"></div>
               <% end %>
               <div class="card__content">
                 <%= link_to participatory_process_path(process), class: "card__link" do %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the problem with the missing hero image in processes, It had a missing a parenthesis.

#### :pushpin: Related Issues
- Fixes #823 