### PR TITLE
Add year to the meetings date

### DIFF
--- a/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/map_helper.rb
@@ -34,6 +34,7 @@ module Decidim
                                                                description: translated_attribute(meeting.description),
                                                                startTimeDay: l(meeting.start_time, format: "%d"),
                                                                startTimeMonth: l(meeting.start_time, format: "%B"),
+                                                               startTimeYear: l(meeting.start_time, format: "%Y"),
                                                                startTime: "#{meeting.start_time.strftime("%H:%M")} - #{meeting.end_time.strftime("%H:%M")}",
                                                                icon: icon("meetings", width: 40, height: 70, remove_icon_class: true),
                                                                location: translated_attribute(meeting.location),

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_datetime.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_datetime.html.erb
@@ -1,6 +1,6 @@
 <div class="card__datetime">
   <div class="card__datetime__date">
-    <%= l meeting.start_time, format: "%d" %> <span class="card__datetime__month"><%= l meeting.start_time, format: "%B" %></span>
+    <%= l meeting.start_time, format: "%d" %> <span class="card__datetime__month"><%= l meeting.start_time, format: "%B %Y" %></span>
   </div>
   <div class="card__datetime__time">
     <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_linked_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_linked_meetings.html.erb
@@ -8,7 +8,7 @@
           <% end %>
           <div class="card__datetime">
             <div class="card__datetime__date">
-              <%= l meeting.start_time, format: "%d" %> <span class="card__datetime__month"><%= l meeting.start_time, format: "%B" %></span>
+              <%= l meeting.start_time, format: "%d" %> <span class="card__datetime__month"><%= l meeting.start_time, format: "%B %Y" %></span>
             </div>
             <div class="card__datetime__time">
               <%= meeting.start_time.strftime("%H:%M") %> - <%= meeting.end_time.strftime("%H:%M") %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -15,7 +15,7 @@
           <div class="map__date-adress">
             <div class="card__datetime">
               <div class="card__datetime__date">
-                ${startTimeDay} <span class="card__datetime__month">${startTimeMonth}</span>
+                ${startTimeDay} <span class="card__datetime__month">${startTimeMonth} ${startTimeYear}</span>
               </div>
               <div class="card__datetime__time">${starTime}</div>
             </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the year to the meeting cards, so it solves the possible confusion that occurs if the process occurs between one years.

#### :pushpin: Related Issues
- Fixes #765

### :camera: Screenshots
<img width="902" alt="screen shot 2017-02-13 at 11 28 54" src="https://cloud.githubusercontent.com/assets/953911/22879894/4f164b80-f1e0-11e6-9d45-96d59d9718ca.png">
<img width="1191" alt="screen shot 2017-02-13 at 11 28 43" src="https://cloud.githubusercontent.com/assets/953911/22879893/4f0e3a4e-f1e0-11e6-8cd4-cfab7f5d722d.png">

#### :ghost: GIF
![](https://media.giphy.com/media/89Eko49m84Ja/giphy.gif)
