### PR TITLE
Allow video embeds into quill

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -3,7 +3,7 @@
 
 $(() => {
   const $container = $('.editor-container');
-  const quillFormats = ['bold', 'italic', 'link', 'underline', 'header', 'list'];
+  const quillFormats = ['bold', 'italic', 'link', 'underline', 'header', 'list', 'video'];
 
   $container.each((idx, container) => {
     const toolbar = $(container).data('toolbar');


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds support for video embeds from different sources into quill.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/4StO24t1Lp1jq/giphy.gif)
