### PR TITLE
Users can report proposals

### DIFF
--- a/decidim-admin/app/queries/decidim/admin/process_admins.rb
+++ b/decidim-admin/app/queries/decidim/admin/process_admins.rb
@@ -18,7 +18,7 @@ module Decidim
         @process = process
       end
 
-      # Finds the UserRoles of the users that can manage the given process.
+      # Finds organization admins and the users with role admin for the given process.
       #
       # Returns an ActiveRecord::Relation.
       def query

--- a/decidim-admin/app/queries/decidim/admin/process_admins.rb
+++ b/decidim-admin/app/queries/decidim/admin/process_admins.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    # A class used to find the admins for a participatory process including
+    # organization admins.
+    class ProcessAdmins < Rectify::Query
+      # Syntactic sugar to initialize the class and return the queried objects.
+      #
+      # process - a process that needs to find its process admins
+      def self.for(process)
+        new(process).query
+      end
+
+      # Initializes the class.
+      #
+      # process - a process that needs to find its process admins
+      def initialize(process)
+        @process = process
+      end
+
+      # Finds the UserRoles of the users that can manage the given process.
+      #
+      # Returns an ActiveRecord::Relation.
+      def query
+        Decidim::User.where(id: organization_admins).or(Decidim::User.where(id: process_admins))
+      end
+
+      private
+
+      attr_reader :process
+
+      def organization_admins
+        process.organization.admins
+      end
+
+      def process_admins
+        Decidim::Admin::ParticipatoryProcessUserRole
+          .where(participatory_process: process, role: :admin)
+          .pluck(:decidim_user_id)
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/queries/process_admins_spec.rb
+++ b/decidim-admin/spec/queries/process_admins_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe Decidim::Admin::ProcessAdmins do
+  let(:organization) { create :organization }
+  let(:participatory_process) { create :participatory_process, organization: organization}
+  let!(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+  let!(:participatory_process_admin) do
+    user = create(:user, :confirmed, organization: organization)
+    Decidim::Admin::ParticipatoryProcessUserRole.create!(
+      role: :admin,
+      user: user,
+      participatory_process: participatory_process
+    )
+    user
+  end
+
+  subject { described_class.new(participatory_process) }
+
+  it "returns the organization admins and participatory process admins" do
+    expect(subject.query).to match_array([admin, participatory_process_admin])
+  end
+end

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -22,7 +22,7 @@ module Decidim
 
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
-         commentable? && !feature.active_step_settings.comments_blocked
+        commentable? && !feature.active_step_settings.comments_blocked
       end
 
       # Public: Overrides the `comments_have_votes?` Commentable concern method.

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -22,6 +22,8 @@ module Decidim
 
     layout "layouts/decidim/application"
 
+    rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_404
+
     private
 
     def store_current_location
@@ -37,6 +39,10 @@ module Decidim
     # displays the JS response instead of the HTML one.
     def add_vary_header
       response.headers["Vary"] = "Accept"
+    end
+
+    def redirect_to_404
+      raise ActionController::RoutingError, "Not Found"
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/replace_buttons_helper.rb
+++ b/decidim-core/app/helpers/decidim/replace_buttons_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Decidim
   module ReplaceButtonsHelper
     # Overrides the submit tags to always be buttons instead of inputs.

--- a/decidim-core/app/models/decidim/newsletter.rb
+++ b/decidim-core/app/models/decidim/newsletter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Decidim
   # This model holds all the data needed to send a newsletter.
   class Newsletter < ApplicationRecord

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -74,10 +74,5 @@ module Decidim
     def documents
       @documents ||= attachments.select(&:document?)
     end
-
-    # Returns participatory process admins and organization admins.
-    def admins
-      organization.admins + Decidim::Admin::ParticipatoryProcessUserRole.where(participatory_process: self, role: :admin).collect(&:user)
-    end
   end
 end

--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -74,5 +74,10 @@ module Decidim
     def documents
       @documents ||= attachments.select(&:document?)
     end
+
+    # Returns participatory process admins and organization admins.
+    def admins
+      organization.admins + Decidim::Admin::ParticipatoryProcessUserRole.where(participatory_process: self, role: :admin).collect(&:user)
+    end
   end
 end

--- a/decidim-core/app/views/decidim/shared/_flag_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_flag_modal.html.erb
@@ -13,6 +13,7 @@
       <%= f.collection_radio_buttons :reason, [[:spam, t('.spam')], [:offensive, t('.offensive')], [:does_not_belong, t('.does_not_belong', organization_name: current_organization.name)]], :first, :last do |builder| %>
         <%= builder.label { builder.radio_button + builder.text } %>
       <% end %>
+      <%= f.text_area :details, rows: 4 %>
       <%= f.submit t(".report") %>
     <% end %>
   <% end %>

--- a/decidim-core/app/views/decidim/shared/_flag_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_flag_modal.html.erb
@@ -1,0 +1,19 @@
+<div class="reveal" id="flagModal" data-reveal>
+  <div class="reveal__header">
+    <h3 class="reveal__title"><%= t('.title') %></h3>
+    <button class="close-button" data-close aria-label="Close modal" type="button">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <% if resource.reported_by? current_user %>
+    <p><%= t('.already_reported') %></p>
+  <% else %>
+    <p><%= t('.description') %></p>
+    <%= decidim_form_for form, url: url, method: :post do |f| %>
+      <%= f.collection_radio_buttons :type, [[:spam, t('.spam')], [:offensive, t('.offensive')], [:does_not_belong, t('.does_not_belong', organization_name: current_organization.name)]], :first, :last do |builder| %>
+        <%= builder.label { builder.radio_button + builder.text } %>
+      <% end %>
+      <%= f.submit t(".report") %>
+    <% end %>
+  <% end %>
+</div>

--- a/decidim-core/app/views/decidim/shared/_flag_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_flag_modal.html.erb
@@ -1,7 +1,7 @@
 <div class="reveal" id="flagModal" data-reveal>
   <div class="reveal__header">
     <h3 class="reveal__title"><%= t('.title') %></h3>
-    <button class="close-button" data-close aria-label="Close modal" type="button">
+    <button class="close-button" data-close aria-label="<%= t('.close') %>" type="button">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
@@ -10,7 +10,7 @@
   <% else %>
     <p><%= t('.description') %></p>
     <%= decidim_form_for form, url: url, method: :post do |f| %>
-      <%= f.collection_radio_buttons :type, [[:spam, t('.spam')], [:offensive, t('.offensive')], [:does_not_belong, t('.does_not_belong', organization_name: current_organization.name)]], :first, :last do |builder| %>
+      <%= f.collection_radio_buttons :reason, [[:spam, t('.spam')], [:offensive, t('.offensive')], [:does_not_belong, t('.does_not_belong', organization_name: current_organization.name)]], :first, :last do |builder| %>
         <%= builder.label { builder.radio_button + builder.text } %>
       <% end %>
       <%= f.submit t(".report") %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -184,6 +184,7 @@ en:
           title: Not authorized
       flag_modal:
         already_reported: This content is already reported and it will be reviewed by an admin.
+        close: Close
         description: Is this content inappropriate?
         does_not_belong: This proposal contains illegal activity, suicide threats, personal information, or something else you think doesn't belong on %{organization_name}.
         offensive: This proposal contains racism, sexism, slurs, personal attacks, death threats, suicide requests or any form of hate speech.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -182,6 +182,14 @@ en:
           invalid: "%{field} isn't valid."
           ok: Ok
           title: Not authorized
+      flag_modal:
+        already_reported: This content is already reported and it will be reviewed by an admin.
+        description: Is this content inappropriate?
+        does_not_belong: This proposal contains illegal activity, suicide threats, personal information, or something else you think doesn't belong on %{organization_name}.
+        offensive: This proposal contains racism, sexism, slurs, personal attacks, death threats, suicide requests or any form of hate speech.
+        report: Report
+        spam: This proposal contains clickbait, advertising, scams or script bots.
+        title: Report a problem
       login_modal:
         please_sign_in: Please sign in
         sign_up: Sign up

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -91,6 +91,9 @@ module Decidim
     10.megabytes
   end
 
+  # The number of reports which an object can receive before hiding it
+  config_accessor :max_reports_before_hiding { 3 }
+
   # Public: Registers a feature, usually held in an external library or in a
   # separate folder in the main repository. Exposes a DSL defined by
   # `Decidim::FeatureManifest`.

--- a/decidim-core/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_process_spec.rb
@@ -22,5 +22,9 @@ module Decidim
 
       it { is_expected.to be_valid }
     end
+
+    describe "#admins" do
+      
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_process_spec.rb
@@ -22,22 +22,5 @@ module Decidim
 
       it { is_expected.to be_valid }
     end
-
-    describe "#admins" do
-      let!(:admin) { create(:user, :admin, :confirmed, organization: participatory_process.organization) }
-      let!(:participatory_process_admin) do
-        user = create(:user, :confirmed, organization: participatory_process.organization)
-        Decidim::Admin::ParticipatoryProcessUserRole.create!(
-          role: :admin,
-          user: user,
-          participatory_process: participatory_process
-        )
-        user
-      end
-
-      it "returns the organization admins and participatory process admins" do
-        expect(participatory_process.admins).to match_array([admin, participatory_process_admin])
-      end
-    end
   end
 end

--- a/decidim-core/spec/models/decidim/participatory_process_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_process_spec.rb
@@ -24,7 +24,20 @@ module Decidim
     end
 
     describe "#admins" do
-      
+      let!(:admin) { create(:user, :admin, :confirmed, organization: participatory_process.organization) }
+      let!(:participatory_process_admin) do
+        user = create(:user, :confirmed, organization: participatory_process.organization)
+        Decidim::Admin::ParticipatoryProcessUserRole.create!(
+          role: :admin,
+          user: user,
+          participatory_process: participatory_process
+        )
+        user
+      end
+
+      it "returns the organization admins and participatory process admins" do
+        expect(participatory_process.admins).to match_array([admin, participatory_process_admin])
+      end
     end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/html_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/html_matchers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "rspec-html-matchers"
 
 RSpec.configure do |config|

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -19,7 +19,7 @@ module Decidim
 
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
-         commentable? && !feature.active_step_settings.comments_blocked
+        commentable? && !feature.active_step_settings.comments_blocked
       end
 
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.

--- a/decidim-proposals/app/commands/decidim/proposals/admin/hide_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/hide_proposal.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    module Admin
+      # A command with all the business logic when a user hides a proposal.
+      class HideProposal < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # proposal - A Decidim::Proposals::Proposal
+        def initialize(proposal)
+          @proposal = proposal
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid, together with the proposal.
+        # - :invalid if the proposal is already hidden
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) if @proposal.hidden?
+
+          hide_proposal
+          broadcast(:ok, @proposal)
+        end
+
+        private
+
+        def hide_proposal
+          @proposal.update_attributes!(hidden_at: Time.current)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/hide_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/hide_proposal.rb
@@ -18,13 +18,17 @@ module Decidim
         #
         # Returns nothing.
         def call
