### PR TITLE
Actually show the video button in editor

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/editor.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/editor.js.es6
@@ -11,7 +11,7 @@ $(() => {
     let quillToolbar = [
       ['bold', 'italic', 'underline'],
       [{ list: 'ordered' }, { list: 'bullet' }],
-      ['link', 'clean']
+      ['link', 'video', 'clean']
     ];
 
     if (toolbar === 'full') {

--- a/decidim-core/app/assets/stylesheets/decidim/extras/_quill.scss
+++ b/decidim-core/app/assets/stylesheets/decidim/extras/_quill.scss
@@ -1,0 +1,8 @@
+.ql-video {
+  max-width: 600px;
+  width: 100%;
+  height: 450px;
+  max-height: 70vh;
+  margin: 40px auto;
+  display: block;
+}


### PR DESCRIPTION
#### :tophat: What? Why?
#984 added the video format to the editor, but forgot to add the button, so there's no way to actually embed videos. This PR adds the button.

#### :pushpin: Related Issues
- Related to #984
- Fixes https://github.com/AjuntamentdeBarcelona/decidim-barcelona/issues/60

#### :clipboard: Subtasks
- [x] Add the button
- [x] Add styles so that the video occupies the whole width of the section

### :camera: Screenshots (optional)
![](https://i.imgur.com/PNdQcNs.png)
