### PR TITLE
Refactor how HTML and meta titles work

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
@@ -1,7 +1,3 @@
-<% add_meta_tags({
-  title: t(".meta_title", feature_name: translated_attribute(current_feature.name))
-}) %>
-
 <% if current_user.present? %>
   <div class="row column">
     <%= render partial: "budget_summary", locals: { include_heading: true } %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
@@ -1,4 +1,6 @@
-<% provide :meta_title, t(".meta_title", feature_name: translated_attribute(current_feature.name)) %>
+<% add_meta_tags({
+  title: t(".meta_title", feature_name: translated_attribute(current_feature.name))
+}) %>
 
 <% if current_user.present? %>
   <div class="row column">

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, translated_attribute(project.title)) %>
+<% add_meta_tags(title: translated_attribute(project.title)) %>
 
 <div class="row column view-header">
   <% if current_user.present? %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -1,4 +1,7 @@
-<% add_meta_tags(title: translated_attribute(project.title)) %>
+<% add_decidim_meta_tags(
+  title: translated_attribute(project.title),
+  description: translated_attribute(project.description)
+) %>
 
 <div class="row column view-header">
   <% if current_user.present? %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -1,6 +1,4 @@
-<% provide :meta_title, "#{translated_attribute(project.title)} - #{translated_attribute(current_feature.name)}" %>
-<% provide :meta_description, strip_tags(translated_attribute(project.description)) %>
-<% provide :meta_url, project_url(project.id) %>
+<% provide(:title, translated_attribute(project.title)) %>
 
 <div class="row column view-header">
   <% if current_user.present? %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -45,14 +45,17 @@ en:
             title: Title
       projects:
         budget_confirm:
-          are_you_sure: Do you agree? Once you have confirmed your vote, you can not change it.
+          are_you_sure: Do you agree? Once you have confirmed your vote, you can not
+            change it.
           cancel: Cancel
           confirm: Confirm
           description: These are the projects you have chosen to be part of the budget.
           title: Confirm vote
         budget_excess:
           close: Close
-          description: This project exceeds the maximum budget and can not be added. If you want, you can delete a project you have already selected to add, or make your vote with your preferences.
+          description: This project exceeds the maximum budget and can not be added.
+            If you want, you can delete a project you have already selected to add,
+            or make your vote with your preferences.
           ok: OK
           title: Maximum budget exceeded
         budget_summary:
@@ -60,9 +63,12 @@ en:
           assigned: 'Assigned:'
           cancel_order: delete your vote and start over
           checked_out:
-            description: You've already voted for the budget. If you've changed your mind, you can %{cancel_link}.
+            description: You've already voted for the budget. If you've changed your
+              mind, you can %{cancel_link}.
             title: Budget vote completed
-          description: What projects do you think we should allocate budget for? Assign at least %{minimum_budget} to the projects you want and vote with your preferences to define the budget.
+          description: What projects do you think we should allocate budget for? Assign
+            at least %{minimum_budget} to the projects you want and vote with your
+            preferences to define the budget.
           title: You decide the budget
         count:
           projects_count:
@@ -72,8 +78,6 @@ en:
           category: Category
           scopes: Scopes
           search: Search
-        index:
-          meta_title: "%{feature_name}"
         order_progress:
           vote: Vote
         order_selected_projects:
@@ -96,11 +100,11 @@ en:
         name: Budgets
         settings:
           global:
-            comments_enabled: "Comments enabled"
-            total_budget: "Total budget"
-            vote_threshold_percent: "Vote threshold percent"
+            comments_enabled: Comments enabled
+            total_budget: Total budget
+            vote_threshold_percent: Vote threshold percent
           step:
-            comments_blocked: "Comments blocked"
+            comments_blocked: Comments blocked
     orders:
       checkout:
         error: An error ocurred while processing your vote

--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -4,7 +4,7 @@ module Decidim
   module LayoutHelper
     def decidim_page_title
       title = content_for(:meta_title)
-      return "#{title} - #{current_organization.name}".html_safe if title
+      return title.html_safe if title
 
       current_organization.name
     end

--- a/decidim-core/app/helpers/decidim/layout_helper.rb
+++ b/decidim-core/app/helpers/decidim/layout_helper.rb
@@ -2,13 +2,6 @@
 module Decidim
   # View helpers related to the layout.
   module LayoutHelper
