### PR TITLE
Temporary fix for all dropdowns

### DIFF
--- a/decidim-comments/app/frontend/comments/comment_order_selector.component.jsx
+++ b/decidim-comments/app/frontend/comments/comment_order_selector.component.jsx
@@ -26,7 +26,7 @@ class CommentOrderSelector extends Component {
     return (
       <div className="order-by__dropdown order-by__dropdown--right">
         <span className="order-by__text">{ I18n.t("components.comment_order_selector.title") }</span>
-        <ul className="dropdown menu" data-dropdown-menu>
+        <ul className="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
           <li>
             <a>{ I18n.t(`components.comment_order_selector.order.${orderBy}`) }</a>
             <ul className="menu">

--- a/decidim-core/app/views/decidim/shared/_orders.html.erb
+++ b/decidim-core/app/views/decidim/shared/_orders.html.erb
@@ -1,7 +1,7 @@
 <div class="row collapse order-by">
   <div class="order-by__dropdown">
     <span class="order-by__text"><%= t("#{i18n_scope}.label") %></span>
-    <ul class="dropdown menu" data-dropdown-menu>
+    <ul class="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
       <li>
         <%= order_link order, i18n_scope: i18n_scope %>
         <ul class="menu">

--- a/decidim-core/app/views/layouts/decidim/_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_header.html.erb
@@ -36,7 +36,7 @@
             </div>
             <% if current_user %>
               <div class="topbar__dropmenu topbar__user__logged">
-                <ul class="dropdown menu" data-dropdown-menu>
+                <ul class="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
                   <li class="is-dropdown-submenu-parent show-for-medium">
                     <%= link_to current_user.name, decidim.account_path %>
                     <ul class="menu is-dropdown-submenu js-append usermenu-off-canvas">

--- a/decidim-core/app/views/layouts/decidim/_language_chooser.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_language_chooser.html.erb
@@ -1,5 +1,5 @@
 <div class="topbar__dropmenu language-choose">
-  <ul class="dropdown menu" data-dropdown-menu>
+  <ul class="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
     <li class="is-dropdown-submenu-parent">
       <%= link_to t("name", scope: "locale") %>
       <% if available_locales.length > 1 %>


### PR DESCRIPTION
#### :tophat: What? Why?
Adding ```data-close-on-click-inside="false"```  to all dropdonws, this PR fixes their behaviour on tablet and mobile devices. 

#### :pushpin: Related Issues
- Related to: https://github.com/AjuntamentdeBarcelona/decidim-design/pull/143
- Fixes #952, #953, #441?

#### :ghost: GIF
![](https://media.giphy.com/media/gZBYbXHtVcYKs/giphy.gif)