-          return broadcast(:invalid) if @proposal.hidden?
+          return broadcast(:invalid) unless proposal_hideable?
 
           hide_proposal
           broadcast(:ok, @proposal)
         end
 
         private
+
+        def proposal_hideable?
+          !@proposal.hidden? && @proposal.reported?
+        end
 
         def hide_proposal
           @proposal.update_attributes!(hidden_at: Time.current)

--- a/decidim-proposals/app/commands/decidim/proposals/admin/unreport_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/unreport_proposal.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    module Admin
+      # A command with all the business logic when a user unreports a proposal.
+      class UnreportProposal < Rectify::Command
+        # Public: Initializes the command.
+        #
+        # proposal - A Decidim::Proposals::Proposal
+        def initialize(proposal)
+          @proposal = proposal
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when everything is valid, together with the proposal.
+        # - :invalid if the proposal is not reported
+        #
+        # Returns nothing.
+        def call
+          return broadcast(:invalid) unless @proposal.reported?
+
+          unreport_proposal
+          broadcast(:ok, @proposal)
+        end
+
+        private
+
+        def unreport_proposal
+          @proposal.update_attributes!(report_count: 0)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/commands/decidim/proposals/admin/unreport_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/admin/unreport_proposal.rb
@@ -27,7 +27,7 @@ module Decidim
         private
 
         def unreport_proposal
-          @proposal.update_attributes!(report_count: 0)
+          @proposal.update_attributes!(report_count: 0, hidden_at: nil)
         end
       end
     end

--- a/decidim-proposals/app/commands/decidim/proposals/report_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/report_proposal.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    # A command with all the business logic when a user reports a proposal.
+    class ReportProposal < Rectify::Command
+      # Public: Initializes the command.
+      #
+      # form         - A form object with the params.
+      # proposal     - The proposal being reported
+      # current_user - The current user.
+      def initialize(form, proposal, current_user)
+        @form = form
+        @proposal = proposal
+        @current_user = current_user
+      end
+
+      # Executes the command. Broadcasts these events:
+      #
+      # - :ok when everything is valid, together with the proposal report.
+      # - :invalid if the form wasn't valid and we couldn't proceed.
+      #
+      # Returns nothing.
+      def call
+        return broadcast(:invalid) if form.invalid?
+
+        create_proposal_report
+        broadcast(:ok, proposal_report)
+      end
+
+      private
+
+      attr_reader :form, :proposal_report
+
+      def create_proposal_report
+        transaction do
+          @proposal_report = ProposalReport.create!(
+            proposal: @proposal,
+            user: @current_user,
+            type: form.type
+          )
+          @proposal.update_attributes!(report_count: @proposal.report_count + 1)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/commands/decidim/proposals/report_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/report_proposal.rb
@@ -46,7 +46,8 @@ module Decidim
         @proposal_report = ProposalReport.create!(
           proposal: @proposal,
           user: @current_user,
-          reason: form.reason
+          reason: form.reason,
+          details: form.details
         )
       end
 

--- a/decidim-proposals/app/commands/decidim/proposals/report_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/report_proposal.rb
@@ -24,6 +24,7 @@ module Decidim
         return broadcast(:invalid) if form.invalid?
 
         create_proposal_report
+        send_notification_to_admins
         broadcast(:ok, proposal_report)
       end
 
@@ -39,6 +40,12 @@ module Decidim
             type: form.type
           )
           @proposal.update_attributes!(report_count: @proposal.report_count + 1)
+        end
+      end
+
+      def send_notification_to_admins
+        @proposal.feature.participatory_process.admins.each do |admin|
+          ProposalReportedMailer.report(admin, @proposal_report).deliver_later
         end
       end
     end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -29,10 +29,31 @@ module Decidim
           end
         end
 
+        def unreport
+          @proposal = Proposal.find(params[:id])
+          authorize! :unreport, @proposal
+
+          Admin::UnreportProposal.call(@proposal) do
+            on(:ok) do
+              flash[:notice] = I18n.t("proposals.unreport.success", scope: "decidim.proposals.admin")
+              redirect_to proposals_path(reported: true)
+            end
+
+            on(:invalid) do
+              flash.now[:alert] = I18n.t("proposals.unreport.invalid", scope: "decidim.proposals.admin")
+              redirect_to proposals_path(reported: true)
+            end
+          end
+        end
+
         private
 
         def proposals
-          @proposals ||= Proposal.where(feature: current_feature)
+          @proposals ||= begin
+            proposals = Proposal.where(feature: current_feature)
+            proposals = proposals.reported if params[:reported]
+            proposals
+          end
         end
       end
     end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -72,7 +72,7 @@ module Decidim
         end
 
         def proposal
-          @proposal ||= Proposal.find(params[:id])
+          @proposal ||= Proposal.where(feature: current_feature).find(params[:id])
         end
       end
     end

--- a/decidim-proposals/app/controllers/decidim/proposals/proposal_reports_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposal_reports_controller.rb
@@ -19,7 +19,7 @@ module Decidim
           end
 
           on(:invalid) do
-            flash.now[:alert] = I18n.t("proposal_reports.create.error", scope: "decidim.proposals")
+            flash[:alert] = I18n.t("proposal_reports.create.error", scope: "decidim.proposals")
             redirect_to proposal_path(proposal)
           end
         end