-    def decidim_page_title
-      title = content_for(:meta_title)
-      return title.html_safe if title
-
-      current_organization.name
-    end
-
     # Public: Generates a set of meta tags that generate the different favicon
     # versions for an organization.
     #

--- a/decidim-core/app/helpers/decidim/meta_tags_helper.rb
+++ b/decidim-core/app/helpers/decidim/meta_tags_helper.rb
@@ -8,22 +8,40 @@ module Decidim
     # values.
     #
     # Returns nothing.
-    def add_meta_tags(tags)
+    def add_decidim_meta_tags(tags)
       add_decidim_page_title(tags[:title])
-
-      provide(:meta_description, tags[:description])
-      provide(:meta_url, tags[:url])
-      provide(:twitter_handler, tags[:twitter_handler])
-      provide(:meta_image_url, tags[:image_url])
+      add_decidim_meta_description(tags[:description])
+      add_decidim_meta_url(tags[:url])
+      add_decidim_meta_twitter_handler(tags[:twitter_handler])
+      add_decidim_meta_image_url(tags[:image_url])
     end
 
     def add_decidim_page_title(title)
-      @title ||= []
-      @title << title
+      @decidim_page_title ||= []
+      @decidim_page_title << title
     end
 
     def decidim_page_title
-      (@title || []).join(" - ")
+      (@decidim_page_title || []).join(" - ")
+    end
+
+    attr_reader :decidim_meta_description, :decidim_meta_url, :decidim_meta_image_url,
+                :decidim_meta_twitter_handler
+
+    def add_decidim_meta_description(description)
+      @decidim_meta_description ||= strip_tags(description)
+    end
+
+    def add_decidim_meta_twitter_handler(twitter_handler)
+      @decidim_meta_twitter_handler ||= twitter_handler
+    end
+
+    def add_decidim_meta_url(url)
+      @decidim_meta_url ||= url
+    end
+
+    def add_decidim_meta_image_url(image_url)
+      @decidim_meta_image_url ||= image_url
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/meta_tags_helper.rb
+++ b/decidim-core/app/helpers/decidim/meta_tags_helper.rb
@@ -9,10 +9,11 @@ module Decidim
     #
     # Returns nothing.
     def add_meta_tags(tags)
-      provide(:meta_description, tags[:description]) unless content_for :meta_description
-      provide(:meta_url, tags[:url]) unless content_for :meta_url
-      provide(:twitter_handler, tags[:twitter_handler]) unless content_for :twitter_handler
-      provide(:meta_image_url, tags[:image_url]) unless content_for :meta_image_url
+      provide(:meta_title, tags[:title])
+      provide(:meta_description, tags[:description])
+      provide(:meta_url, tags[:url])
+      provide(:twitter_handler, tags[:twitter_handler])
+      provide(:meta_image_url, tags[:image_url])
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/meta_tags_helper.rb
+++ b/decidim-core/app/helpers/decidim/meta_tags_helper.rb
@@ -9,11 +9,21 @@ module Decidim
     #
     # Returns nothing.
     def add_meta_tags(tags)
-      provide(:meta_title, tags[:title])
+      add_decidim_page_title(tags[:title])
+
       provide(:meta_description, tags[:description])
       provide(:meta_url, tags[:url])
       provide(:twitter_handler, tags[:twitter_handler])
       provide(:meta_image_url, tags[:image_url])
+    end
+
+    def add_decidim_page_title(title)
+      @title ||= []
+      @title << title
+    end
+
+    def decidim_page_title
+      (@title || []).join(" - ")
     end
   end
 end

--- a/decidim-core/app/helpers/decidim/meta_tags_helper.rb
+++ b/decidim-core/app/helpers/decidim/meta_tags_helper.rb
@@ -2,10 +2,11 @@
 module Decidim
   # Helper that provides convenient methods to deal with the page meta tags.
   module MetaTagsHelper
-    # Public: Sets the given metatags for the page.
+    # Public: Sets the given metatags for the page. It's a wrapper for the individual
+    # methods, so that you can set multiple values with a single call. See the docs for
+    # the other methods to see how they work.
     #
-    # tags - A Hash containing the meta tag name as keys and its content as
-    # values.
+    # tags - A Hash containing the meta tag name as keys and its content as values.
     #
     # Returns nothing.
     def add_decidim_meta_tags(tags)
@@ -16,11 +17,30 @@ module Decidim
       add_decidim_meta_image_url(tags[:image_url])
     end
 
