### PR TITLE
Processes ending soon should be "active processes" instead

### DIFF
--- a/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
+++ b/decidim-core/app/views/pages/home/_highlighted_processes.html.erb
@@ -1,6 +1,6 @@
 <section class="wrapper-home">
   <div class="row">
-    <h3 class="section-heading"><%= t(".processes_ending_soon") %></h3>
+    <h3 class="section-heading"><%= t(".active_processes") %></h3>
     <div class="row collapse">
       <div class="row small-up-1 smallmedium-up-2 mediumlarge-up-3
                   large-up-4 card-grid">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -300,7 +300,7 @@ en:
         welcome: Welcome to %{organization}!
       highlighted_processes:
         active_step: Active step
-        processes_ending_soon: Processes ending soon
+        active_processes: Active processes
         see_all_processes: See all processes
       statistics:
         headline: Current state of %{organization}

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -299,8 +299,8 @@ en:
         participate: Participate
         welcome: Welcome to %{organization}!
       highlighted_processes:
-        active_step: Active step
         active_processes: Active processes
+        active_step: Active step
         see_all_processes: See all processes
       statistics:
         headline: Current state of %{organization}


### PR DESCRIPTION
#### :tophat: What? Why?
"Processes ending soon" is not precise, as it's actually "processes about to advance to the next step". We should rename it to avoid confusion.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/l4JyLs9tMBG9InVOo/source.gif)