### PR TITLE
Fix budget search

### DIFF
--- a/decidim-budgets/app/services/decidim/budgets/project_search.rb
+++ b/decidim-budgets/app/services/decidim/budgets/project_search.rb
@@ -17,7 +17,6 @@ module Decidim
         query
           .where(localized_search_text_in(:title), text: "%#{search_text}%")
           .or(query.where(localized_search_text_in(:description), text: "%#{search_text}%"))
-          .or(query.where(localized_search_text_in(:short_description), text: "%#{search_text}%"))
       end
 
       # Handle the scope_id filter

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -8,7 +8,6 @@ en:
         decidim_scope_id: Scope
         description: Description
         proposal_ids: Related proposals
-        short_description: Short description
         title: Title
   decidim:
     budgets:


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes budget search by removing a couple of appearances of `short_description` on budgets that were supposed to be gone.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/l41lFw057lAJQMwg0/giphy.gif)
