### PR TITLE
Warn the user when not meetings or upcoming meetings scheduled.

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -14,22 +14,22 @@ module Decidim
         if !params[:filter] && results.length == 0
           params[:filter] = {
             date: "past",
-            meetings_warning: true
+            no_upcoming_meetings: true
           }
           results = search_klass.new(search_params).results
           if results.length == 0
             params[:filter] = {
               date: "past",
-              meetings_warning: true,
-              meetings_alert: true
+              no_upcoming_meetings: true,
+              no_meetings_scheduled: true
             }
             results = search_klass.new(search_params).results
           end
         end
 
         params[:filter] ||= {}
-        @meetings_alert = params[:filter]["meetings_alert"]
-        @meetings_warning = params[:filter]["meetings_warning"]
+        @no_meetings_scheduled = params[:filter]["no_meetings_scheduled"]
+        @no_upcoming_meetings = params[:filter]["no_upcoming_meetings"]
         @meetings = results.page(params[:page]).per(12)
         @geocoded_meetings = results.select(&:geocoded?)
       end

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -9,7 +9,7 @@ module Decidim
       helper_method :meetings, :geocoded_meetings, :meeting
 
       def index
-        if search.results.length == 0 && params.dig("filter", "date") != "past" # Maybe this could be extracted to a method
+        if search.results.length == 0 && params.dig("filter", "date") != "past" 
           @past_meetings = search_klass.new(search_params.merge(date: "past" ))
           if @past_meetings.results.length > 0
             params[:filter] ||= {}
@@ -18,14 +18,6 @@ module Decidim
             @search = @past_meetings
           end
         end
-      end
-
-      def meetings
-        @meetings ||= search.results.page(params[:page]).per(12)
-      end
-
-      def geocoded_meetings
-        @geocoded_meetings ||= search.results.select(&:geocoded?)
       end
 
       def static_map
@@ -37,6 +29,14 @@ module Decidim
 
       def meeting
         @meeting ||= Meeting.where(feature: current_feature).find(params[:id])
+      end
+
+      def meetings
+        @meetings ||= search.results.page(params[:page]).per(12)
+      end
+
+      def geocoded_meetings
+        @geocoded_meetings ||= search.results.select(&:geocoded?)
       end
 
       def search_klass

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -10,7 +10,13 @@ module Decidim
 
       def index
         if search.results.length == 0 && params.dig("filter", "date") != "past" # Maybe this could be extracted to a method
-          @search = search_klass.new(search_params.merge(filter: { date: "past" }))
+          @past_meetings = search_klass.new(search_params.merge(date: "past" ))
+          if @past_meetings.results.length > 0
+            params[:filter] ||= {}
+            params[:filter][:date] = "past"
+            @forced_past_meetings = true
+            @search = @past_meetings
+          end
         end
       end
 

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -12,7 +12,9 @@
     </div>
   </div>
 
-  <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
+  <% unless @forced_past_meetings %>
+    <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
+  <% end %>
 
   <% if current_organization.scopes.any? %>
     <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t(".scopes") %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -12,12 +12,12 @@
     </div>
   </div>
 
-  <% unless @meetings_warning %>
+  <% unless @no_upcoming_meetings %>
     <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
   <% else %>
     <%= form.hidden_field :date, value: "past" %>
-    <%= form.hidden_field :meetings_warning, value: @meetings_warning %>
-    <%= form.hidden_field :meetings_alert, value: @meetings_alert %>
+    <%= form.hidden_field :no_upcoming_meetings, value: @no_upcoming_meetings %>
+    <%= form.hidden_field :no_meetings_scheduled, value: @no_meetings_scheduled %>
   <% end %>
 
   <% if current_organization.scopes.any? %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -12,13 +12,7 @@
     </div>
   </div>
 
-  <% unless @no_upcoming_meetings %>
-    <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
-  <% else %>
-    <%= form.hidden_field :date, value: "past" %>
-    <%= form.hidden_field :no_upcoming_meetings, value: @no_upcoming_meetings %>
-    <%= form.hidden_field :no_meetings_scheduled, value: @no_meetings_scheduled %>
-  <% end %>
+  <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
 
   <% if current_organization.scopes.any? %>
     <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t(".scopes") %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -12,7 +12,13 @@
     </div>
   </div>
 
