### PR TITLE
Fix bug when hasComments was true for max depth

### DIFF
--- a/decidim-comments/lib/decidim/comments/api/comment_type.rb
+++ b/decidim-comments/lib/decidim/comments/api/comment_type.rb
@@ -51,6 +51,12 @@ module Decidim
           obj.down_voted_by?(ctx[:current_user])
         }
       end
+
+      field :hasComments, !types.Boolean, "Check if the commentable has comments" do
+        resolve lambda { |obj, _args, _ctx|
+          obj.accepts_new_comments? && obj.comments.size.positive?
+        }
+      end
     end
   end
 end

--- a/decidim-comments/spec/types/comment_type_spec.rb
+++ b/decidim-comments/spec/types/comment_type_spec.rb
@@ -28,6 +28,12 @@ module Decidim
           FactoryGirl.create(:comment, commentable: model)
           expect(response).to include("hasComments" => true)
         end
+
+        it "returns false if the comment depth is equal to MAX_DEPTH" do
+          FactoryGirl.create(:comment, commentable: model)
+          model.update_attribute(:depth, Comment::MAX_DEPTH)
+          expect(response).to include("hasComments" => false)
+        end
       end
 
       describe "acceptsNewComments" do


### PR DESCRIPTION
#### :tophat: What? Why?

We are not allowing new comments after a `MAX_DEPTH` value but we had a problem when importing old data from https://github.com/AjuntamentdeBarcelona/decidim-barcelona/.

I change the API to return `hasComments` as a false value when a comment is not supposed to have replies.

#### :pushpin: Related Issues
- Fixes https://github.com/AjuntamentdeBarcelona/decidim-barcelona/issues/58

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