+    # Public: Accumulates the given `title` so that they can be chained. Since Rails views
+    # are rendered inside-out, `title` is appended to an array. This way the beggining of
+    # the title will be the most specific one. Use the `decidim_page_title` method to
+    # render the title whenever you need to (most surely, in the `<title>` tag in the HTML
+    # head and in some `title` metatags).
+    #
+    # Example:
+    #   add_decidim_page_title("My Process")
+    #   add_decidim_page_title("My Organization")
+    #   decidim_page_title # => "My Process - My Organization"
+    #
+    # title - A String to be added to the title
+    #
+    # Returns an Array of Strings.
     def add_decidim_page_title(title)
       @decidim_page_title ||= []
       @decidim_page_title << title
     end
 
+    # Public: Renders the title for a page. Use the `add_decidim_page_title` method to
+    # accumulate elements for the title. Basically, it joins the elements of the title
+    # array with `" - "`.
+    #
+    # Returns a String.
     def decidim_page_title
       (@decidim_page_title || []).join(" - ")
     end
@@ -28,18 +48,54 @@ module Decidim
     attr_reader :decidim_meta_description, :decidim_meta_url, :decidim_meta_image_url,
                 :decidim_meta_twitter_handler
 
+    # Sets the meta description for the current page. We want to keep the most specific
+    # one, so you cannot replace the description if it is set by a view that has already
+    # been rendered. Remember that Rails's views are render inside-out, so the `layout`
+    # is the last one to be rendered. You can put there a basic content and override it
+    # in other layers.
+    #
+    # description - The String to be set as description
+    #
+    # Returns nothing.
     def add_decidim_meta_description(description)
       @decidim_meta_description ||= strip_tags(description)
     end
 
+    # Sets the meta Twitter handler for the current page. We want to keep the most specific
+    # one, so you cannot replace the Twitter handler if it is set by a view that has already
+    # been rendered. Remember that Rails's views are render inside-out, so the `layout`
+    # is the last one to be rendered. You can put there a basic content and override it
+    # in other layers.
+    #
+    # twitter_handler - The String to be set as Twitter handler
+    #
+    # Returns nothing.
     def add_decidim_meta_twitter_handler(twitter_handler)
       @decidim_meta_twitter_handler ||= twitter_handler
     end
 
+    # Sets the meta URL for the current page. We want to keep the most specific
+    # one, so you cannot replace the URL if it is set by a view that has already
+    # been rendered. Remember that Rails's views are render inside-out, so the `layout`
+    # is the last one to be rendered. You can put there a basic content and override it
+    # in other layers.
+    #
+    # url - The String to be set as URL
+    #
+    # Returns nothing.
     def add_decidim_meta_url(url)
       @decidim_meta_url ||= url
     end
 
+    # Sets the meta image URL for the current page. We want to keep the most specific
+    # one, so you cannot replace the image URL if it is set by a view that has already
+    # been rendered. Remember that Rails's views are render inside-out, so the `layout`
+    # is the last one to be rendered. You can put there a basic content and override it
+    # in other layers.
+    #
+    # image_url - The String to be set as image URL
+    #
+    # Returns nothing.
     def add_decidim_meta_image_url(image_url)
       @decidim_meta_image_url ||= image_url
     end

--- a/decidim-core/app/helpers/decidim/meta_tags_helper.rb
+++ b/decidim-core/app/helpers/decidim/meta_tags_helper.rb
@@ -33,6 +33,7 @@ module Decidim
     # Returns an Array of Strings.
     def add_decidim_page_title(title)
       @decidim_page_title ||= []
+      return @decidim_page_title unless title.present?
       @decidim_page_title << title
     end
 

--- a/decidim-core/app/views/decidim/devise/confirmations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/confirmations/new.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t("devise.confirmations.new.resend_confirmation_instructions")) %>
+
 <main class="wrapper">
 <div class="row collapse">
   <div class="row collapse">

--- a/decidim-core/app/views/decidim/devise/passwords/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/passwords/new.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t("devise.passwords.new.forgot_your_password")) %>
+
 <main class="wrapper">
 <div class="row collapse">
   <div class="row collapse">

--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t(".sign_up")) %>
+
 <main class="wrapper">
 <div class="row collapse">
   <div class="row collapse">

--- a/decidim-core/app/views/decidim/devise/sessions/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/sessions/new.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t("devise.sessions.new.sign_in")) %>
+
 <main class="wrapper">
   <div class="row collapse">
     <div class="row collapse">