--- a/decidim-proposals/app/controllers/decidim/proposals/proposal_reports_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposal_reports_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # Exposes the proposal report resource so users can report proposals.
+    class ProposalReportsController < Decidim::Proposals::ApplicationController
+      include FormFactory
+      before_action :authenticate_user!
+
+      def create
+        authorize! :report, proposal
+
+        @form = form(ProposalReportForm).from_params(params)
+
+        ReportProposal.call(@form, proposal, current_user) do
+          on(:ok) do
+            flash[:notice] = I18n.t("proposal_reports.create.success", scope: "decidim.proposals")
+            redirect_to proposal_path(proposal)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("proposal_reports.create.error", scope: "decidim.proposals")
+            redirect_to proposal_path(proposal)
+          end
+        end
+      end
+
+      private
+
+      def proposal
+        @proposal ||= Proposal.where(feature: current_feature).find(params[:proposal_id])
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/controllers/decidim/proposals/proposal_reports_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposal_reports_controller.rb
@@ -15,7 +15,7 @@ module Decidim
         ReportProposal.call(@form, proposal, current_user) do
           on(:ok) do
             flash[:notice] = I18n.t("proposal_reports.create.success", scope: "decidim.proposals")
-            redirect_to proposal_path(proposal)
+            redirect_to proposals_path
           end
 
           on(:invalid) do

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -34,10 +34,7 @@ module Decidim
 
       def show
         @proposal = Proposal.not_hidden.where(feature: current_feature).find(params[:id])
-        @proposal_report_form = form(ProposalReportForm).from_params({ type: "spam" })
-      rescue ActiveRecord::RecordNotFound
-        flash[:alert] = I18n.t("proposals.not_found", scope: "decidim")
-        redirect_to proposals_path
+        @proposal_report_form = form(ProposalReportForm).from_params(reason: "spam")
       end
 
       def new

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -13,6 +13,7 @@ module Decidim
 
       def show
         @proposal = Proposal.where(feature: current_feature).find(params[:id])
+        @proposal_report_form = form(ProposalReportForm).from_params({ type: "spam" })
       end
 
       def index

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -11,14 +11,10 @@ module Decidim
 
       before_action :authenticate_user!, only: [:new, :create]
 
-      def show
-        @proposal = Proposal.where(feature: current_feature).find(params[:id])
-        @proposal_report_form = form(ProposalReportForm).from_params({ type: "spam" })
-      end
-
       def index
         @proposals = search
                      .results
+                     .not_hidden
                      .includes(:author)
                      .includes(:category)
                      .includes(:scope)
@@ -34,6 +30,14 @@ module Decidim
                            else
                              []
                            end
+      end
+
+      def show
+        @proposal = Proposal.not_hidden.where(feature: current_feature).find(params[:id])
+        @proposal_report_form = form(ProposalReportForm).from_params({ type: "spam" })
+      rescue ActiveRecord::RecordNotFound
+        flash[:alert] = I18n.t("proposals.not_found", scope: "decidim")
+        redirect_to proposals_path
       end
 
       def new

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_report_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_report_form.rb
@@ -6,6 +6,7 @@ module Decidim
       mimic :proposal_report
 
       attribute :reason, String
+      attribute :details, String
 
       validates :reason, inclusion: { in: ProposalReport::REASONS }
     end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_report_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_report_form.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    # A form object to be used when public users want to report a proposal.
+    class ProposalReportForm < Decidim::Form
+      mimic :proposal_report
+
+      attribute :type, String
+
+      validates :type, inclusion: { in: ProposalReport::TYPES }
+    end
+  end
+end

--- a/decidim-proposals/app/forms/decidim/proposals/proposal_report_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/proposal_report_form.rb
@@ -5,9 +5,9 @@ module Decidim
     class ProposalReportForm < Decidim::Form
       mimic :proposal_report
 
-      attribute :type, String
+      attribute :reason, String
 
-      validates :type, inclusion: { in: ProposalReport::TYPES }
+      validates :reason, inclusion: { in: ProposalReport::REASONS }
     end
   end
 end

--- a/decidim-proposals/app/mailers/decidim/proposals/proposal_reported_mailer.rb
+++ b/decidim-proposals/app/mailers/decidim/proposals/proposal_reported_mailer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    # A custom mailer for sending notifications to an admin when a proposal is reported.
+    class ProposalReportedMailer < Decidim::ApplicationMailer
+      helper Decidim::ResourceHelper
+
+      def report(user, proposal_report)
+        with_user(user) do
+          @proposal_report = proposal_report
+          @organization = user.organization
+          @user = user
+          subject = I18n.t("report.subject", scope: "decidim.proposals.proposal_reported_mailer")
+          mail(to: user.email, subject: subject)
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/mailers/decidim/proposals/proposal_reported_mailer.rb
+++ b/decidim-proposals/app/mailers/decidim/proposals/proposal_reported_mailer.rb
@@ -14,6 +14,16 @@ module Decidim
           mail(to: user.email, subject: subject)
         end
       end
+
+      def hide(user, proposal_report)
+        with_user(user) do
+          @proposal_report = proposal_report
+          @organization = user.organization
+          @user = user
+          subject = I18n.t("hide.subject", scope: "decidim.proposals.proposal_reported_mailer")
+          mail(to: user.email, subject: subject)
+        end
+      end
     end
   end
 end

--- a/decidim-proposals/app/models/decidim/proposals/abilities/admin_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/admin_user.rb
@@ -17,6 +17,7 @@ module Decidim
 
           can :manage, Proposal
           can :unreport, Proposal
+          can :hide, Proposal
           cannot :create, Proposal unless can_create_proposal?
           cannot :update, Proposal unless can_update_proposal?
         end

--- a/decidim-proposals/app/models/decidim/proposals/abilities/admin_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/admin_user.rb
@@ -16,6 +16,7 @@ module Decidim
           @context = context
 
           can :manage, Proposal
+          can :unreport, Proposal
           cannot :create, Proposal unless can_create_proposal?
           cannot :update, Proposal unless can_update_proposal?
         end

--- a/decidim-proposals/app/models/decidim/proposals/abilities/current_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/current_user.rb
@@ -24,6 +24,8 @@ module Decidim
           end
 
           can :create, Proposal if authorized?(:create) && creation_enabled?
+
+          can :report, Proposal if authorized?(:report)
         end
 
         private

--- a/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
@@ -18,7 +18,7 @@ module Decidim
           can :manage, Proposal do |proposal|
             participatory_processes.include?(proposal.feature.participatory_process)
           end
-
+          can :unreport, Proposal
           cannot :create, Proposal unless can_create_proposal?
           cannot :update, Proposal unless can_update_proposal?
         end

--- a/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
+++ b/decidim-proposals/app/models/decidim/proposals/abilities/process_admin_user.rb
@@ -19,6 +19,7 @@ module Decidim
             participatory_processes.include?(proposal.feature.participatory_process)
           end
           can :unreport, Proposal
+          can :hide, Proposal
           cannot :create, Proposal unless can_create_proposal?
           cannot :update, Proposal unless can_update_proposal?
         end

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -13,6 +13,7 @@ module Decidim
       feature_manifest_name "proposals"
 
       has_many :votes, foreign_key: "decidim_proposal_id", class_name: ProposalVote, dependent: :destroy, counter_cache: "proposal_votes_count"
+      has_many :reports, foreign_key: "decidim_proposal_id", class_name: ProposalReport, dependent: :destroy
 
       validates :title, :body, presence: true
 
@@ -32,6 +33,13 @@ module Decidim
       # Returns Boolean.
       def voted_by?(user)
         votes.where(author: user).any?
+      end
+
+      # Public: Check if the user has reported the proposal.
+      #
+      # Returns Boolean.
+      def reported_by?(user)
+        reports.where(user: user).any?
       end
 
       # Public: Checks if the organization has given an answer for the proposal.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -17,9 +17,11 @@ module Decidim
 
       validates :title, :body, presence: true
 
-      scope :accepted, -> { where(state: "accepted") }
-      scope :rejected, -> { where(state: "rejected") }
-      scope :reported, -> { where("report_count > 0") }
+      scope :accepted,   -> { where(state: "accepted") }
+      scope :rejected,   -> { where(state: "rejected") }
+      scope :reported,   -> { where("report_count > 0") }
+      scope :not_hidden, -> { where(hidden_at: nil) }
+      scope :hidden,     -> { where.not(hidden_at: nil) }
 
       def author_name
         user_group&.name || author&.name || I18n.t("decidim.proposals.models.proposal.fields.official_proposal")

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -19,6 +19,7 @@ module Decidim
 
       scope :accepted, -> { where(state: "accepted") }
       scope :rejected, -> { where(state: "rejected") }
