### PR TITLE
Fix start & end time for meetings

### DIFF
--- a/decidim-admin/app/forms/decidim/admin/permission_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/permission_form.rb
@@ -14,13 +14,13 @@ module Decidim
       def sanitize
         self.authorization_handler_name = nil if authorization_handler_name.blank?
         self.options = nil if authorization_handler_name.blank?
-        self.options = nil if self.options.blank?
+        self.options = nil if options.blank?
       end
 
       def options_is_valid_json
         return unless options
 
-        result = JSON.parse(self.options)
+        result = JSON.parse(options)
         errors.add(:options, :invalid_json) unless result.is_a?(Hash)
         result
       rescue JSON::ParserError

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -8,7 +8,7 @@ Decidim.register_feature(:budgets) do |feature|
   feature.icon = "decidim/budgets/icon.svg"
   feature.stylesheet = "decidim/budgets/budgets"
 
-  feature.actions = %{vote}
+  feature.actions = %(vote)
 
   feature.on(:before_destroy) do |instance|
     raise StandardError, "Can't remove this feature" if Decidim::Budgets::Project.where(feature: instance).any?

--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -13,19 +13,20 @@ module Decidim
 
     layout "layouts/decidim/user_profile", only: [:index]
 
-    def new
-    end
+    def new; end
 
     def index
       @authorizations = current_user.authorizations
     end
 
     def first_login
-      redirect_to(
-        action: :new,
-        handler: handlers.first.handler_name,
-        redirect_url: account_path
-      ) if handlers.length == 1
+      if handlers.length == 1
+        redirect_to(
+          action: :new,
+          handler: handlers.first.handler_name,
+          redirect_url: account_path
+        )
+      end
     end
 
     def create

--- a/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
+++ b/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
@@ -7,11 +7,9 @@ module Decidim
     skip_authorization_check
 
     def accept
-      response.set_cookie 'decidim-cc', {
-        value: 'true',
-        path: '/',
-        expires: 1.year.from_now.utc
-      }
+      response.set_cookie "decidim-cc", value: "true",
+                                        path: "/",
+                                        expires: 1.year.from_now.utc
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -65,7 +65,7 @@ module Decidim
       private
 
       def terms_and_conditions_page
-        @terms_and_conditions_page ||= Decidim::StaticPage.find_by_slug('terms-and-conditions')
+        @terms_and_conditions_page ||= Decidim::StaticPage.find_by_slug("terms-and-conditions")
       end
     end
   end

--- a/decidim-core/app/helpers/decidim/cookies_helper.rb
+++ b/decidim-core/app/helpers/decidim/cookies_helper.rb
@@ -5,7 +5,7 @@ module Decidim
   module CookiesHelper
     # Public: Returns true if the cookie policy has been accepted
     def cookies_accepted?
-      cookies['decidim-cc'].present?
+      cookies["decidim-cc"].present?
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/decidim_form_helper.rb
+++ b/decidim-core/app/helpers/decidim/decidim_form_helper.rb
@@ -16,4 +16,3 @@ module Decidim
     end
   end
 end
-

--- a/decidim-core/app/helpers/decidim/language_chooser_helper.rb
+++ b/decidim-core/app/helpers/decidim/language_chooser_helper.rb
@@ -12,7 +12,7 @@ module Decidim
     #
     # Returns a String.
     def locale_name(locale)
-      I18n.with_locale(locale){ I18n.t("name", scope: "locale")}
+      I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/localized_locales_helper.rb
+++ b/decidim-core/app/helpers/decidim/localized_locales_helper.rb
@@ -33,7 +33,7 @@ module Decidim
         end
 
         def name
-          I18n.with_locale(@locale){ I18n.t("name", scope: "locale") }
+          I18n.with_locale(@locale) { I18n.t("name", scope: "locale") }
         end
       end
 

--- a/decidim-core/app/helpers/decidim/orders_helper.rb
+++ b/decidim-core/app/helpers/decidim/orders_helper.rb
@@ -22,7 +22,7 @@ module Decidim
     # options - An optional hash of options
     #         * i18n_scope - The scope of the i18n translations
     def order_link(order, options = {})
