### PR TITLE
Add waffle badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg)](https://crowdin.com/project/decidim/invite)
 [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
 
-### Project management 
+### Project management [[See on Waffle.io]](https://waffle.io/AjuntamentdeBarcelona/decidim)
 [![Stories in Discussion](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/discussion.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Adiscussion)
 [![Stories in Ready](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/ready.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Aready)
 [![Bugs](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/bug.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Abug)

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
 [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
 
 ### Project management
-[![GitHub pull requests](https://img.shields.io/github/issues-pr/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/pulls)
-[![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aclosed)
-[![GitHub issues](https://img.shields.io/github/issues/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues)
-[![GitHub closed issues](https://img.shields.io/github/issues-closed/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed)
+![Stories in Discussion](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=discussion&title=Discussions)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+![Stories in Ready](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=ready&title=Ready)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+![Bugs](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=bug&title=Bugs)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+![In Progress](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-progress&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+![In Review](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-review&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors)
 
 ---

--- a/README.md
+++ b/README.md
@@ -5,19 +5,18 @@
 ### Code quality
 [![Build Status](https://img.shields.io/travis/AjuntamentdeBarcelona/decidim/master.svg)](https://travis-ci.org/AjuntamentdeBarcelona/decidim)
 [![Code Climate](https://img.shields.io/codeclimate/github/AjuntamentdeBarcelona/decidim.svg)](https://codeclimate.com/github/AjuntamentdeBarcelona/decidim/trends)
-[![Issue Count](https://img.shields.io/codeclimate/issues/github/AjuntamentdeBarcelona/decidim.svg)](https://codeclimate.com/github/AjuntamentdeBarcelona/decidim/issues)
 [![codecov](https://img.shields.io/codecov/c/github/AjuntamentdeBarcelona/decidim.svg)](https://codecov.io/gh/AjuntamentdeBarcelona/decidim)
 [![Dependency Status](https://img.shields.io/gemnasium/AjuntamentdeBarcelona/decidim.svg)](https://gemnasium.com/github.com/AjuntamentdeBarcelona/decidim)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg)](https://crowdin.com/project/decidim/invite)
 [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
 
-### Project management
+### Project management [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors)
+
 [![Stories in Discussion](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/discussion.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![Stories in Ready](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/ready.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![Bugs](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/bug.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![In Progress](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/in-progress.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![In Review](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/in-review.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
 
 ### Project management [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors)
-
 [![Stories in Discussion](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/discussion.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![Stories in Ready](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/ready.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![Bugs](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/bug.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
 
 ### Project management
-![Stories in Discussion](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=discussion&title=Discussions)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-![Stories in Ready](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=ready&title=Ready)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-![Bugs](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=bug&title=Bugs)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-![In Progress](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-progress&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-![In Review](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-review&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![Stories in Discussion](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=discussion&title=Discussions)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![Stories in Ready](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=ready&title=Ready)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![Bugs](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=bug&title=Bugs)][(http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![In Progress](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-progress&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![In Review](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-review&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors)
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Decidim [![Gem](https://img.shields.io/gem/v/decidim.svg)](https://rubygems.org/gems/decidim) [![Gem](https://img.shields.io/gem/dt/decidim.svg)](https://rubygems.org/gems/decidim) [![License: AGPL v3](https://img.shields.io/github/license/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/blob/master/LICENSE-AGPLv3.txt)
+# Decidim [![Gem](https://img.shields.io/gem/v/decidim.svg)](https://rubygems.org/gems/decidim) [![Gem](https://img.shields.io/gem/dt/decidim.svg)](https://rubygems.org/gems/decidim) [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors) [![License: AGPL v3](https://img.shields.io/github/license/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/blob/master/LICENSE-AGPLv3.txt)
+
 
 [[Documentation](https://github.com/AjuntamentdeBarcelona/decidim/tree/master/docs)] - [[Demo](http://staging.decidim.codegram.com)]
 
@@ -10,7 +11,7 @@
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg)](https://crowdin.com/project/decidim/invite)
 [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
 
-### Project management [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors)
+### Project management 
 [![Stories in Discussion](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/discussion.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Adiscussion)
 [![Stories in Ready](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/ready.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Aready)
 [![Bugs](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/bug.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Abug)

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
 
 ### Project management
-[![Stories in Discussion](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=discussion&title=Discussions)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![Stories in Ready](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=ready&title=Ready)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![Bugs](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=bug&title=Bugs)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![In Progress](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-progress&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![In Review](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-review&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![Stories in Discussion](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/discussion.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![Stories in Ready](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/ready.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![Bugs](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/bug.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![In Progress](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/in-progress.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![In Review](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/in-review.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors)
 
 ---

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### Project management
 [![Stories in Discussion](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=discussion&title=Discussions)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![Stories in Ready](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=ready&title=Ready)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![Bugs](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=bug&title=Bugs)][(http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![Bugs](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=bug&title=Bugs)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![In Progress](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-progress&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![In Review](https://badge.waffle.io/AjuntamentdeBarcelona/decidim.svg?label=in-review&title=In%20progress)](http://waffle.io/AjuntamentdeBarcelona/decidim)
 [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
 
 ### Project management [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors)
-[![Stories in Discussion](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/discussion.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![Stories in Ready](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/ready.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![Bugs](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/bug.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![In Progress](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/in-progress.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
-[![In Review](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/in-review.svg)](http://waffle.io/AjuntamentdeBarcelona/decidim)
+[![Stories in Discussion](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/discussion.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Adiscussion)
+[![Stories in Ready](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/ready.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Aready)
+[![Bugs](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/bug.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
+[![In Progress](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/in-progress.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Ain-progress)
+[![In Review](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/in-review.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Ain-review)
 
 ---
 


### PR DESCRIPTION
#### :tophat: What? Why?
Adds waffle labels that are way more indicative of the progress of the project than GitHub's ones.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/n1JN4fSrXovJe/giphy.gif)
