### PR TITLE
Reorder remaining steps after step deletion

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/destroy_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/destroy_participatory_process_step.rb
@@ -22,7 +22,16 @@ module Decidim
         return broadcast(:invalid, :active_step) if @step.active?
 
         @step.destroy!
+        reorder_steps
         broadcast(:ok)
+      end
+
+      private
+
+      def reorder_steps
+        ReorderParticipatoryProcessSteps
+          .new(@participatory_process.steps, @participatory_process.steps.map(&:id))
+          .call
       end
     end
   end

--- a/decidim-admin/spec/commands/destroy_participatory_process_step_spec.rb
+++ b/decidim-admin/spec/commands/destroy_participatory_process_step_spec.rb
@@ -26,6 +26,8 @@ describe Decidim::Admin::DestroyParticipatoryProcessStep, class: true do
     end
 
     context "when destroying an inactive step" do
+      let(:reorderer) { double(call: true) }
+
       it "broadcasts ok" do
         expect { subject.call(inactive_step) }.to broadcast(:ok)
       end
@@ -33,6 +35,16 @@ describe Decidim::Admin::DestroyParticipatoryProcessStep, class: true do
       it "destroys the step" do
         subject.call(inactive_step)
         expect(inactive_step).not_to be_persisted
+      end
+
+      it "reorders the remaining steps" do
+        allow(Decidim::Admin::ReorderParticipatoryProcessSteps)
+          .to receive(:new)
+          .with([active_step], [active_step.id])
+          .and_return(reorderer)
+        expect(reorderer).to receive(:call)
+
+        subject.call(inactive_step)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
After removing a step, we did not reorder the remaining ones. This caused weird bugs with orders, because if you have 3 steps and remove the 2n step, you get positions 1 and 3 for the remaining ones, and this is wrong. See this screenshot, it shows what happens when you remove steps that are not the last one:

![](https://i.imgur.com/2MO2PIJ.png)

Positions are 2, 4, and 5 instead of 1, 2, and 3.

I've forced a reordering after removing a step, so that steps get the correct order. This is the effects of the code after removing the step in the middle from the previous screenshot:

![](https://i.imgur.com/vzarX9w.png)

#### :pushpin: Related Issues
- Fixes #986

#### :clipboard: Subtasks
None