+      scope :reported, -> { where("report_count > 0") }
 
       def author_name
         user_group&.name || author&.name || I18n.t("decidim.proposals.models.proposal.fields.official_proposal")
@@ -63,11 +64,18 @@ module Decidim
         state == "rejected"
       end
 
-      # Public: Checks if the proposal is hidden or not
+      # Public: Checks if the proposal is hidden or not.
       #
       # Returns Boolean.
       def hidden?
         hidden_at.present?
+      end
+
+      # Public: Checks if the proposal has been reported or not.
+      #
+      # Returns Boolean.
+      def reported?
+        report_count > 0
       end
 
       # Public: Overrides the `commentable?` Commentable concern method.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -87,7 +87,7 @@ module Decidim
 
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
-         commentable? && !feature.active_step_settings.comments_blocked
+        commentable? && !feature.active_step_settings.comments_blocked
       end
 
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -63,6 +63,13 @@ module Decidim
         state == "rejected"
       end
 
+      # Public: Checks if the proposal is hidden or not
+      #
+      # Returns Boolean.
+      def hidden?
+        hidden_at.present?
+      end
+
       # Public: Overrides the `commentable?` Commentable concern method.
       def commentable?
         feature.settings.comments_enabled?

--- a/decidim-proposals/app/models/decidim/proposals/proposal_report.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal_report.rb
@@ -3,15 +3,14 @@ module Decidim
   module Proposals
     # A proposal can be reported one time for each user.
     class ProposalReport < ApplicationRecord
-      TYPES = %w(spam offensive does_not_belong)
-      self.inheritance_column = nil
+      REASONS = %w(spam offensive does_not_belong).freeze
 
       belongs_to :proposal, foreign_key: "decidim_proposal_id", class_name: Decidim::Proposals::Proposal
       belongs_to :user, foreign_key: "decidim_user_id", class_name: Decidim::User
 
-      validates :proposal, :user, :type, presence: true
+      validates :proposal, :user, :reason, presence: true
       validates :proposal, uniqueness: { scope: :user }
-      validates :type, inclusion: { in: TYPES }
+      validates :reason, inclusion: { in: REASONS }
       validate :user_and_proposal_same_organization
 
       private

--- a/decidim-proposals/app/models/decidim/proposals/proposal_report.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal_report.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module Decidim
+  module Proposals
+    # A proposal can be reported one time for each user.
+    class ProposalReport < ApplicationRecord
+      TYPES = %w(spam offensive does_not_belong)
+      self.inheritance_column = nil
+
+      belongs_to :proposal, foreign_key: "decidim_proposal_id", class_name: Decidim::Proposals::Proposal
+      belongs_to :user, foreign_key: "decidim_user_id", class_name: Decidim::User
+
+      validates :proposal, :user, :type, presence: true
+      validates :proposal, uniqueness: { scope: :user }
+      validates :type, inclusion: { in: TYPES }
+      validate :user_and_proposal_same_organization
+
+      private
+
+      # Private: check if the proposal and the user have the same organization
+      def user_and_proposal_same_organization
+        return if !proposal || !user
+        errors.add(:proposal, :invalid) unless user.organization == proposal.organization
+      end
+    end
+  end
+end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -49,7 +49,7 @@
         <td>
           <% if params[:reported] || params[:hidden] %>
             <% proposal.reports.each do |report| %>
-              <span><%= report.user.name %> - <%= report.type %></span>
+              <span><%= report.user.name %> - <%= report.reason %></span>
               <br />
             <% end %>
           <% else %>
@@ -60,10 +60,10 @@
           <%= link_to t("actions.answer", scope: "decidim.proposals"), edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id) if can? :update, proposal %>
           <% if params[:reported] || params[:hidden] %>
             <% if can? :unreport, proposal %>
-              | <%= link_to t("actions.unreport", scope: "decidim.proposals"), unreport_proposal_path(proposal), method: :put %>
+              | <%= link_to t("actions.unreport", scope: "decidim.proposals"), unreport_proposal_path(proposal), method: :put, class: "button" %>
             <% end %>
             <% if !proposal.hidden? && can?(:hide, proposal) %>
-              | <%= link_to t("actions.hide", scope: "decidim.proposals"), hide_proposal_path(proposal), method: :put %>
+              | <%= link_to t("actions.hide", scope: "decidim.proposals"), hide_proposal_path(proposal), method: :put, class: "button" %>
             <% end %>
           <% end %>
         </td>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -48,10 +48,23 @@
         <% end %>
         <td>
           <% if params[:reported] || params[:hidden] %>
-            <% proposal.reports.each do |report| %>
-              <span><%= report.user.name %> - <%= report.reason %></span>
-              <br />
-            <% end %>
+            <ul>
+              <% proposal.reports.each do |report| %>
+                <li>
+                  <% if report.details.blank? %>
+                    <%= report.reason %>
+                  <% else %>
+                    <span
+                      data-tooltip
+                      aria-haspopup="true"
+                      class="has-tip"
+                      title="<%= report.details %>">
+                        <%= report.reason %>
+                    </span>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
           <% else %>
             <%= humanize_proposal_state proposal.state %>
           <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -56,8 +56,13 @@
         </td>
         <td class="actions">
           <%= link_to t("actions.answer", scope: "decidim.proposals"), edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id) if can? :update, proposal %>
-          <% if params[:reported] && proposal.reported? && can?(:unreport, proposal) %>
-            | <%= link_to t("actions.unreport", scope: "decidim.proposals"), unreport_proposal_path(proposal), method: :put %>
+          <% if params[:reported] %>
+            <% if can? :unreport, proposal %>
+              | <%= link_to t("actions.unreport", scope: "decidim.proposals"), unreport_proposal_path(proposal), method: :put %>
+            <% end %>
+          <% end %>
+          <% if can? :hide, proposal %>
+            | <%= link_to t("actions.hide", scope: "decidim.proposals"), hide_proposal_path(proposal), method: :put %>
           <% end %>
         </td>
       </tr>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -3,6 +3,10 @@
 <% if feature_settings.official_proposals_enabled %>
   <div class="actions title">
     <%= link_to t("actions.new", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), new_proposal_path, class: 'new' if can? :manage, current_feature %>
+    |
+    <%= link_to t("actions.all_proposals", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), proposals_path if can? :manage, current_feature %>
+    |
+    <%= link_to t("actions.reported_proposals", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), proposals_path(reported: true) if can? :manage, current_feature %>
   </div>
 <% end %>
 
@@ -14,7 +18,11 @@
       <% if feature_settings.scoped_proposals_enabled %>
         <th><%= t("models.proposal.fields.scope", scope: "decidim.proposals") %></th>
       <% end %>
-      <th><%= t("models.proposal.fields.state", scope: "decidim.proposals") %></th>
+      <% if params[:reported] %>
+        <th><%= t("models.proposal.fields.reports", scope: "decidim.proposals") %></th>
+      <% else %>
+        <th><%= t("models.proposal.fields.state", scope: "decidim.proposals") %></th>
+      <% end %>
       <th class="actions"><%= t("actions.title", scope: "decidim.proposals") %></th>
     </tr>
   </thead>
@@ -37,10 +45,20 @@
           </td>
         <% end %>
         <td>
-          <%= humanize_proposal_state proposal.state %>
+          <% if params[:reported] %>
+            <% proposal.reports.each do |report| %>
+              <span><%= report.user.name %> - <%= report.type %></span>
+              <br />
+            <% end %>
+          <% else %>
+            <%= humanize_proposal_state proposal.state %>
+          <% end %>
         </td>
         <td class="actions">
           <%= link_to t("actions.answer", scope: "decidim.proposals"), edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id) if can? :update, proposal %>
+          <% if params[:reported] && proposal.reported? && can?(:unreport, proposal) %>
+            | <%= link_to t("actions.unreport", scope: "decidim.proposals"), unreport_proposal_path(proposal), method: :put %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -7,6 +7,8 @@
     <%= link_to t("actions.all_proposals", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), proposals_path if can? :manage, current_feature %>
     |
     <%= link_to t("actions.reported_proposals", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), proposals_path(reported: true) if can? :manage, current_feature %>