-  <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
+  <% unless @meetings_warning %>
+    <%= form.collection_radio_buttons :date, [["upcoming", t(".upcoming")], ["past", t(".past")]], :first, :last, legend_title: t(".date") %>
+  <% else %>
+    <%= form.hidden_field :date, value: "past" %>
+    <%= form.hidden_field :meetings_warning, value: @meetings_warning %>
+    <%= form.hidden_field :meetings_alert, value: @meetings_alert %>
+  <% end %>
 
   <% if current_organization.scopes.any? %>
     <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t(".scopes") %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -1,5 +1,5 @@
-  <% if @meetings_warning %>
-    <% if @meetings_alert %>
+  <% if @no_upcoming_meetings %>
+    <% if @no_meetings_scheduled %>
       <div class="callout warning">
         <%= t ".no_meetings_warning" %>
       </div>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -1,8 +1,12 @@
-  <% if meetings.length == 0 %>
-    <div class="callout warning">
-      <%= t ".upcoming_meetings_warning" %>
-    </div>
-  <% end %>
+<% if @forced_past_meetings %>
+  <div class="callout warning">
+    <%= t ".upcoming_meetings_warning" %>
+  </div>
+<% elsif meetings.length == 0 %>
+  <div class="callout warning">
+    <%= t ".no_meetings_warning" %>
+  </div>
+<% end %>
 
 <div class="row small-up-1 medium-up-2 card-grid">
   <% meetings.each do |meeting| %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -1,17 +1,11 @@
-  <% if @no_upcoming_meetings %>
-    <% if @no_meetings_scheduled %>
-      <div class="callout warning">
-        <%= t ".no_meetings_warning" %>
-      </div>
-    <% else %>
-      <div class="callout warning">
-        <%= t ".upcoming_meetings_warning" %>
-      </div>
-    <% end %>
+  <% if meetings.length == 0 %>
+    <div class="callout warning">
+      <%= t ".upcoming_meetings_warning" %>
+    </div>
   <% end %>
 
 <div class="row small-up-1 medium-up-2 card-grid">
-  <% @meetings.each do |meeting| %>
+  <% meetings.each do |meeting| %>
     <div class="column">
       <article class="card card--meeting">
         <div class="card__content">
@@ -32,4 +26,4 @@
     </div>
   <% end %>
 </div>
-<%= decidim_paginate @meetings, order_start_time: params[:order_start_time], scope_id: params[:scope_id] %>
+<%= decidim_paginate meetings, order_start_time: params[:order_start_time], scope_id: params[:scope_id] %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meetings.html.erb
@@ -1,5 +1,17 @@
+  <% if @meetings_warning %>
+    <% if @meetings_alert %>
+      <div class="callout warning">
+        <%= t ".no_meetings_warning" %>
+      </div>
+    <% else %>
+      <div class="callout warning">
+        <%= t ".upcoming_meetings_warning" %>
+      </div>
+    <% end %>
+  <% end %>
+
 <div class="row small-up-1 medium-up-2 card-grid">
-  <% meetings.each do |meeting| %>
+  <% @meetings.each do |meeting| %>
     <div class="column">
       <article class="card card--meeting">
         <div class="card__content">
@@ -20,4 +32,4 @@
     </div>
   <% end %>
 </div>
-<%= decidim_paginate meetings, order_start_time: params[:order_start_time], scope_id: params[:scope_id] %>
+<%= decidim_paginate @meetings, order_start_time: params[:order_start_time], scope_id: params[:scope_id] %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -1,6 +1,6 @@
 <% if Decidim.geocoder.present? %>
   <div class="row column">
-    <div class="google-map" id="meetings-map" data-meetings="<%= meetings_data_for_map(@geocoded_meetings).to_json %>" data-here-app-id="<%= Decidim.geocoder[:here_app_id] %>" data-here-app-code="<%= Decidim.geocoder[:here_app_code] %>">
+    <div class="google-map" id="meetings-map" data-meetings="<%= meetings_data_for_map(geocoded_meetings).to_json %>" data-here-app-id="<%= Decidim.geocoder[:here_app_id] %>" data-here-app-code="<%= Decidim.geocoder[:here_app_code] %>">
     </div>
 
     <template id="meeting-popup">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.html.erb