-      link_to t("#{options[:i18n_scope]}.#{order}"), url_for(params.to_unsafe_h.merge(page: nil,order: order)), data: { order: order }, remote: true 
+      link_to t("#{options[:i18n_scope]}.#{order}"), url_for(params.to_unsafe_h.merge(page: nil, order: order)), data: { order: order }, remote: true
     end
   end
 end

--- a/decidim-core/app/services/decidim/action_authorizer.rb
+++ b/decidim-core/app/services/decidim/action_authorizer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Decidim
   # This class is used to authorize a user against an action in the context of a
   # feature.

--- a/decidim-core/config/initializers/mail_previews.rb
+++ b/decidim-core/config/initializers/mail_previews.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
-  config.action_mailer.preview_path = Decidim::Core::Engine.root.join('spec/mailers')
+  config.action_mailer.preview_path = Decidim::Core::Engine.root.join("spec/mailers")
 end

--- a/decidim-core/lib/decidim/attributes.rb
+++ b/decidim-core/lib/decidim/attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Decidim
   module Attributes
     autoload :TimeWithZone, "decidim/attributes/time_with_zone"

--- a/decidim-core/lib/decidim/attributes.rb
+++ b/decidim-core/lib/decidim/attributes.rb
@@ -1,0 +1,5 @@
+module Decidim
+  module Attributes
+    autoload :TimeWithZone, "decidim/attributes/time_with_zone"
+  end
+end

--- a/decidim-core/lib/decidim/attributes/time_with_zone.rb
+++ b/decidim-core/lib/decidim/attributes/time_with_zone.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Decidim
   module Attributes
     # Custom Virtus value to parse a String representing a Time using

--- a/decidim-core/lib/decidim/attributes/time_with_zone.rb
+++ b/decidim-core/lib/decidim/attributes/time_with_zone.rb
@@ -1,0 +1,12 @@
+module Decidim
+  module Attributes
+    # Custom Virtus value to parse a String representing a Time using
+    # the app TimeZone.
+    class TimeWithZone < Virtus::Attribute
+      def coerce(value)
+        return value unless value.is_a?(String)
+        Time.zone.parse(value)
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 require "decidim/core/engine"
 require "decidim/core/version"
@@ -15,10 +16,11 @@ module Decidim
   autoload :Authorable, "decidim/authorable"
   autoload :Features, "decidim/features"
   autoload :HasAttachments, "decidim/has_attachments"
-  autoload :FeatureValidator, "decidim/feature_validator"  
+  autoload :FeatureValidator, "decidim/feature_validator"
   autoload :HasFeature, "decidim/has_feature"
   autoload :HasScope, "decidim/has_scope"
   autoload :HasCategory, "decidim/has_category"
+  autoload :Attributes, "decidim/attributes"
 
   include ActiveSupport::Configurable
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -45,7 +45,7 @@ FactoryGirl.define do
     available_locales Decidim.available_locales
     official_img_header { test_file("avatar.jpg", "image/jpeg") }
     official_img_footer { test_file("avatar.jpg", "image/jpeg") }
-    official_url  { Faker::Internet.url }
+    official_url { Faker::Internet.url }
   end
 
   factory :participatory_process, class: Decidim::ParticipatoryProcess do
@@ -58,7 +58,7 @@ FactoryGirl.define do
     banner_image { test_file("city2.jpeg", "image/jpeg") }
     published_at { Time.current }
     organization
-    scope  { Decidim::Faker::Localized.word }
+    scope { Decidim::Faker::Localized.word }
     developer_group { Decidim::Faker::Localized.sentence(1) }
     local_area { Decidim::Faker::Localized.sentence(2) }
     target { Decidim::Faker::Localized.sentence(3) }

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -30,7 +30,7 @@ module Decidim
         tabs_panels = content_tag(:ul, class: "tabs", id: "#{name}-tabs", data: { tabs: true }) do
           locales.each_with_index.inject("".html_safe) do |string, (locale, index)|
             string + content_tag(:li, class: tab_element_class_for("title", index)) do