--- a/decidim-core/app/views/decidim/pages/index.html.erb
+++ b/decidim-core/app/views/decidim/pages/index.html.erb
@@ -1,5 +1,3 @@
-<% provide :meta_title, t(".title") %>
-
 <main class="wrapper">
   <div class="row column">
     <h1 class="heading1 page-title"><%= t ".title" %></h1>

--- a/decidim-core/app/views/decidim/pages/index.html.erb
+++ b/decidim-core/app/views/decidim/pages/index.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(t(".title")) %>
+
 <main class="wrapper">
   <div class="row column">
     <h1 class="heading1 page-title"><%= t ".title" %></h1>

--- a/decidim-core/app/views/decidim/participatory_process_steps/index.html.erb
+++ b/decidim-core/app/views/decidim/participatory_process_steps/index.html.erb
@@ -1,4 +1,4 @@
-<% provide :meta_title, "#{t(".title")} - #{translated_attribute(current_participatory_process.title)}" %>
+<% provide :meta_title, t(".title") %>
 
 <main class="steps">
   <div class="row column">

--- a/decidim-core/app/views/decidim/participatory_process_steps/index.html.erb
+++ b/decidim-core/app/views/decidim/participatory_process_steps/index.html.erb
@@ -1,4 +1,4 @@
-<% provide :meta_title, t(".title") %>
+<% add_decidim_page_title(t(".title")) %>
 
 <main class="steps">
   <div class="row column">

--- a/decidim-core/app/views/decidim/participatory_processes/show.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/show.html.erb
@@ -1,4 +1,4 @@
-<% provide :meta_description, strip_tags(translated_attribute(current_participatory_process.short_description)) %>
+<% provide :meta_description, translated_attribute(current_participatory_process.short_description) %>
 <% provide :meta_title, translated_attribute(current_participatory_process.title) %>
 <% provide :meta_url, participatory_process_url(current_participatory_process) %>
 

--- a/decidim-core/app/views/layouts/decidim/_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_application.html.erb
@@ -1,7 +1,16 @@
+<% add_meta_tags({
+  description: strip_tags(translated_attribute(current_organization.description)),
+  title: current_organization.name,
+  url: request.original_url,
+  twitter_handler: current_organization.twitter_handler,
+  image_url: current_organization.homepage_image.url
+}) %>
+
 <!DOCTYPE html>
 <html class="no-js">
   <head>
     <title><%= decidim_page_title %></title>
+
     <%= csrf_meta_tags %>
 
     <%= render partial: 'layouts/decidim/meta' %>