@@ -1,6 +1,6 @@
 <% if Decidim.geocoder.present? %>
   <div class="row column">
-    <div class="google-map" id="meetings-map" data-meetings="<%= meetings_data_for_map(geocoded_meetings).to_json %>" data-here-app-id="<%= Decidim.geocoder[:here_app_id] %>" data-here-app-code="<%= Decidim.geocoder[:here_app_code] %>">
+    <div class="google-map" id="meetings-map" data-meetings="<%= meetings_data_for_map(@geocoded_meetings).to_json %>" data-here-app-id="<%= Decidim.geocoder[:here_app_id] %>" data-here-app-code="<%= Decidim.geocoder[:here_app_code] %>">
     </div>
 
     <template id="meeting-popup">
@@ -39,6 +39,7 @@
 
 <div class="row">
   <div class="columns mediumlarge-4 large-3">
+  
     <%= render partial: "filters_small_view" %>
     <div class="card card--secondary show-for-mediumlarge" >
       <%= render partial: "filters" %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
@@ -4,5 +4,5 @@ $meetings.html('<%= j(render partial: "meetings") %>');
 
 window.DecidimMeetings.currentMap = window.DecidimMeetings.loadMap(
   'meetings-map',
-  JSON.parse('<%= escape_javascript meetings_data_for_map(geocoded_meetings).to_json.html_safe %>')
+  JSON.parse('<%= escape_javascript meetings_data_for_map(@geocoded_meetings).to_json.html_safe %>')
 );

--- a/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/index.js.erb
@@ -4,5 +4,5 @@ $meetings.html('<%= j(render partial: "meetings") %>');
 
 window.DecidimMeetings.currentMap = window.DecidimMeetings.loadMap(
   'meetings-map',
-  JSON.parse('<%= escape_javascript meetings_data_for_map(@geocoded_meetings).to_json.html_safe %>')
+  JSON.parse('<%= escape_javascript meetings_data_for_map(geocoded_meetings).to_json.html_safe %>')
 );

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
         index:
           view_meeting: View meeting
         meetings:
-          no_meetings_warning: At the moment, this process doesn't have any meeting scheduled.
+          no_meetings_warning: No meetings match your search criteria or no there isn't any meeting scheduled.
           upcoming_meetings_warning: Currently, there are no scheduled meetings, but
             here you can find all the past meetings listed.
         show:

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -64,6 +64,10 @@ en:
           unfold: Unfold
         index:
           view_meeting: View meeting
+        meetings:
+          no_meetings_warning: At the moment, this process doesn't have any meeting scheduled.
+          upcoming_meetings_warning: Currently, there are no scheduled meetings, but
+            here you can find all the past meetings listed.
         show:
           attendees: Attendees count
           contributions: Contributions count

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -65,7 +65,7 @@ en:
         index:
           view_meeting: View meeting
         meetings:
-          no_meetings_warning: No meetings match your search criteria or no there isn't any meeting scheduled.
+          no_meetings_warning: No meetings match your search criteria or there isn't any meeting scheduled.
           upcoming_meetings_warning: Currently, there are no scheduled meetings, but
             here you can find all the past meetings listed.
         show:

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -65,6 +65,9 @@ describe "Explore meetings", type: :feature do
         expect(page).to have_css(".card--meeting", count: 1)
       end
     end
+
+    context "shows past meetins if isn't any upcoming one.'"
+    
   end
 
   context "show" do

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -104,10 +104,10 @@ describe "Explore meetings", type: :feature do
         start_time: date.beginning_of_day,
         end_time: date.end_of_day
       )
+      visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
     end
 
     it "shows all meeting info" do
-      visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
       expect(page).to have_i18n_content(meeting.title)
       expect(page).to have_i18n_content(meeting.description)
       expect(page).to have_i18n_content(meeting.location)
@@ -122,8 +122,7 @@ describe "Explore meetings", type: :feature do
 
     context "without category or scope" do
       it "does not show any tag" do