+    |
+    <%= link_to t("actions.hidden_proposals", scope: "decidim.proposals", name: t("models.proposal.name", scope: "decidim.proposals.admin")), proposals_path(hidden: true) if can? :manage, current_feature %>
   </div>
 <% end %>
 
@@ -18,7 +20,7 @@
       <% if feature_settings.scoped_proposals_enabled %>
         <th><%= t("models.proposal.fields.scope", scope: "decidim.proposals") %></th>
       <% end %>
-      <% if params[:reported] %>
+      <% if params[:reported] || params[:hidden] %>
         <th><%= t("models.proposal.fields.reports", scope: "decidim.proposals") %></th>
       <% else %>
         <th><%= t("models.proposal.fields.state", scope: "decidim.proposals") %></th>
@@ -45,7 +47,7 @@
           </td>
         <% end %>
         <td>
-          <% if params[:reported] %>
+          <% if params[:reported] || params[:hidden] %>
             <% proposal.reports.each do |report| %>
               <span><%= report.user.name %> - <%= report.type %></span>
               <br />
@@ -56,13 +58,13 @@
         </td>
         <td class="actions">
           <%= link_to t("actions.answer", scope: "decidim.proposals"), edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id) if can? :update, proposal %>
-          <% if params[:reported] %>
+          <% if params[:reported] || params[:hidden] %>
             <% if can? :unreport, proposal %>
               | <%= link_to t("actions.unreport", scope: "decidim.proposals"), unreport_proposal_path(proposal), method: :put %>
             <% end %>
-          <% end %>
-          <% if can? :hide, proposal %>
-            | <%= link_to t("actions.hide", scope: "decidim.proposals"), hide_proposal_path(proposal), method: :put %>
+            <% if !proposal.hidden? && can?(:hide, proposal) %>
+              | <%= link_to t("actions.hide", scope: "decidim.proposals"), hide_proposal_path(proposal), method: :put %>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/decidim-proposals/app/views/decidim/proposals/proposal_reported_mailer/hide.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposal_reported_mailer/hide.html.erb
@@ -1,0 +1,10 @@
+<p><%= t(".hello", name: @user.name) %></p>
+
+<p>
+  <%=
+    t(".report_html", {
+      reporter_name: @proposal_report.user.name,
+      proposal_link: link_to(@proposal_report.proposal.title, decidim_resource_url(@proposal_report.proposal))
+    })
+  %>
+</p>

--- a/decidim-proposals/app/views/decidim/proposals/proposal_reported_mailer/hide.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposal_reported_mailer/hide.html.erb
@@ -3,7 +3,6 @@
 <p>
   <%=
     t(".report_html", {
-      reporter_name: @proposal_report.user.name,
       proposal_link: link_to(@proposal_report.proposal.title, decidim_resource_url(@proposal_report.proposal))
     })
   %>

--- a/decidim-proposals/app/views/decidim/proposals/proposal_reported_mailer/report.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposal_reported_mailer/report.html.erb
@@ -1,0 +1,10 @@
+<p><%= t(".hello", name: @user.name) %></p>
+
+<p>
+  <%=
+    t(".report_html", {
+      reporter_name: @proposal_report.user.name,
+      proposal_link: link_to(@proposal_report.proposal.title, decidim_resource_url(@proposal_report.proposal))
+    })
+  %>
+</p>

--- a/decidim-proposals/app/views/decidim/proposals/proposal_reported_mailer/report.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposal_reported_mailer/report.html.erb
@@ -3,7 +3,6 @@
 <p>
   <%=
     t(".report_html", {
-      reporter_name: @proposal_report.user.name,
       proposal_link: link_to(@proposal_report.proposal.title, decidim_resource_url(@proposal_report.proposal))
     })
   %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -19,6 +19,11 @@
         </span>
       </div>
     </div>
+    <div class="author-data__extra">
+      <button type="button" data-open="<%= current_user.present? ? 'flagModal' : 'loginModal' %>" title="<%= t('.report') %>" aria-controls="<%= current_user.present? ? 'flagModal' : 'loginModal' %>" aria-haspopup="true" tabindex="0">
+        <%= icon "flag", aria_label: t('.report'), class: 'icon--small' %>
+      </button>
+    </div>
   </div>
 </div>
 <div class="row">
@@ -70,3 +75,5 @@
 
 <%= javascript_include_tag "decidim/proposals/social_share" %>
 <%= stylesheet_link_tag "decidim/proposals/social_share" %>
+
+<%= render partial: "decidim/shared/flag_modal", locals: { resource: @proposal, form: @proposal_report_form, url: proposal_proposal_report_path(@proposal) } %>

--- a/decidim-proposals/config/i18n-tasks.yml
+++ b/decidim-proposals/config/i18n-tasks.yml
@@ -5,6 +5,7 @@ ignore_unused:
 - "decidim.features.proposals.settings.*"
 - "decidim.resource_links.*"
 - "activemodel.attributes.proposal.*"
+- "activemodel.attributes.proposal_report.*"
 - "decidim.proposals.answers.*"
 - "decidim.features.proposals.actions.*"
 - "decidim.proposals.proposals.orders.*"

--- a/decidim-proposals/config/locales/ca.yml
+++ b/decidim-proposals/config/locales/ca.yml
@@ -65,9 +65,13 @@ ca:
         error: Hi ha hagut errors en desar la proposta.
         success: Proposta creada correctament.
       proposal_reported_mailer:
+        hide:
+          hello: Hola %{name},
+          report_html: La proposta %{proposal_link} ha estat amagada automàticament.
+          subject: Una proposta ha estat amagada automàticament
         report:
           hello: Hola %{name},
-          report_html: La proposta %{proposal_link} ha estat reportada per %{reporter_name}
+          report_html: La proposta %{proposal_link} ha estat reportada per %{reporter_name}.
           subject: Una proposta ha estat reportada
       models:
         proposal:

--- a/decidim-proposals/config/locales/ca.yml
+++ b/decidim-proposals/config/locales/ca.yml
@@ -64,6 +64,11 @@ ca:
       create:
         error: Hi ha hagut errors en desar la proposta.
         success: Proposta creada correctament.
+      proposal_reported_mailer:
+        report:
+          hello: Hola %{name},
+          report_html: La proposta %{proposal_link} ha estat reportada per %{reporter_name}
+          subject: Una proposta ha estat reportada
       models:
         proposal:
           fields:

--- a/decidim-proposals/config/locales/ca.yml
+++ b/decidim-proposals/config/locales/ca.yml
@@ -71,8 +71,8 @@ ca:
           subject: Una proposta ha estat amagada automàticament
         report:
           hello: Hola %{name},
-          report_html: La proposta %{proposal_link} ha estat reportada per %{reporter_name}.
-          subject: Una proposta ha estat reportada
+          report_html: La proposta %{proposal_link} ha estat denunciada.
+          subject: Una proposta ha estat denunciada
       models:
         proposal:
           fields:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -73,6 +73,10 @@ en:
             scope: Scope
             state: State
             title: Title
+      proposal_reports:
+        create:
+          error: An error ocurred while reporting the proposal. Please, try it again.
+          success: The proposal has been reported successfully and it will be reviewed by an admin.
       proposals:
         count:
           proposals_count:
@@ -119,6 +123,7 @@ en:
         show:
           proposal_accepted_reason: 'This proposal has been accepted because:'
           proposal_rejected_reason: 'This proposal has been rejected because:'
+          report: Report
         vote_button:
           already_voted: Already voted
           no_votes_remaining: No votes remaining

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
       actions:
         all_proposals: All proposals
         answer: Answer
+        hidden_proposals: Hidden proposals
         hide: Hide
         new: New proposal
         reported_proposals: Reported proposals
@@ -84,6 +85,7 @@ en:
             scope: Scope
             state: State
             title: Title
+      not_found: The proposal doesn't exists.
       proposal_reported_mailer:
         hide:
           hello: Hello %{name},

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -8,6 +8,8 @@ en:
         scope_id: Scope
         title: Title
         user_group_id: Create proposal as
+      proposal_report:
+        details: Additional comments
   decidim:
     features:
       proposals:
@@ -92,7 +94,7 @@ en:
           subject: A proposal has been hidden automatically
         report:
           hello: Hello %{name},
-          report_html: The proposal %{proposal_link} has been reported by %{reporter_name}
+          report_html: The proposal %{proposal_link} has been reported.
           subject: A proposal has been reported
       proposal_reports:
         create:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -85,7 +85,6 @@ en:
             scope: Scope
             state: State
             title: Title
