### PR TITLE
Description and content editors updated

### DIFF
--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/_form.html.erb
@@ -7,7 +7,7 @@
 </div>
 
 <div class="field">
-  <%= form.translated :editor, :description, toolbar: :full, lines: 20 %>
+  <%= form.translated :editor, :description, toolbar: :full, lines: 25 %>
 </div>
 
 <div class="field">

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/_form.html.erb
@@ -19,7 +19,7 @@
 </div>
 
 <div class="field">
-  <%= form.translated :editor, :description, toolbar: :full, lines: 20 %>
+  <%= form.translated :editor, :description, toolbar: :full, lines: 25 %>
 </div>
 
 <div class="field">

--- a/decidim-admin/app/views/decidim/admin/static_pages/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/_form.html.erb
@@ -9,5 +9,5 @@
 <% end %>
 
 <div class="field">
-  <%= form.translated :editor, :content, toolbar: :full %>
+  <%= form.translated :editor, :content, toolbar: :full, lines: 25 %>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR increase the size of all WYSIWYG editors that are suppose to content long texts ( updated to 25 lines ) . So the user could work more confortable on it.

#### :pushpin: Related Issues
- Fixes #809

### :camera: Screenshots (optional)
<img width="1416" alt="screen shot 2017-02-13 at 14 52 42" src="https://cloud.githubusercontent.com/assets/953911/22886013/3ba6967e-f1fc-11e6-8ecc-c0efab809d16.png">

#### :ghost: GIF
![](https://media.giphy.com/media/tHufwMDTUi20E/giphy.gif)
