### PR TITLE
Show processes ending soon list on home page

### DIFF
--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -11,7 +11,7 @@ module Decidim
 
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
-    helper_method :page, :highlighted_participatory_processes, :promoted_participatory_processes, :participatory_processes, :users
+    helper_method :page, :highlighted_participatory_processes, :participatory_processes, :users
 
     def page_finder
       @page_finder ||= Decidim::PageFinder.new(params[:id], current_organization)

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -27,7 +27,7 @@ module Decidim
     end
 
     def highlighted_participatory_processes
-      @promoted_processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new | HighlightedParticipatoryProcesses.new
+      @promoted_processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -11,7 +11,7 @@ module Decidim
 
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
-    helper_method :page, :promoted_participatory_processes, :participatory_processes, :users
+    helper_method :page, :highlighted_participatory_processes, :promoted_participatory_processes, :participatory_processes, :users
 
     def page_finder
       @page_finder ||= Decidim::PageFinder.new(params[:id], current_organization)
@@ -26,8 +26,8 @@ module Decidim
       @processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new
     end
 
-    def promoted_participatory_processes
-      @promoted_processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new | PromotedParticipatoryProcesses.new
+    def highlighted_participatory_processes
+      @promoted_processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new | HighlightedParticipatoryProcesses.new
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -27,7 +27,7 @@ module Decidim
     end
 
     def highlighted_participatory_processes
-      @promoted_processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new
+      @promoted_processes ||= OrganizationParticipatoryProcesses.new(current_organization) | HighlightedParticipatoryProcesses.new
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/pages_controller.rb
+++ b/decidim-core/app/controllers/decidim/pages_controller.rb
@@ -11,7 +11,7 @@ module Decidim
 
     authorize_resource :public_pages, class: false
     delegate :page, to: :page_finder
-    helper_method :page, :highlighted_participatory_processes, :participatory_processes, :users
+    helper_method :page, :promoted_participatory_processes, :highlighted_participatory_processes, :participatory_processes, :users
 
     def page_finder
       @page_finder ||= Decidim::PageFinder.new(params[:id], current_organization)
@@ -24,6 +24,10 @@ module Decidim
     # This should be deleted once the statistics are done properly.
     def participatory_processes
       @processes ||= OrganizationParticipatoryProcesses.new(current_organization) | PublicParticipatoryProcesses.new
+    end
+
+    def promoted_participatory_processes
+      @promoted_processes ||= participatory_processes | PromotedParticipatoryProcesses.new
     end
 
     def highlighted_participatory_processes

--- a/decidim-core/app/queries/decidim/highlighted_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/highlighted_participatory_processes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+module Decidim
+  # This query filters processes so only promoted ones are returned.
+  class HighlightedParticipatoryProcesses < Rectify::Query
+    def query
+      Decidim::ParticipatoryProcess.includes(:active_step).order("promoted DESC, end_date ASC")
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/highlighted_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/highlighted_participatory_processes.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-module Decidim
-  # This query filters processes so only promoted ones are returned.
-  class HighlightedParticipatoryProcesses < Rectify::Query
-    def query
-      Decidim::ParticipatoryProcess.includes(:active_step).order("promoted DESC, end_date ASC")
-    end
-  end
-end

--- a/decidim-core/app/queries/decidim/highlighted_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/highlighted_participatory_processes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module Decidim
+  # This query adds some scopes so the processes are ready to be showed in a
+  # public view.
+  class HighlightedParticipatoryProcesses < Rectify::Query
+    def query
+      Decidim::ParticipatoryProcess.order("promoted DESC").includes(:active_step).order("decidim_participatory_process_steps.end_date ASC").limit(8)
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/public_participatory_processes.rb
+++ b/decidim-core/app/queries/decidim/public_participatory_processes.rb
@@ -4,7 +4,7 @@ module Decidim
   # public view.
   class PublicParticipatoryProcesses < Rectify::Query
     def query
-      Decidim::ParticipatoryProcess.includes(:active_step).order("end_date ASC")
+      Decidim::ParticipatoryProcess.order("promoted DESC").includes(:active_step).order("decidim_participatory_process_steps.end_date ASC")
     end
   end
 end

--- a/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
+++ b/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
@@ -4,7 +4,7 @@
     <div class="row collapse">
       <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
                   large-up-4 card-grid">
-        <% promoted_participatory_processes.each do |process| %>
+        <% highlighted_participatory_processes.each do |process| %>
           <div class="column">
             <article class="card card--process card--mini">
               <%= link_to participatory_process_path(process), class: "card__link" do %>

--- a/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
+++ b/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
@@ -1,6 +1,6 @@
 <section class="wrapper-home">
   <div class="row">
