### PR TITLE
Bugfix/prevent double voting

### DIFF
--- a/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
@@ -35,8 +35,10 @@ module Decidim
       end
 
       def add_line_item
-        order.projects << @project
-        order.save!
+        order.with_lock do
+          order.projects << @project
+          order.save!
+        end
       end
     end
   end

--- a/decidim-budgets/app/commands/decidim/budgets/checkout.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/checkout.rb
@@ -19,15 +19,19 @@ module Decidim
       #
       # Returns nothing.
       def call
-        return broadcast(:invalid) unless @order&.can_checkout?
-        checkout!
+        return broadcast(:invalid, @order) unless checkout!
         broadcast(:ok, @order)
       end
 
       private
 
       def checkout!
-        @order.update_attributes!(checked_out_at: Time.current)
+        return unless @order
+
+        @order.with_lock do
+          @order.checked_out_at = Time.current
+          @order.save
+        end
       end
     end
   end

--- a/decidim-budgets/app/models/decidim/budgets/order.rb
+++ b/decidim-budgets/app/models/decidim/budgets/order.rb
@@ -16,9 +16,17 @@ module Decidim
       validates :user, presence: true, uniqueness: { scope: :feature }
       validate :user_belongs_to_organization
 
+      validates :total_budget, numericality: {
+                  greater_than_or_equal_to: :minimum_budget,
+                }, if: :checked_out?
+
+      validates :total_budget, numericality: {
+                  less_than_or_equal_to: :maximum_budget
+                }
+
       # Public: Returns the sum of project budgets
       def total_budget
-        @total_budget ||= projects.sum(&:budget)
+        projects.to_a.sum(&:budget)
       end
 
       # Public: Returns true if the order has been checked out
@@ -38,7 +46,14 @@ module Decidim
 
       # Public: Returns the required minimum budget to checkout
       def minimum_budget
+        return 0 unless feature
         feature.settings.total_budget.to_f * (feature.settings.vote_threshold_percent.to_f / 100)
+      end
+
+      # Public: Returns the required maximum budget to checkout
+      def maximum_budget
+        return 0 unless feature
+        feature.settings.total_budget.to_f
       end
 
       private

--- a/decidim-budgets/spec/commands/cancel_order_spec.rb
+++ b/decidim-budgets/spec/commands/cancel_order_spec.rb
@@ -9,7 +9,13 @@ describe Decidim::Budgets::CancelOrder do
     )
   end
   let(:project) { create(:project, feature: feature, budget: 90_000_000) }
-  let(:order) { create(:order, user: user, feature: feature, checked_out_at: Time.zone.now) }
+  let(:order) do
+    order = create(:order, user: user, feature: feature)
+    order.projects << project
+    order.checked_out_at = Time.zone.now
+    order.save!
+    order
+  end
 
   subject { described_class.new(order) }
 

--- a/decidim-budgets/spec/commands/checkout_spec.rb
+++ b/decidim-budgets/spec/commands/checkout_spec.rb
@@ -8,9 +8,16 @@ describe Decidim::Budgets::Checkout do
       organization: user.organization
     )
   end
+
   let(:project) { create(:project, feature: feature, budget: 90_000_000) }
-  let(:order) { create(:order, user: user, feature: feature) }
-  let!(:line_item) { create(:line_item, order: order, project: project)}
+
+  let(:order) do
+    order = create(:order, user: user, feature: feature)
+    order.projects << project
+    order.save!
+    order
+  end
+
   let(:current_order) { order }
 
   subject { described_class.new(current_order, feature) }

--- a/decidim-budgets/spec/features/orders_spec.rb
+++ b/decidim-budgets/spec/features/orders_spec.rb
@@ -143,7 +143,13 @@ describe "Orders", type: :feature do
     end
 
     context "and has a finished order" do
-      let!(:order) { create(:order, user: user, feature: feature, checked_out_at: Time.current) }
+      let!(:order) do
+        order = create(:order, user: user, feature: feature)
+        order.projects << projects
+        order.checked_out_at = Time.current
+        order.save!
+        order
+      end
 
       it "can cancel the order" do
         visit_feature

--- a/decidim-budgets/spec/models/order_spec.rb
+++ b/decidim-budgets/spec/models/order_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Budgets::Order do
-  let(:order) { build :order }
+  let!(:order) { create :order, feature: create(:budget_feature) }
   subject { order }
 
   describe "validations" do
@@ -26,6 +26,34 @@ describe Decidim::Budgets::Order do
       new_order = build :order, user: subject.user, feature: subject.feature
       expect(new_order).to be_invalid
     end
+
+    it "can't exceed a maximum order value" do
+      project1 = create(:project, feature: subject.feature, budget: 100)
+      project2 = create(:project, feature: subject.feature, budget: 20)
+
+      subject.projects << project1
+      subject.projects << project2
+
+      subject.feature.settings = {
+        "total_budget" => 100, "vote_threshold" => 50
+      }
+
+      expect(subject).to be_invalid
+    end
+
+    it "can't be lower than a minimum order value when checked out" do
+      project1 = create(:project, feature: subject.feature, budget: 20)
+
+      subject.projects << project1
+
+      subject.feature.settings = {
+        "total_budget" => 100, "vote_threshold" => 50
+      }
+
+      expect(subject).to be_valid
+      subject.checked_out_at = Time.current
+      expect(subject).to be_invalid
+    end
   end
 
   describe "#total_budget" do
@@ -33,6 +61,7 @@ describe Decidim::Budgets::Order do
       subject.projects << build(:project, feature: subject.feature)
 
       expect(subject.total_budget).to eq(subject.projects.sum(&:budget))
+      expect(subject)
     end
   end
 

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -70,13 +70,15 @@ describe "Explore meetings", type: :feature do
   context "show" do
     let(:meetings_count) { 1 }
     let(:meeting) { meetings.first }
+    let(:date) { 10.days.from_now }
 
     before do
       meeting.update_attributes(
-        start_time: DateTime.new(Time.current.year + 1, 12, 13, 14, 15),
-        end_time: DateTime.new(Time.current.year + 1, 12, 13, 16, 17)
+        start_time: date.beginning_of_day,
+        end_time: date.end_of_day
       )
-      click_link translated(meeting.title)
+
+      visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
     end
 
     it "shows all meeting info" do
@@ -87,9 +89,8 @@ describe "Explore meetings", type: :feature do
       expect(page).to have_content(meeting.address)
 
       within ".section.view-side" do
-        expect(page).to have_content(13)
-        expect(page).to have_content(/December/i)
-        expect(page).to have_content("14:15 - 16:17")
+        expect(page).to have_content(date.day)
+        expect(page).to have_content("00:00 - 23:59")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This keeps votes under a threshold and ensures it all works by using pessimistic locking.

#### :pushpin: Related Issues
- Fixes #862
- Fixes #873

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/3o6MbegGqy8rFuRGHm/giphy.gif)