-        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
-        expect(page).not_to have_selector("ul.tags.tags--meeting")
+          expect(page).not_to have_selector("ul.tags.tags--meeting")
       end
     end
 
@@ -136,16 +135,14 @@ describe "Explore meetings", type: :feature do
       end
 
       it "shows tags for category" do
-        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
-        expect(page).to have_selector("ul.tags.tags--meeting")
+          expect(page).to have_selector("ul.tags.tags--meeting")
         within "ul.tags.tags--meeting" do
           expect(page).to have_content(translated(meeting.category.name))
         end
       end
 
       it "links to the filter for this category" do
-        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
-        within "ul.tags.tags--meeting" do
+          within "ul.tags.tags--meeting" do
           click_link translated(meeting.category.name)
         end
         expect(page).to have_select("filter_category_id", selected: translated(meeting.category.name))
@@ -161,7 +158,6 @@ describe "Explore meetings", type: :feature do
       end
 
       it "shows tags for scope" do
-        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
         expect(page).to have_selector("ul.tags.tags--meeting")
         within "ul.tags.tags--meeting" do
           expect(page).to have_content(meeting.scope.name)
@@ -169,7 +165,6 @@ describe "Explore meetings", type: :feature do
       end
 
       it "links to the filter for this scope" do
-        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
         within "ul.tags.tags--meeting" do
           click_link meeting.scope.name
         end

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -9,12 +9,9 @@ describe "Explore meetings", type: :feature do
     create_list(:meeting, meetings_count, feature: feature)
   end
 
-  before do
-    visit_feature
-  end
-
   context "index" do
     it "shows all meetings for the given process" do
+      visit_feature
       expect(page).to have_selector("article.card", count: meetings_count)
 
       meetings.each do |meeting|
@@ -24,6 +21,7 @@ describe "Explore meetings", type: :feature do
 
     context "filtering" do
       it "allows searching by text" do
+        visit_feature
         within ".filters" do
           fill_in :filter_search_text, with: translated(meetings.first.title)
         end
@@ -66,8 +64,34 @@ describe "Explore meetings", type: :feature do
       end
     end
 
-    context "shows past meetins if isn't any upcoming one.'"
-    
+    context "No upcoming meetings scheduled" do
+      let!(:meetings) do
+        create_list(:meeting, 2, feature: feature, start_time: Time.current - 4.days, end_time: Time.current - 2.days)
+      end
+
+      it "only shows the past meetings" do
+        visit_feature
+        expect(page).to have_css(".card--meeting", count: 2)
+      end
+
+      it "shows the correct warning" do
+        visit_feature
+        within ".callout" do
+          expect(page).to have_content("no scheduled meetings")
+        end
+      end
+    end
+
+    context "No meetings scheduled" do
+      let!(:meetings){[]}
+
+      it "shows the correct warning" do
+        visit_feature
+        within ".callout" do
+          expect(page).to have_content("any meeting scheduled")
+        end
+      end
+    end
   end
 
   context "show" do
@@ -80,11 +104,10 @@ describe "Explore meetings", type: :feature do
         start_time: date.beginning_of_day,
         end_time: date.end_of_day
       )
-
-      visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
     end
 
     it "shows all meeting info" do
+      visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
       expect(page).to have_i18n_content(meeting.title)
       expect(page).to have_i18n_content(meeting.description)
       expect(page).to have_i18n_content(meeting.location)
@@ -99,6 +122,7 @@ describe "Explore meetings", type: :feature do
 
     context "without category or scope" do
       it "does not show any tag" do
+        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
         expect(page).not_to have_selector("ul.tags.tags--meeting")
       end
     end
@@ -112,6 +136,7 @@ describe "Explore meetings", type: :feature do
       end
 
       it "shows tags for category" do
+        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
         expect(page).to have_selector("ul.tags.tags--meeting")
         within "ul.tags.tags--meeting" do
           expect(page).to have_content(translated(meeting.category.name))
@@ -119,6 +144,7 @@ describe "Explore meetings", type: :feature do
       end
 
       it "links to the filter for this category" do
+        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
         within "ul.tags.tags--meeting" do
           click_link translated(meeting.category.name)
         end
@@ -135,6 +161,7 @@ describe "Explore meetings", type: :feature do
       end
 
       it "shows tags for scope" do
