### PR TITLE
Remove unclosed tag from invitation email

### DIFF
--- a/decidim-core/app/views/devise/mailer/organization_admin_invitation_instructions.html.erb
+++ b/decidim-core/app/views/devise/mailer/organization_admin_invitation_instructions.html.erb
@@ -1,6 +1,6 @@
 <p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
 
-<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", application: @resource.organization.name) %></p>p>
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", application: @resource.organization.name) %></p>
 <p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, invitation_token: @token, invite_redirect: decidim_admin.root_path, host: @resource.organization.host) %></p>
 
 <% if @resource.invitation_due_at %>


### PR DESCRIPTION
#### :tophat: What? Why?
Removes extra unclosed tag from email.

#### :pushpin: Related Issues
- Fixes #967 

#### :clipboard: Subtasks
None