-              title = I18n.with_locale(locale){ I18n.t("name", scope: "locale") }
+              title = I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
               element_class = ""
               element_class += "alert" if error?(name_with_locale(name, locale))
               content_tag(:a, title, href: "##{name}-panel-#{index}", class: element_class)
@@ -104,7 +104,7 @@ module Decidim
     end
 
     # Public: Override so checkboxes are rendered before the label.
-    def check_box(attribute, options = {}, checked_value = '1', unchecked_value = '0')
+    def check_box(attribute, options = {}, checked_value = "1", unchecked_value = "0")
       custom_label(attribute, options[:label], options[:label_options], true) do
         options[:label] = false
         options[:label_options] = false

--- a/decidim-core/lib/decidim/resourceable.rb
+++ b/decidim-core/lib/decidim/resourceable.rb
@@ -85,11 +85,11 @@ module Decidim
 
         from = scope
                .joins(:resource_links_from)
-               .where(decidim_resource_links: { from_type: self.name })
+               .where(decidim_resource_links: { from_type: name })
 
         to = scope
              .joins(:resource_links_to)
-             .where(decidim_resource_links: { to_type: self.name })
+             .where(decidim_resource_links: { to_type: name })
 
         ResourceLink
           .where(from: from)
@@ -97,9 +97,8 @@ module Decidim
           .pluck(:from_type, :to_type)
           .flatten
           .uniq
-          .reject { |k| k == self.name }
+          .reject { |k| k == name }
       end
-
 
       # Finds the resource manifest for the model.
       #

--- a/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
+++ b/decidim-core/spec/lib/attributes/time_with_timezone_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+module Decidim
+  module Attributes
+    describe TimeWithZone do
+      describe "coerce" do
+        subject { described_class.build(TimeWithZone, {}).coerce(value) }
+
+        context "when given a Time" do
+          let(:value) { Time.current }
+
+          it "returns the time" do
+            expect(subject).to eq(value)
+          end
+        end
+
+        context "when given a String" do
+          let(:value) { "2017-02-01T15:00:00" }
+
+          context "in a different timezone" do
+            it "parses the String in the correct timezone" do
+              Time.use_zone("CET") do
+                expect(subject.utc.to_s).to eq("2017-02-01 14:00:00 UTC")
+              end
+            end
+          end
+
+          context "but it is not valid" do
+            let(:value) { "foo" }
+
+            it "returns nil" do
+              expect(subject).to eq(nil)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -41,7 +41,7 @@ end
 Decidim.register_feature(:dummy) do |feature|
   feature.engine = Decidim::DummyEngine
 
-  feature.actions = %w{foo bar}
+  feature.actions = %w(foo bar)
 
   feature.settings(:global) do |settings|
     settings.attribute :dummy_global_attribute_1, type: :boolean

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
@@ -67,7 +67,7 @@ module TranslationHelpers
   def fill_in_i18n_fields(field, tab_selector, localized_values)
     localized_values.each do |locale, value|
       within tab_selector do
-        click_link I18n.with_locale(locale){ I18n.t("name", scope: "locale") }
+        click_link I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
       end
       yield "#{field}_#{locale}", value
     end

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_form.rb
@@ -11,8 +11,8 @@ module Decidim
         translatable_attribute :location, String
         translatable_attribute :location_hints, String
         attribute :address, String
-        attribute :start_time, DateTime
-        attribute :end_time, DateTime
+        attribute :start_time, Decidim::Attributes::TimeWithZone
+        attribute :end_time, Decidim::Attributes::TimeWithZone
         attribute :decidim_scope_id, Integer
         attribute :decidim_category_id, Integer
 

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -13,7 +13,7 @@ Decidim.register_feature(:proposals) do |feature|
     end
   end
 
-  feature.actions = %w{vote create}
+  feature.actions = %w(vote create)
 
   feature.settings(:global) do |settings|
     settings.attribute :vote_limit, type: :integer, default: 0


### PR DESCRIPTION
#### :tophat: What? Why?

We need to use `Time` instead of `DateTime` so when we coerce the String to the value it uses the correct timezone.

#### :pushpin: Related Issues
- Fixes #693