+        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
         expect(page).to have_selector("ul.tags.tags--meeting")
         within "ul.tags.tags--meeting" do
           expect(page).to have_content(meeting.scope.name)
@@ -142,6 +169,7 @@ describe "Explore meetings", type: :feature do
       end
 
       it "links to the filter for this scope" do
+        visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
         within "ul.tags.tags--meeting" do
           click_link meeting.scope.name
         end
@@ -157,11 +185,11 @@ describe "Explore meetings", type: :feature do
 
       before do
         meeting.link_resources(proposals, "proposals_from_meeting")
-        visit_feature
-        click_link translated(meeting.title)
       end
 
       it "shows related proposals" do
+        visit_feature
+        click_link translated(meeting.title)
         proposals.each do |proposal|
           expect(page).to have_content(proposal.title)
           expect(page).to have_content(proposal.author_name)
@@ -178,11 +206,11 @@ describe "Explore meetings", type: :feature do
 
       before do
         meeting.link_resources(results, "meetings_through_proposals")
-        visit_feature
-        click_link translated(meeting.title)
       end
 
       it "shows related results" do
+        visit_feature
+        click_link translated(meeting.title)
         results.each do |result|
           expect(page).to have_i18n_content(result.title)
         end
@@ -195,13 +223,9 @@ describe "Explore meetings", type: :feature do
     context "when the meeting is closed" do
       let!(:meeting) { create(:meeting, :closed, feature: feature) }
 
-      before do
-        meeting
+      it "shows the closing report" do
         visit_feature
         click_link translated(meeting.title)
-      end
-
-      it "shows the closing report" do
         expect(page).to have_i18n_content(meeting.closing_report)
 
         within ".definition-data" do

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -104,6 +104,7 @@ describe "Explore meetings", type: :feature do
         start_time: date.beginning_of_day,
         end_time: date.end_of_day
       )
+
       visit decidim_meetings.meeting_path(participatory_process_id: participatory_process.id, feature_id: feature.id, id: meeting.id)
     end
 

--- a/decidim-meetings/spec/features/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/features/explore_meetings_spec.rb
@@ -83,7 +83,7 @@ describe "Explore meetings", type: :feature do
     end
 
     context "No meetings scheduled" do
-      let!(:meetings){[]}
+      let!(:meetings){ [] }
 
       it "shows the correct warning" do
         visit_feature
@@ -122,7 +122,7 @@ describe "Explore meetings", type: :feature do
 
     context "without category or scope" do
       it "does not show any tag" do
-          expect(page).not_to have_selector("ul.tags.tags--meeting")
+        expect(page).not_to have_selector("ul.tags.tags--meeting")
       end
     end
 
@@ -135,14 +135,14 @@ describe "Explore meetings", type: :feature do
       end
 
       it "shows tags for category" do
-          expect(page).to have_selector("ul.tags.tags--meeting")
+        expect(page).to have_selector("ul.tags.tags--meeting")
         within "ul.tags.tags--meeting" do
           expect(page).to have_content(translated(meeting.category.name))
         end
       end
 
       it "links to the filter for this category" do
-          within "ul.tags.tags--meeting" do
+        within "ul.tags.tags--meeting" do
           click_link translated(meeting.category.name)
         end
         expect(page).to have_select("filter_category_id", selected: translated(meeting.category.name))


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a couple of warnings when there's no upcoming meetings or there's not meetings at all. Also, now we're showing all the past meetings the process had if aren't any upcoming meetings scheduled.

#### :pushpin: Related Issues
- Fixes #970

### :camera: Screenshots (optional)
<img width="1218" alt="screen shot 2017-02-17 at 10 32 29" src="https://cloud.githubusercontent.com/assets/953911/23120197/a572c92e-f75b-11e6-94f0-0792fd64b6f4.png">
<img width="1230" alt="screen shot 2017-02-16 at 15 59 21" src="https://cloud.githubusercontent.com/assets/953911/23059590/574a87cc-f4fa-11e6-88fa-be6bc6163b1c.png">

#### :ghost: GIF
![](https://media.giphy.com/media/eXTue7sCt6ZvG/giphy.gif)