--- a/decidim-core/app/views/layouts/decidim/_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_application.html.erb
@@ -1,4 +1,4 @@
-<% add_meta_tags({
+<% add_decidim_meta_tags({
   description: strip_tags(translated_attribute(current_organization.description)),
   title: current_organization.name,
   url: request.original_url,

--- a/decidim-core/app/views/layouts/decidim/_social_meta.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_social_meta.html.erb
@@ -1,5 +1,6 @@
 <% add_meta_tags({
   description: strip_tags(translated_attribute(current_organization.description)),
+  title: current_organization.name,
   url: request.original_url,
   twitter_handler: current_organization.twitter_handler,
   image_url: current_organization.homepage_image.url
@@ -7,12 +8,12 @@
 
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@<%= content_for(:twitter_handler) %>" />
-<meta name="twitter:title" content="<%= decidim_page_title %>" />
+<meta name="twitter:title" content="<%= content_for(:meta_title) %>" />
 <meta name="twitter:description" content="<%= content_for(:meta_description) %>" />
 <meta name="twitter:image" content="<%= content_for(:meta_image_url) %>" />
 
 <meta property="og:url" content="<%= content_for(:meta_url) %>" />
 <meta property="og:type" content="article" />
-<meta property="og:title" content="<%= decidim_page_title %>" />
+<meta property="og:title" content="<%= content_for(:meta_title) %>" />
 <meta property="og:description" content="<%= content_for(:meta_description) %>" />
 <meta property="og:image" content="<%= content_for(:meta_image_url) %>" />

--- a/decidim-core/app/views/layouts/decidim/_social_meta.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_social_meta.html.erb
@@ -1,19 +1,11 @@
-<% add_meta_tags({
-  description: strip_tags(translated_attribute(current_organization.description)),
-  title: current_organization.name,
-  url: request.original_url,
-  twitter_handler: current_organization.twitter_handler,
-  image_url: current_organization.homepage_image.url
-}) %>
-
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@<%= content_for(:twitter_handler) %>" />
-<meta name="twitter:title" content="<%= content_for(:meta_title) %>" />
+<meta name="twitter:title" content="<%= decidim_page_title %>" />
 <meta name="twitter:description" content="<%= content_for(:meta_description) %>" />
 <meta name="twitter:image" content="<%= content_for(:meta_image_url) %>" />
 
 <meta property="og:url" content="<%= content_for(:meta_url) %>" />
 <meta property="og:type" content="article" />
-<meta property="og:title" content="<%= content_for(:meta_title) %>" />
+<meta property="og:title" content="<%= decidim_page_title %>" />
 <meta property="og:description" content="<%= content_for(:meta_description) %>" />
 <meta property="og:image" content="<%= content_for(:meta_image_url) %>" />

--- a/decidim-core/app/views/layouts/decidim/_social_meta.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_social_meta.html.erb
@@ -1,11 +1,11 @@
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:site" content="@<%= content_for(:twitter_handler) %>" />
+<meta name="twitter:site" content="@<%= decidim_meta_twitter_handler %>" />
 <meta name="twitter:title" content="<%= decidim_page_title %>" />
-<meta name="twitter:description" content="<%= content_for(:meta_description) %>" />
-<meta name="twitter:image" content="<%= content_for(:meta_image_url) %>" />
+<meta name="twitter:description" content="<%= decidim_meta_description %>" />
+<meta name="twitter:image" content="<%= decidim_meta_image_url %>" />
 
-<meta property="og:url" content="<%= content_for(:meta_url) %>" />
+<meta property="og:url" content="<%= decidim_meta_url %>" />
 <meta property="og:type" content="article" />
 <meta property="og:title" content="<%= decidim_page_title %>" />
-<meta property="og:description" content="<%= content_for(:meta_description) %>" />
-<meta property="og:image" content="<%= content_for(:meta_image_url) %>" />
+<meta property="og:description" content="<%= decidim_meta_description %>" />
+<meta property="og:image" content="<%= decidim_meta_image_url %>" />

--- a/decidim-core/app/views/layouts/decidim/participatory_process.html.erb
+++ b/decidim-core/app/views/layouts/decidim/participatory_process.html.erb
@@ -1,5 +1,9 @@
 <% add_decidim_page_title(translated_attribute(current_feature.name)) if try(:current_feature) %>
 <% add_decidim_page_title(translated_attribute(current_participatory_process.title)) %>
+<% add_decidim_meta_tags(
+  image_url: current_participatory_process.banner_image.url,
+  description: translated_attribute(current_participatory_process.short_description),
+) %>
 
 <%= render "layouts/decidim/application" do %>
   <div class="wrapper">

--- a/decidim-core/app/views/layouts/decidim/participatory_process.html.erb
+++ b/decidim-core/app/views/layouts/decidim/participatory_process.html.erb
@@ -1,3 +1,6 @@
+<% add_decidim_page_title(translated_attribute(current_feature.name)) if try(:current_feature) %>
+<% add_decidim_page_title(translated_attribute(current_participatory_process.title)) %>
+
 <%= render "layouts/decidim/application" do %>
   <div class="wrapper">
     <%= render partial: "layouts/decidim/process_header" %>

--- a/decidim-core/app/views/pages/decidim_page.html.erb
+++ b/decidim-core/app/views/pages/decidim_page.html.erb
@@ -1,4 +1,7 @@
-<% add_decidim_page_title(translated_attribute(page.title)) %>
+<% add_decidim_meta_tags(
+  title: translated_attribute(page.title),
+  description: translated_attribute(page.content)
+) %>
 
 <main class="wrapper">
   <div class="row column">

--- a/decidim-core/app/views/pages/decidim_page.html.erb
+++ b/decidim-core/app/views/pages/decidim_page.html.erb
@@ -1,5 +1,3 @@
-<% provide :meta_title, translated_attribute(page.title) %>
-
 <main class="wrapper">
   <div class="row column">
     <h1 class="heading1 page-title"><%= translated_attribute page.title %></h1>

--- a/decidim-core/app/views/pages/decidim_page.html.erb
+++ b/decidim-core/app/views/pages/decidim_page.html.erb
@@ -1,3 +1,5 @@
+<% add_decidim_page_title(translated_attribute(page.title)) %>
+
 <main class="wrapper">
   <div class="row column">
     <h1 class="heading1 page-title"><%= translated_attribute page.title %></h1>

--- a/decidim-core/app/views/pages/home.html.erb
+++ b/decidim-core/app/views/pages/home.html.erb
@@ -1,3 +1,5 @@
+<% provide(:meta_title, current_organization.name) %>
+
 <%= render partial: 'pages/home/hero' %>
 
 <% if !translated_attribute(current_organization.description).blank? %>

--- a/decidim-core/lib/decidim/features/base_controller.rb
+++ b/decidim-core/lib/decidim/features/base_controller.rb
@@ -15,6 +15,7 @@ module Decidim
       helper Decidim::ParticipatoryProcessHelper
       helper Decidim::ResourceHelper
       helper Decidim::ActionAuthorizationHelper
+      helper Decidim::MetaTagsHelper
 
       helper_method :current_feature,
                     :current_manifest

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -1,7 +1,3 @@
-<% add_meta_tags({
-  title: t(".meta_title", feature_name: translated_attribute(current_feature.name))
-}) %>
-
 <% if Decidim.geocoder.present? %>
   <div class="row column">
     <div class="google-map" id="meetings-map" data-meetings="<%= meetings_data_for_map(geocoded_meetings).to_json %>" data-here-app-id="<%= Decidim.geocoder[:here_app_id] %>" data-here-app-code="<%= Decidim.geocoder[:here_app_code] %>">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -1,4 +1,6 @@
-<% provide :meta_title, t(".meta_title", feature_name: translated_attribute(current_feature.name)) %>
+<% add_meta_tags({
+  title: t(".meta_title", feature_name: translated_attribute(current_feature.name))
+}) %>
 
 <% if Decidim.geocoder.present? %>
   <div class="row column">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -1,6 +1,10 @@
-<% provide :meta_title, "#{translated_attribute(meeting.title)} - #{translated_attribute(current_feature.name)}" %>
-<% provide :meta_description, strip_tags(translated_attribute(meeting.description)) %>
-<% provide :meta_url, meeting_url(meeting.id) %>
+<% provide(:title, translated_attribute(meeting.title)) %>
+
+<% add_meta_tags({
+  title: translated_attribute(meeting.title),
+  description: translated_attribute(meeting.description),
+  url: meeting_url(meeting.id)
+}) %>
 
 <div class="row column view-header">
   <h2 class="heading2"><%= translated_attribute meeting.title %></h2>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, translated_attribute(meeting.title)) %>
 
-<% add_meta_tags({
+<% add_decidim_meta_tags({
   title: translated_attribute(meeting.title),
   description: translated_attribute(meeting.description),
   url: meeting_url(meeting.id)

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -63,7 +63,6 @@ en:
           filter_for: Filter by
           unfold: Unfold
         index:
-          meta_title: "%{feature_name}"
           view_meeting: View meeting
         show:
           attendees: Attendees count

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -1,4 +1,4 @@
-<% add_meta_tags({
+<% add_decidim_meta_tags({
   title: translated_attribute(@page.title),
   description: translated_attribute(@page.body),
 }) %>

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -1,5 +1,7 @@
-<% provide :meta_title, "#{translated_attribute(@page.title)} - #{translated_attribute(current_feature.name)}" %>
-<% provide :meta_description, strip_tags(translated_attribute(@page.body)) %>
+<% add_meta_tags({
+  title: translated_attribute(@page.title),
+  description: translated_attribute(@page.body),
+}) %>
 
 <div class="row column">
   <div class="row">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -1,4 +1,6 @@
-<% provide :meta_title, t(".meta_title", feature_name: translated_attribute(current_feature.name)) %>
+<% add_meta_tags({
+  title: t(".meta_title", feature_name: translated_attribute(current_feature.name))
+}) %>
 
 <%= render partial: "votes_limit" %>
 <div class="row columns">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -1,7 +1,3 @@
-<% add_meta_tags({
-  title: t(".meta_title", feature_name: translated_attribute(current_feature.name))
-}) %>
-
 <%= render partial: "votes_limit" %>
 <div class="row columns">
   <div class="title-action">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -1,4 +1,4 @@
-<% add_meta_tags({
+<% add_decidim_meta_tags({
   description: @proposal.body,
   title: @proposal.title,
   url: proposal_url(@proposal.id)

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -1,6 +1,8 @@
-<% provide :meta_title, "#{@proposal.title} - #{translated_attribute(current_feature.name)}" %>
-<% provide :meta_description, strip_tags(@proposal.body) %>
-<% provide :meta_url, proposal_url(@proposal.id) %>
+<% add_meta_tags({
+  description: @proposal.body,
+  title: @proposal.title,
+  url: proposal_url(@proposal.id)
+}) %>
 
 <%= render partial: "votes_limit" %>
 <div class="row column view-header">

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -98,7 +98,6 @@ en:
           filter_for: Filter by
           unfold: Unfold
         index:
-          meta_title: "%{feature_name}"
           new_proposal: New proposal
         linked_proposals:
           proposal_votes:

--- a/decidim-results/app/views/decidim/results/results/index.html.erb
+++ b/decidim-results/app/views/decidim/results/results/index.html.erb
@@ -1,7 +1,3 @@
-<% add_meta_tags({
-  title: t(".meta_title", feature_name: translated_attribute(current_feature.name))
-}) %>
-
 <div class="row columns">
   <div class="title-action">
     <h2 id="proposals-count" class="title-action__title section-heading">

--- a/decidim-results/app/views/decidim/results/results/index.html.erb
+++ b/decidim-results/app/views/decidim/results/results/index.html.erb
@@ -1,4 +1,6 @@
-<% provide :meta_title, t(".meta_title", feature_name: translated_attribute(current_feature.name)) %>
+<% add_meta_tags({
+  title: t(".meta_title", feature_name: translated_attribute(current_feature.name))
+}) %>
 
 <div class="row columns">
   <div class="title-action">

--- a/decidim-results/app/views/decidim/results/results/show.html.erb
+++ b/decidim-results/app/views/decidim/results/results/show.html.erb
@@ -1,5 +1,3 @@
-<% provide(:title, translated_attribute(result.title)) %>
-
 <% add_meta_tags({
   description: translated_attribute(result.description),
   title: translated_attribute(result.title),

--- a/decidim-results/app/views/decidim/results/results/show.html.erb
+++ b/decidim-results/app/views/decidim/results/results/show.html.erb
@@ -1,4 +1,4 @@
-<% add_meta_tags({
+<% add_decidim_meta_tags({
   description: translated_attribute(result.description),
   title: translated_attribute(result.title),
   url: result_url(result.id)

--- a/decidim-results/app/views/decidim/results/results/show.html.erb
+++ b/decidim-results/app/views/decidim/results/results/show.html.erb
@@ -1,6 +1,10 @@
-<% provide :meta_title, "#{translated_attribute(result.title)} - #{translated_attribute(current_feature.name)}" %>
-<% provide :meta_description, strip_tags(translated_attribute(result.description)) %>
-<% provide :meta_url, result_url(result.id) %>
+<% provide(:title, translated_attribute(result.title)) %>
+
+<% add_meta_tags({
+  description: translated_attribute(result.description),
+  title: translated_attribute(result.title),
+  url: result_url(result.id)
+}) %>
 
 <div class="row column view-header">
   <h2 class="heading2"><%= translated_attribute result.title %></h2>

--- a/decidim-results/config/locales/en.yml
+++ b/decidim-results/config/locales/en.yml
@@ -55,8 +55,6 @@ en:
           category: Category
           scopes: Scopes
           search: Search
-        index:
-          meta_title: "%{feature_name}"
         show:
           stats:
             attendees: Attendees


### PR DESCRIPTION
#### :tophat: What? Why?
#968 changed how metatags and HTML titles work, but it was not the best solution as it was very complicated and hard to maintain. This PR refactors how this work so that it's (hopefully) easier to understand and maintain.

Also, sets the titles to what #675 defines, and sets the description to this rules:

* When viewing a process: description is process's `short_description`
* When viewing the index of a resource inside the process (eg meetings, proposals...): process' `short_description`
* When viewing a single resource inside a process (meeting, proposal...): the resource `short_description`, `body`, `content` or any similar field. It varies between resources.
* When viewing any other page (static pages, homepage, processes index): organization's `description`

All descriptions are translated and have their HTML tags stripped in order to appear good when embedded in social networks.

It also sets meta images:

* When inside a process (process apge or any resource page, both index and show): process's `banner_image`
* Any other page: organization's `homepage_image`.

#### :pushpin: Related Issues
- Related to #968 
- Fixes #675 

#### :clipboard: Subtasks
* [x] Docs