### PR TITLE
Add new footer subhero partial to homepage

### DIFF
--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -13,3 +13,5 @@
 <% if current_organization.show_statistics? %>
   <%= render partial: 'pages/home/statistics' %>
 <% end %>
+
+  <%= render partial: 'pages/home/footer_sub_hero' %>

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -14,4 +14,4 @@
   <%= render partial: 'pages/home/statistics' %>
 <% end %>
 
-  <%= render partial: 'pages/home/footer_sub_hero' %>
+<%= render partial: 'pages/home/footer_sub_hero' %>

--- a/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
@@ -1,4 +1,4 @@
-  <section class="extended subhero home-section">
+  <section class="footer__subhero extended subhero home-section">
     <div class="row">
       <div class="columns small-centered large-10">
         <h2 class="heading3"><%= t(".footer_sub_hero_headline", organization: current_organization.name) %></h2>

--- a/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
@@ -1,0 +1,12 @@
+  <section class="extended subhero home-section">
+    <div class="row">
+      <div class="columns small-centered large-10">
+        <h2 class="heading3"><%= t(".footer_sub_hero_headline", organization: current_organization.name) %></h2>
+        <h5 class="heading4"><%= t(".footer_sub_hero_body") %></h5>
+        <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
+          <%= t(".register") %>
+          <%= icon "chevron-right", aria_hidden: true %>
+        <% end %>
+      </div>
+    </div>
+  </section>

--- a/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
+++ b/decidim-core/app/views/pages/home/_footer_sub_hero.html.erb
@@ -1,12 +1,12 @@
-  <section class="footer__subhero extended subhero home-section">
-    <div class="row">
-      <div class="columns small-centered large-10">
-        <h2 class="heading3"><%= t(".footer_sub_hero_headline", organization: current_organization.name) %></h2>
-        <h5 class="heading4"><%= t(".footer_sub_hero_body") %></h5>
-        <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
-          <%= t(".register") %>
-          <%= icon "chevron-right", aria_hidden: true %>
-        <% end %>
-      </div>
+<section class="footer__subhero extended subhero home-section">
+  <div class="row">
+    <div class="columns small-centered large-10">
+      <h2 class="heading3"><%= t(".footer_sub_hero_headline", organization: current_organization.name) %></h2>
+      <h5 class="heading4"><%== t(".footer_sub_hero_body") %></h5>
+      <%= link_to new_user_registration_path, class: "button--sc link subhero-cta" do %>
+        <%= t(".register") %>
+        <%= icon "chevron-right", aria_hidden: true %>
+      <% end %>
     </div>
-  </section>
+  </div>
+</section>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -261,8 +261,9 @@ en:
         proposals: Proposals
         proposals_explanation: Open space for citizen proposals about what kind of city we want to live in.
       footer_sub_hero:
-        footer_sub_hero_body: Construïm una societat més oberta, transparent i col·laborativa. Entra, participa i decideix.
-        footer_sub_hero_headline: Benvingut/da a la plataforma de participació %{organization}.
+        footer_sub_hero_body: Let's build a more open, transparent and collaborative society.<br />
+                              Join, participate and decide.
+        footer_sub_hero_headline: Welcome to %{organization} participatory platform.
         register: Register
       hero:
         participate: Participate

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -260,6 +260,10 @@ en:
         more_info: More info
         proposals: Proposals
         proposals_explanation: Open space for citizen proposals about what kind of city we want to live in.
+      footer_sub_hero:
+        footer_sub_hero_body: Construïm una societat més oberta, transparent i col·laborativa. Entra, participa i decideix.
+        footer_sub_hero_headline: Benvingut/da a la plataforma de participació %{organization}.
+        register: Register
       hero:
         participate: Participate
         welcome: Welcome to %{organization}!

--- a/decidim-core/spec/features/homepage_spec.rb
+++ b/decidim-core/spec/features/homepage_spec.rb
@@ -41,6 +41,14 @@ describe "Homepage", type: :feature do
 
         expect(page).to have_i18n_content(static_page.content, locale: "en")
       end
+
+      it "includes the footer sub_hero with the current organization name" do
+        expect(page).to have_css(".footer__subhero")
+
+        within ".footer__subhero" do
+          expect(page).to have_content(organization.name)
+        end
+      end
     end
 
     describe "statistics" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the footer sub hero section is missing from the homepage. With a static generic header and body test.

#### :pushpin: Related Issues
- Fixes #791

### :camera: Screenshots (optional)
![screen shot 2017-02-10 at 13 21 55](https://cloud.githubusercontent.com/assets/953911/22828345/ff897924-ef9c-11e6-808a-a935bb45b1ad.png)

#### :ghost: GIF
![](https://media.giphy.com/media/63k5Rw37GB1DO/giphy.gif)