-    <h3 class="section-heading"><%= t(".highlighted_processes") %></h3>
+    <h3 class="section-heading"><%= t(".processes_ending_soon") %></h3>
     <div class="row collapse">
       <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
                   large-up-4 card-grid">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -264,8 +264,7 @@ en:
         proposals: Proposals
         proposals_explanation: Open space for citizen proposals about what kind of city we want to live in.
       footer_sub_hero:
-        footer_sub_hero_body: Let's build a more open, transparent and collaborative society.<br />
-                              Join, participate and decide.
+        footer_sub_hero_body: Let's build a more open, transparent and collaborative society.<br /> Join, participate and decide.
         footer_sub_hero_headline: Welcome to %{organization} participatory platform.
         register: Register
       hero:
@@ -273,7 +272,7 @@ en:
         welcome: Welcome to %{organization}!
       highlighted_processes:
         active_step: Active step
-        highlighted_processes: Highlighted processes
+        processes_ending_soon: Processes ending soon
         see_all_processes: See all processes
       statistics:
         headline: Current state of %{organization}

--- a/decidim-core/spec/controllers/pages_controller_spec.rb
+++ b/decidim-core/spec/controllers/pages_controller_spec.rb
@@ -33,3 +33,4 @@ module Decidim
     end
   end
 end
+ 

--- a/decidim-core/spec/shared/with_participatory_processes_examples.rb
+++ b/decidim-core/spec/shared/with_participatory_processes_examples.rb
@@ -9,30 +9,37 @@ RSpec.shared_examples "with participatory processes" do
       it "orders them by end_date" do
         unpublished = create(
           :participatory_process,
+          :with_steps,
           :unpublished,
           organization: organization
         )
 
         last = create(
           :participatory_process,
+          :with_steps,
           :published,
           organization: organization,
           end_date: nil
         )
+        last.active_step.update_attribute(:end_date, nil)
 
         first = create(
           :participatory_process,
+          :with_steps,
           :published,
           organization: organization,
           end_date: Time.current.advance(days: 10)
         )
+        first.active_step.update_attribute(:end_date, Time.current.advance(days: 2))
 
         second = create(
           :participatory_process,
+          :with_steps,
           :published,
           organization: organization,
           end_date: Time.current.advance(days: 20)
         )
+        second.active_step.update_attribute(:end_date, Time.current.advance(days: 4))
 
         expect(controller.helpers.participatory_processes.count).to eq(3)
         expect(controller.helpers.participatory_processes).not_to include(unpublished)
@@ -50,9 +57,10 @@ RSpec.shared_examples "with promoted participatory processes" do
   end
   describe "helper methods" do
     describe "promoted_participatory_processes" do
-      it "orders them by end_date" do
+      it "orders them by active_step end_date" do
         unpublished = create(
           :participatory_process,
+          :with_steps,
           :unpublished,
           :promoted,
           organization: organization
@@ -60,33 +68,39 @@ RSpec.shared_examples "with promoted participatory processes" do
 
         unpromoted = create(
           :participatory_process,
+          :with_steps,
           :unpublished,
           organization: organization
         )
 
         last = create(
           :participatory_process,
+          :with_steps,
           :published,
           :promoted,
-          organization: organization,
-          end_date: nil
+          organization: organization
         )
+        last.active_step.update_attribute(:end_date, nil)
 
         first = create(
           :participatory_process,
+          :with_steps,
           :published,
           :promoted,
           organization: organization,
           end_date: Time.current.advance(days: 10)
         )
+        first.active_step.update_attribute(:end_date, Time.current.advance(days: 2))
 
         second = create(
           :participatory_process,
+          :with_steps,
           :published,
           :promoted,
           organization: organization,
-          end_date: Time.current.advance(days: 20)
+          end_date: Time.current.advance(days: 8)
         )
+        second.active_step.update_attribute(:end_date, Time.current.advance(days: 4))
 
         expect(controller.helpers.promoted_participatory_processes.count).to eq(3)
         expect(controller.helpers.promoted_participatory_processes).not_to include(unpublished)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR changes the current highlighted processes to a processes ending soon list where promoted ones have preference and all of them are ordered by sooner active step ending date.

#### :pushpin: Related Issues
- Fixes #740 

### :camera: Screenshots (optional)
![screen shot 2017-02-14 at 10 52 30](https://cloud.githubusercontent.com/assets/953911/22925200/1a21bbda-f2a8-11e6-81d7-d138bf4f86ba.png)

#### :ghost: GIF
![](https://media.giphy.com/media/t6f2bNAjx7Bio/giphy.gif)