-      not_found: The proposal doesn't exists.
       proposal_reported_mailer:
         hide:
           hello: Hello %{name},

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -30,9 +30,12 @@ en:
             votes_enabled: Votes enabled
     proposals:
       actions:
+        all_proposals: All proposals
         answer: Answer
         new: New proposal
+        reported_proposals: Reported proposals
         title: Actions
+        unreport: Unreport
       admin:
         models:
           proposal:
@@ -58,6 +61,9 @@ en:
           new:
             create: Create proposal
             title: New proposal
+          unreport:
+            invalid: There's been a problem unreporting this proposal
+            success: Proposal successfully unreported
       answers:
         accepted: Accepted
         not_answered: Not answered
@@ -70,6 +76,7 @@ en:
           fields:
             category: Category
             official_proposal: Official proposal
+            reports: Reports
             scope: Scope
             state: State
             title: Title

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -74,6 +74,10 @@ en:
             state: State
             title: Title
       proposal_reported_mailer:
+        hide:
+          hello: Hello %{name},
+          report_html: The proposal %{proposal_link} has been hidden automatically.
+          subject: A proposal has been hidden automatically
         report:
           hello: Hello %{name},
           report_html: The proposal %{proposal_link} has been reported by %{reporter_name}

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
       actions:
         all_proposals: All proposals
         answer: Answer
+        hide: Hide
         new: New proposal
         reported_proposals: Reported proposals
         title: Actions
@@ -56,6 +57,9 @@ en:
           form:
             select_a_category: Select a category
             select_a_scope: Select a scope
+          hide:
+            invalid: There's been a problem hiding this proposal
+            success: Proposal successfully hidden
           index:
             title: Proposals
           new:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -73,10 +73,16 @@ en:
             scope: Scope
             state: State
             title: Title
+      proposal_reported_mailer:
+        report:
+          hello: Hello %{name},
+          report_html: The proposal %{proposal_link} has been reported by %{reporter_name}
+          subject: A proposal has been reported
       proposal_reports:
         create:
           error: An error ocurred while reporting the proposal. Please, try it again.
-          success: The proposal has been reported successfully and it will be reviewed by an admin.
+          success: The proposal has been reported successfully and it will be reviewed
+            by an admin.
       proposals:
         count:
           proposals_count:

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -67,7 +67,7 @@ es:
       proposal_reported_mailer:
         report:
           hello: Hola %{name},
-          report_html: La propuesta %{proposal_link} ha sido denunciada por %{reporter_name}
+          report_html: La propuesta %{proposal_link} ha sido denunciada.
           subject: Una propuesta ha sido denunciada
       models:
         proposal:

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -67,8 +67,8 @@ es:
       proposal_reported_mailer:
         report:
           hello: Hola %{name},
-          report_html: La propuesta %{proposal_link} ha sido reportada por %{reporter_name}
-          subject: Una proposta ha sido reportada
+          report_html: La propuesta %{proposal_link} ha sido denunciada por %{reporter_name}
+          subject: Una propuesta ha sido denunciada
       models:
         proposal:
           fields:

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -64,6 +64,11 @@ es:
       create:
         error: Ha habido errores al guardar la propuesta.
         success: Propuesta creada correctamente.
+      proposal_reported_mailer:
+        report:
+          hello: Hola %{name},
+          report_html: La propuesta %{proposal_link} ha sido reportada por %{reporter_name}
+          subject: Una proposta ha sido reportada
       models:
         proposal:
           fields:

--- a/decidim-proposals/db/migrate/20170215113152_create_proposal_reports.rb
+++ b/decidim-proposals/db/migrate/20170215113152_create_proposal_reports.rb
@@ -1,0 +1,13 @@
+class CreateProposalReports < ActiveRecord::Migration[5.0]
+  def change
+    create_table :decidim_proposals_proposal_reports do |t|
+      t.references :decidim_proposal, null: false, index: { name: "decidim_proposals_proposal_result_proposal" }
+      t.references :decidim_user, null: false, index: { name: "decidim_proposals_proposal_result_user" }
+      t.string :type, null: false
+
+      t.timestamps
+    end
+
+    add_index :decidim_proposals_proposal_reports, [:decidim_proposal_id, :decidim_user_id], unique: true, name: "decidim_proposals_proposal_report_proposal_user_unique"
+  end
+end

--- a/decidim-proposals/db/migrate/20170215113152_create_proposal_reports.rb
+++ b/decidim-proposals/db/migrate/20170215113152_create_proposal_reports.rb
@@ -4,6 +4,7 @@ class CreateProposalReports < ActiveRecord::Migration[5.0]
       t.references :decidim_proposal, null: false, index: { name: "decidim_proposals_proposal_result_proposal" }
       t.references :decidim_user, null: false, index: { name: "decidim_proposals_proposal_result_user" }
       t.string :reason, null: false
+      t.text :details
 
       t.timestamps
     end

--- a/decidim-proposals/db/migrate/20170215113152_create_proposal_reports.rb
+++ b/decidim-proposals/db/migrate/20170215113152_create_proposal_reports.rb
@@ -3,7 +3,7 @@ class CreateProposalReports < ActiveRecord::Migration[5.0]
     create_table :decidim_proposals_proposal_reports do |t|
       t.references :decidim_proposal, null: false, index: { name: "decidim_proposals_proposal_result_proposal" }
       t.references :decidim_user, null: false, index: { name: "decidim_proposals_proposal_result_user" }
-      t.string :type, null: false
+      t.string :reason, null: false
 
       t.timestamps
     end

--- a/decidim-proposals/db/migrate/20170215131720_add_report_count_to_proposals.rb
+++ b/decidim-proposals/db/migrate/20170215131720_add_report_count_to_proposals.rb
@@ -1,0 +1,5 @@
+class AddReportCountToProposals < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_proposals_proposals, :report_count, :integer, default: 0
+  end
+end

--- a/decidim-proposals/db/migrate/20170220152416_add_hidden_at_to_proposals.rb
+++ b/decidim-proposals/db/migrate/20170220152416_add_hidden_at_to_proposals.rb
@@ -1,0 +1,5 @@
+class AddHiddenAtToProposals < ActiveRecord::Migration[5.0]
+  def change
+    add_column :decidim_proposals_proposals, :hidden_at, :datetime
+  end
+end

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -10,6 +10,9 @@ module Decidim
       routes do
         resources :proposals, only: [:index, :new, :create] do
           resources :proposal_answers, only: [:edit, :update]
+          member do
+            put :unreport
+          end
         end
         root to: "proposals#index"
       end

--- a/decidim-proposals/lib/decidim/proposals/admin_engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/admin_engine.rb
@@ -12,6 +12,7 @@ module Decidim
           resources :proposal_answers, only: [:edit, :update]
           member do
             put :unreport
+            put :hide
           end
         end
         root to: "proposals#index"

--- a/decidim-proposals/lib/decidim/proposals/engine.rb
+++ b/decidim-proposals/lib/decidim/proposals/engine.rb
@@ -13,6 +13,7 @@ module Decidim
       routes do
         resources :proposals, only: [:create, :new, :index, :show] do
           resource :proposal_vote, only: [:create, :destroy]
+          resource :proposal_report, only: [:create]
         end
         root to: "proposals#index"
       end

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -74,6 +74,13 @@ FactoryGirl.define do
       answer { Decidim::Faker::Localized.sentence }
       answered_at { Time.current }
     end
+
+    trait :reported do
+      report_count 1
+      after(:create) do |proposal|
+        create(:proposal_report, proposal: proposal)
+      end
+    end
   end
 
   factory :proposal_vote, class: Decidim::Proposals::ProposalVote do

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -80,4 +80,10 @@ FactoryGirl.define do
     proposal { build(:proposal) }
     author { build(:user, organization: proposal.organization) }
   end
+
+  factory :proposal_report, class: Decidim::Proposals::ProposalReport do
+    proposal { build(:proposal) }
+    user { build(:user, organization: proposal.organization) }
+    type "spam"
+  end
 end

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -81,6 +81,10 @@ FactoryGirl.define do
         create(:proposal_report, proposal: proposal)
       end
     end
