### PR TITLE
Redirect to show instead of index after saving a process

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
@@ -48,9 +48,9 @@ module Decidim
         @form = form(ParticipatoryProcessForm).from_params(params)
 
         UpdateParticipatoryProcess.call(@participatory_process, @form) do
-          on(:ok) do
+          on(:ok) do |participatory_process|
             flash[:notice] = I18n.t("participatory_processes.update.success", scope: "decidim.admin")
-            redirect_to participatory_processes_path
+            redirect_to participatory_process_path(participatory_process)
           end
 
           on(:invalid) do

--- a/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_processes_controller.rb
@@ -24,9 +24,9 @@ module Decidim
         @form = form(ParticipatoryProcessForm).from_params(params)
 
         CreateParticipatoryProcess.call(@form) do
-          on(:ok) do
+          on(:ok) do |participatory_process|
             flash[:notice] = I18n.t("participatory_processes.create.success", scope: "decidim.admin")
-            redirect_to participatory_processes_path
+            redirect_to participatory_process_path(participatory_process)
           end
 
           on(:invalid) do

--- a/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
@@ -58,12 +58,8 @@ describe "Admin manage participatory processes", type: :feature do
       expect(page).to have_content("successfully")
     end
 
-    within "table" do
+    within ".tabs-content" do
       expect(page).to have_content("My participatory process")
-      click_link("My participatory process")
-    end
-
-    within "dl" do
       expect(page).to have_css("img[src*='#{image1_filename}']")
       expect(page).to have_css("img[src*='#{image2_filename}']")
     end

--- a/decidim-admin/spec/shared/manage_processes_examples.rb
+++ b/decidim-admin/spec/shared/manage_processes_examples.rb
@@ -75,12 +75,8 @@ RSpec.shared_examples "manage processes examples" do
       expect(page).to have_content("successfully")
     end
 
-    within "table" do
+    within ".tabs-content" do
       expect(page).to have_content("My new title")
-      click_link("My new title")
-    end
-
-    within "dl" do
       expect(page).not_to have_css("img[src*='#{image2_filename}']")
       expect(page).to have_css("img[src*='#{image3_filename}']")
     end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR amends the ```participatory_processes``` controller to redirect to show instead of index after updating a process.

#### :pushpin: Related Issues
- Fixes #830