### PR TITLE
Filter meetings by date

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -26,7 +26,7 @@ module Decidim
       end
 
       def meeting
-        @meeting ||= meetings.find(params[:id])
+        @meeting ||= Meeting.where(feature: current_feature).find(params[:id])
       end
 
       def search_klass
@@ -35,7 +35,7 @@ module Decidim
 
       def default_filter_params
         {
-          order_start_time: "asc",
+          date: "upcoming",
           search_text: "",
           scope_id: "",
           category_id: ""

--- a/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
@@ -20,9 +20,13 @@ module Decidim
           .or(query.where(localized_search_text_in(:description), text: "%#{search_text}%"))
       end
 
-      # Handle the order_start_time filter
-      def search_order_start_time
-        query.order(start_time: order_start_time)
+      # Handle the date filter
+      def search_date
+        if options[:date] == "upcoming"
+          query.where("start_time >= ? ", Time.current).order("start_time ASC")
+        elsif options[:date] == "past"
+          query.where("start_time <= ? ", Time.current).order("start_time DESC")
+        end
       end
 
       # Handle the scope_id filter

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -2,23 +2,23 @@
   <div class="filters__section">
     <div class="filters__search">
       <div class="input-group">
-        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t('.search') %>
+        <%= form.search_field :search_text, label: false, class: "input-group-field", placeholder: t(".search") %>
         <div class="input-group-button">
           <button type="submit" class="button button--muted">
-            <%= icon "magnifying-glass", aria_label: t('.search') %>
+            <%= icon "magnifying-glass", aria_label: t(".search") %>
           </button>
         </div>
       </div>
     </div>
   </div>
 
-  <%= form.collection_radio_buttons :order_start_time, [["asc", t('.ascendent')], ["desc", t('.descendent')]], :first, :last, legend_title: t('.date') %>
+  <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
 
   <% if current_organization.scopes.any? %>
-    <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t('.scopes') %>
+    <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t(".scopes") %>
   <% end %>
 
   <% if current_feature.categories.any? %>
-    <%= form.categories_select :category_id, current_feature.categories, legend_title: t('.category'), disable_parents: false, label: false, include_blank: true %>
+    <%= form.categories_select :category_id, current_feature.categories, legend_title: t(".category"), disable_parents: false, label: false, include_blank: true %>
   <% end %>
 <% end %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -51,12 +51,12 @@ en:
             name: Meeting
       meetings:
         filters:
-          ascendent: Ascendent
           category: Category
           date: Date
-          descendent: Descendent
+          past: Past
           scopes: Scopes
           search: Search
+          upcoming: Upcoming
         filters_small_view:
           close_modal: Close modal
           filter: Filter

--- a/decidim-meetings/spec/services/meeting_search_spec.rb
+++ b/decidim-meetings/spec/services/meeting_search_spec.rb
@@ -53,29 +53,32 @@ describe Decidim::Meetings::MeetingSearch do
       end
     end
 
-    context "order_start_time" do
-      let(:params) { default_params.merge(order_start_time: order) }
+    context "date" do
+      let(:params) { default_params.merge(date: date) }
+      let!(:past_meeting) do
+        create(:meeting, feature: current_feature, start_time: 1.day.ago)
+      end
 
-      context "is :asc" do
-        let(:order) { :asc }
+      context "is upcoming" do
+        let(:date) { "upcoming" }
 
-        it "sorts the meetings by start_time asc" do
-          expect(subject.results).to eq [meeting1, meeting2]
+        it "only returns that are scheduled in the future" do
+          expect(subject.results).to match_array [meeting1, meeting2]
         end
       end
 
-      context "is :desc" do
-        let(:order) { :desc }
+      context "is past" do
+        let(:date) { "past" }
 
-        it "sorts the meetings by start_time desc" do
-          expect(subject.results).to eq [meeting2, meeting1]
+        it "only returns meetings that were scheduled in the past" do
+          expect(subject.results).to match_array [past_meeting]
         end
       end
     end
 
     context "search_text" do
       let(:params) { default_params.merge(search_text: "TestCheck") }
-      
+
       it "show only the meeting containing the search_text" do
         expect(subject.results).to include(meeting1)
         expect(subject.results.length).to eq(1)
@@ -95,7 +98,7 @@ describe Decidim::Meetings::MeetingSearch do
         let(:params) { default_params.merge(scope_id: [scope2.id, scope1.id]) }
 
         it "filters meetings by scope" do
-          expect(subject.results).to match_array [meeting1,meeting2]
+          expect(subject.results).to match_array [meeting1, meeting2]
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Users need to know the upcoming meetings first, rather than all the meetings. With this PR, meetings are ordered by starting date descending and users can also filter by upcoming & past meetings.

#### :pushpin: Related Issues
- Fixes #874 
- Fixes #813

### :camera: Screenshots 
![Description](https://i.imgur.com/dQFTEuS.png)

#### :ghost: GIF
![](https://i.imgur.com/keoHVM0.gif)