+
+    trait :hidden do
+      hidden_at Time.current
+    end
   end
 
   factory :proposal_vote, class: Decidim::Proposals::ProposalVote do

--- a/decidim-proposals/lib/decidim/proposals/test/factories.rb
+++ b/decidim-proposals/lib/decidim/proposals/test/factories.rb
@@ -95,6 +95,6 @@ FactoryGirl.define do
   factory :proposal_report, class: Decidim::Proposals::ProposalReport do
     proposal { build(:proposal) }
     user { build(:user, organization: proposal.organization) }
-    type "spam"
+    reason "spam"
   end
 end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin_hide_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin_hide_proposal_spec.rb
@@ -5,7 +5,7 @@ module Decidim
   module Proposals
     module Admin
       describe HideProposal do
-        let(:proposal) { create(:proposal) }
+        let(:proposal) { create(:proposal, :reported) }
         let(:command) { described_class.new(proposal) }
 
         context "when everything is ok" do
@@ -21,6 +21,14 @@ module Decidim
 
         context "when the proposal is already hidden" do
           let(:proposal) { create(:proposal, :hidden) }
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when the proposal is not reported" do
+          let(:proposal) { create(:proposal) }
 
           it "broadcasts invalid" do
             expect { command.call }.to broadcast(:invalid)

--- a/decidim-proposals/spec/commands/decidim/proposals/admin_hide_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin_hide_proposal_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    module Admin
+      describe HideProposal do
+        let(:proposal) { create(:proposal) }
+        let(:command) { described_class.new(proposal) }
+
+        context "when everything is ok" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "hides the proposal" do
+            command.call
+            expect(proposal.reload).to be_hidden
+          end
+        end
+
+        context "when the proposal is already hidden" do
+          let(:proposal) { create(:proposal, :hidden) }
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/commands/decidim/proposals/admin_unreport_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin_unreport_proposal_spec.rb
@@ -17,6 +17,15 @@ module Decidim
             command.call
             expect(proposal.reload.report_count).to eq(0)
           end
+
+          context "when the proposal is hidden" do
+            let(:proposal) { create(:proposal, :reported, :hidden) }
+
+            it "unhides the proposal" do
+              command.call
+              expect(proposal.reload).not_to be_hidden
+            end
+          end
         end
 
         context "when the proposal is not reported" do

--- a/decidim-proposals/spec/commands/decidim/proposals/admin_unreport_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/admin_unreport_proposal_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    module Admin
+      describe UnreportProposal do
+        let(:proposal) { create(:proposal, :reported) }
+        let(:command) { described_class.new(proposal) }
+
+        context "when everything is ok" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "resets the report count" do
+            command.call
+            expect(proposal.reload.report_count).to eq(0)
+          end
+        end
+
+        context "when the proposal is not reported" do
+          let(:proposal) { create(:proposal) }
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/commands/decidim/proposals/report_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/report_proposal_spec.rb
@@ -13,7 +13,7 @@ module Decidim
         let(:form) { ProposalReportForm.from_params(form_params) }
         let(:form_params) do
           {
-            type: "spam"
+            reason: "spam"
           }
         end
 

--- a/decidim-proposals/spec/commands/decidim/proposals/report_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/report_proposal_spec.rb
@@ -8,6 +8,7 @@ module Decidim
         let(:organization) { create(:organization) }
         let(:feature) { create(:proposal_feature, organization: organization) }
         let(:proposal) { create(:proposal, feature: feature) }
+        let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
         let(:user) { create(:user, :confirmed, organization: organization) }
         let(:form) { ProposalReportForm.from_params(form_params) }
         let(:form_params) do
@@ -31,6 +32,15 @@ module Decidim
             expect {
               command.call
             }.to_not change { ProposalReport.count }
+          end
+
+          it "sends an email to the admin" do
+            allow(ProposalReportedMailer).to receive(:report)
+            command.call
+            last_report = ProposalReport.last
+            expect(ProposalReportedMailer)
+              .to have_received(:report)
+              .with(admin, last_report)
           end
         end
 

--- a/decidim-proposals/spec/features/report_proposal_spec.rb
+++ b/decidim-proposals/spec/features/report_proposal_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+describe "Report Proposal", type: :feature do
+  include_context "feature"
+  let(:manifest_name) { "proposals" }
+  let!(:proposals) { create_list(:proposal, 3, feature: feature) }
+  let(:proposal) { proposals.first }
+  let!(:user) { create :user, :confirmed, organization: organization }
+
+  let!(:feature) do
+    create(:proposal_feature,
+      manifest: manifest,
+      participatory_process: participatory_process)
+  end
+
+  context "when the user is not logged in" do
+    it "should be given the option to sign in" do
+      visit_feature
+      click_link proposal.title
+
+      within ".author-data__extra", match: :first do
+        page.find('button').click
+      end
+
+      expect(page).to have_css('#loginModal', visible: true)
+    end
+  end
+
+  context "when the user is logged in" do
+    before do
+      login_as user, scope: :user
+    end
+
+    context "and the user has not reported the proposal yet" do
+      it "reports the proposal" do
+        visit_feature
+        click_link proposal.title
+
+        within ".author-data__extra", match: :first do
+          page.find('button').click
+        end
+
+        expect(page).to have_css('#flagModal', visible: true)
+
+        choose "proposal_report_type_offensive"
+
+        within "#flagModal" do
+          click_button "Report"
+        end
+
+        expect(page).to have_content "has been reported"
+      end
+    end
+
+    context "and the user has reported the proposal previously" do
+      before do
+        create(:proposal_report, proposal: proposal, user: user, type: "spam")
+      end
+
+      it "cannot report it twice" do
+        visit_feature
+        click_link proposal.title
+
+        within ".author-data__extra", match: :first do
+          page.find('button').click
+        end
+
+        expect(page).to have_css('#flagModal', visible: true)
+
+        expect(page).to have_content "already reported"        
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/features/report_proposal_spec.rb
+++ b/decidim-proposals/spec/features/report_proposal_spec.rb
@@ -43,7 +43,7 @@ describe "Report Proposal", type: :feature do
 
         expect(page).to have_css('#flagModal', visible: true)
 
-        choose "proposal_report_type_offensive"
+        choose "proposal_report_reason_offensive"
 
         within "#flagModal" do
           click_button "Report"
@@ -55,7 +55,7 @@ describe "Report Proposal", type: :feature do
 
     context "and the user has reported the proposal previously" do
       before do
-        create(:proposal_report, proposal: proposal, user: user, type: "spam")
+        create(:proposal_report, proposal: proposal, user: user, reason: "spam")
       end
 
       it "cannot report it twice" do
@@ -68,7 +68,7 @@ describe "Report Proposal", type: :feature do
 
         expect(page).to have_css('#flagModal', visible: true)
 
-        expect(page).to have_content "already reported"        
+        expect(page).to have_content "already reported"
       end
     end
   end

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_report_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_report_form_spec.rb
@@ -4,10 +4,10 @@ require "spec_helper"
 module Decidim
   module Proposals
     describe ProposalReportForm do
-      let(:type) { "spam" }
+      let(:reason) { "spam" }
       let(:params) do
         {
-          type: type
+          reason: reason
         }
       end
 
@@ -21,8 +21,8 @@ module Decidim
         it { is_expected.to be_valid }
       end
 
-      context "when type is not in the list" do
-        let(:type) { "foo" }
+      context "when reason is not in the list" do
+        let(:reason) { "foo" }
         it { is_expected.to be_invalid }
       end
     end

--- a/decidim-proposals/spec/forms/decidim/proposals/proposal_report_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/proposal_report_form_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe ProposalReportForm do
+      let(:type) { "spam" }
+      let(:params) do
+        {
+          type: type
+        }
+      end
+
+      let(:form) do
+        described_class.from_params(params)
+      end
+
+      subject { form }
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when type is not in the list" do
+        let(:type) { "foo" }
+        it { is_expected.to be_invalid }
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/mailers/proposal_reported_mailer_spec.rb
+++ b/decidim-proposals/spec/mailers/proposal_reported_mailer_spec.rb
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe ProposalReportedMailer, type: :mailer do
+      let(:organization) { create(:organization) }
+      let(:user) { create(:user, :admin, organization: organization) }
+      let(:feature) { create(:proposal_feature, organization: organization) }
+      let(:proposal) { create(:proposal, feature: feature) }
+      let(:proposal_report) { create(:proposal_report, proposal: proposal) }
+
+      describe "#report" do
+        let(:mail) { described_class.report(user, proposal_report) }
+
+        let(:subject) { "Una proposta ha estat reportada" }
+        let(:default_subject) { "A proposal has been reported" }
+
+        let(:body) { "ha estat reportada" }
+        let(:default_body) { "has been reported" }
+
+        include_examples "localised email"
+      end
+    end
+  end
+end

--- a/decidim-proposals/spec/mailers/proposal_reported_mailer_spec.rb
+++ b/decidim-proposals/spec/mailers/proposal_reported_mailer_spec.rb
@@ -21,6 +21,18 @@ module Decidim
 
         include_examples "localised email"
       end
+
+      describe "#hide" do
+        let(:mail) { described_class.hide(user, proposal_report) }
+
+        let(:subject) { "Una proposta ha estat amagada automàticament" }
+        let(:default_subject) { "A proposal has been hidden automatically" }
+
+        let(:body) { "ha estat amagada" }
+        let(:default_body) { "has been hidden" }
+
+        include_examples "localised email"
+      end
     end
   end
 end

--- a/decidim-proposals/spec/mailers/proposal_reported_mailer_spec.rb
+++ b/decidim-proposals/spec/mailers/proposal_reported_mailer_spec.rb
@@ -13,10 +13,10 @@ module Decidim
       describe "#report" do
         let(:mail) { described_class.report(user, proposal_report) }
 
-        let(:subject) { "Una proposta ha estat reportada" }
+        let(:subject) { "Una proposta ha estat denunciada" }
         let(:default_subject) { "A proposal has been reported" }
 
-        let(:body) { "ha estat reportada" }
+        let(:body) { "ha estat denunciada" }
         let(:default_body) { "has been reported" }
 
         include_examples "localised email"

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -31,6 +31,19 @@ module Decidim
         end
       end
 
+      describe "#reported_by?" do
+        let(:user) { create(:user, organization: subject.organization) }
+
+        it "returns false if the proposal has not been reported by the given user" do
+          expect(subject.reported_by?(user)).to be_falsey
+        end
+
+        it "returns true if the proposal has been reported by the given user" do
+          create(:proposal_report, proposal: subject, user: user)
+          expect(subject.reported_by?(user)).to be_truthy
+        end
+      end
+
       context "when it has been accepted" do
         let(:proposal) { build(:proposal, :accepted) }
 

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -55,6 +55,17 @@ module Decidim
         end
       end
 
+      context "#reported?" do
+        it "returns false if the proposal report count is equal to 0" do
+          expect(subject).not_to be_reported
+        end
+
+        it "returns true if the proposal report count is greater than 0" do
+          subject.report_count = 1
+          expect(subject).to be_reported
+        end
+      end
+
       context "when it has been accepted" do
         let(:proposal) { build(:proposal, :accepted) }
 

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -44,6 +44,17 @@ module Decidim
         end
       end
 
+      context "#hidden?" do
+        it "returns false if the proposal hidden_at attribute is nil" do
+          expect(subject).not_to be_hidden
+        end
+
+        it "returns true if the proposal is not voted by the given user" do
+          subject.hidden_at = Time.current
+          expect(subject).to be_hidden
+        end
+      end
+
       context "when it has been accepted" do
         let(:proposal) { build(:proposal, :accepted) }
 

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -209,7 +209,7 @@ RSpec.shared_examples "manage proposals" do
       reported_proposals.each do |proposal|
         expect(page).to have_selector("tr", text: proposal.title)
         expect(page).to have_selector("tr", text: proposal.reports.first.user.name)
-        expect(page).to have_selector("tr", text: proposal.reports.first.type)
+        expect(page).to have_selector("tr", text: proposal.reports.first.reason)
       end
     end
 

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -208,7 +208,6 @@ RSpec.shared_examples "manage proposals" do
 
       reported_proposals.each do |proposal|
         expect(page).to have_selector("tr", text: proposal.title)
-        expect(page).to have_selector("tr", text: proposal.reports.first.user.name)
         expect(page).to have_selector("tr", text: proposal.reports.first.reason)
       end
     end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -197,4 +197,34 @@ RSpec.shared_examples "manage proposals" do
       end
     end
   end
+
+  context "listing reported proposals" do
+    let!(:reported_proposals) { create_list(:proposal, 3, :reported, feature: current_feature) }
+
+    it "user can review them" do
+      visit current_path
+
+      click_link "Reported proposals"
+
+      reported_proposals.each do |proposal|
+        expect(page).to have_selector("tr", text: proposal.title)
+        expect(page).to have_selector("tr", text: proposal.reports.first.user.name)
+        expect(page).to have_selector("tr", text: proposal.reports.first.type)
+      end
+    end
+
+    it "user can unreport a proposal" do
+      visit current_path
+
+      click_link "Reported proposals"
+
+      within find("tr", text: reported_proposals.first.title) do
+        click_link "Unreport"
+      end
+
+      within ".flash" do
+        expect(page).to have_content("Proposal successfully unreported")
+      end
+    end
+  end
 end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -213,7 +213,7 @@ RSpec.shared_examples "manage proposals" do
       end
     end
 
-    it "user can unreport a proposal" do
+    it "user can un-report a proposal" do
       visit current_path
 
       click_link "Reported proposals"
@@ -241,6 +241,20 @@ RSpec.shared_examples "manage proposals" do
       end
 
       expect(page).to have_no_content(reported_proposals.first.title)
+    end
+  end
+
+  context "listing hidden proposals" do
+    let!(:hidden_proposals) { create_list(:proposal, 3, :hidden, feature: current_feature) }
+
+    it "user can review them" do
+      visit current_path
+
+      click_link "Hidden proposals"
+
+      hidden_proposals.each do |proposal|
+        expect(page).to have_selector("tr", text: proposal.title)
+      end
     end
   end
 end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -226,5 +226,21 @@ RSpec.shared_examples "manage proposals" do
         expect(page).to have_content("Proposal successfully unreported")
       end
     end
+
+    it "user can hide a proposal" do
+      visit current_path
+
+      click_link "Reported proposals"
+
+      within find("tr", text: reported_proposals.first.title) do
+        click_link "Hide"
+      end
+
+      within ".flash" do
+        expect(page).to have_content("Proposal successfully hidden")
+      end
+
+      expect(page).to have_no_content(reported_proposals.first.title)
+    end
   end
 end

--- a/decidim-results/app/models/decidim/results/result.rb
+++ b/decidim-results/app/models/decidim/results/result.rb
@@ -19,7 +19,7 @@ module Decidim
 
       # Public: Overrides the `accepts_new_comments?` Commentable concern method.
       def accepts_new_comments?
-         commentable? && !feature.active_step_settings.comments_blocked
+        commentable? && !feature.active_step_settings.comments_blocked
       end
 
       # Public: Overrides the `comments_have_alignment?` Commentable concern method.

--- a/lib/generators/decidim/templates/initializer.rb
+++ b/lib/generators/decidim/templates/initializer.rb
@@ -16,4 +16,7 @@ Decidim.configure do |config|
 
   # Currency unit
   # config.currency_unit = "€"
+
+  # The number of reports which an object can receive before hiding it
+  # config.max_reports_before_hiding = 3
 end


### PR DESCRIPTION
#### :tophat: What? Why?

A proposal can be reported by an user and participatory process admins will be notified. If a proposal is reported 3 times (configurable by `Decidim.max_reports_before_hiding`) then the proposal is hidden automatically and admins will be notified as well.

#### :pushpin: Related Issues
- Closes #904 
- Related to #903 

#### :clipboard: Subtasks
- [x] Users can report proposals
- [x] An admin receive an email when a proposal is reported.
- [x] A proposal reported three times is hidden automatically and admin receive an email.
- [x] An admin can list reported proposals
- [x] An admin can unreport a proposal (reset reports count)
- [x] An admin can hide a proposal
- [x] Hidden proposals should not be public

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/23250742/b45f9d4e-f9aa-11e6-882b-ae88047236d9.png)
![image](https://cloud.githubusercontent.com/assets/106021/23250698/9285b352-f9aa-11e6-92a2-3af30a5f6b13.png)


#### :ghost: GIF
![](https://media.giphy.com/media/vgMlIHF5PAJO0/giphy.gif)
