### PR TITLE
Remove duplicated title on pages feature

### DIFF
--- a/decidim-pages/app/commands/decidim/pages/admin/update_page.rb
+++ b/decidim-pages/app/commands/decidim/pages/admin/update_page.rb
@@ -27,10 +27,7 @@ module Decidim
         private
 
         def update_page
-          @page.update_attributes!(
-            title: @form.title,
-            body: @form.body
-          )
+          @page.update_attributes!(body: @form.body)
         end
       end
     end

--- a/decidim-pages/app/commands/decidim/pages/create_page.rb
+++ b/decidim-pages/app/commands/decidim/pages/create_page.rb
@@ -9,10 +9,7 @@ module Decidim
       end
 
       def call
-        @page = Page.new(
-          title: @feature.name,
-          feature: @feature
-        )
+        @page = Page.new(feature: @feature)
 
         @page.save ? broadcast(:ok) : broadcast(:invalid)
       end

--- a/decidim-pages/app/forms/decidim/pages/admin/page_form.rb
+++ b/decidim-pages/app/forms/decidim/pages/admin/page_form.rb
@@ -6,10 +6,7 @@ module Decidim
       class PageForm < Decidim::Form
         include TranslatableAttributes
 
-        translatable_attribute :title, String
         translatable_attribute :body, String
-
-        validates :title, translatable_presence: true
       end
     end
   end

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -9,7 +9,7 @@ module Decidim
       belongs_to :feature, foreign_key: "decidim_feature_id", class_name: Decidim::Feature
       has_one :organization, through: :feature
 
-      validates :title, :feature, presence: true
+      validates :feature, presence: true
       validate :feature_manifest_matches
 
       # Public: Overrides the `commentable?` Commentable concern method.

--- a/decidim-pages/app/views/decidim/pages/admin/pages/_form.html.erb
+++ b/decidim-pages/app/views/decidim/pages/admin/pages/_form.html.erb
@@ -1,4 +1,3 @@
 <div class="field">
-  <%= form.translated :text_field, :title, autofocus: true, label: t("models.components.title", scope: "decidim.pages.admin") %>
   <%= form.translated :editor, :body, toolbar: :full, lines: 30, label: t("models.components.body", scope: "decidim.pages.admin")  %>
 </div>

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -1,5 +1,4 @@
 <% add_decidim_meta_tags({
-  title: translated_attribute(@page.title),
   description: translated_attribute(@page.body),
 }) %>
 

--- a/decidim-pages/config/locales/en.yml
+++ b/decidim-pages/config/locales/en.yml
@@ -14,7 +14,6 @@ en:
         models:
           components:
             body: Body
-            title: Title
         pages:
           edit:
             save: Save page

--- a/decidim-pages/db/migrate/20170220091402_remove_page_feature_titles.rb
+++ b/decidim-pages/db/migrate/20170220091402_remove_page_feature_titles.rb
@@ -1,0 +1,5 @@
+class RemovePageFeatureTitles < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :decidim_pages_pages, :title
+  end
+end

--- a/decidim-pages/lib/decidim/pages/feature.rb
+++ b/decidim-pages/lib/decidim/pages/feature.rb
@@ -40,7 +40,6 @@ Decidim.register_feature(:pages) do |feature|
 
       page = Decidim::Pages::Page.create!(
         feature: feature,
-        title: Decidim::Faker::Localized.sentence(2),
         body: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
           Decidim::Faker::Localized.paragraph(3)
         end

--- a/decidim-pages/spec/commands/create_page_spec.rb
+++ b/decidim-pages/spec/commands/create_page_spec.rb
@@ -31,10 +31,9 @@ module Decidim
 
           it "creates a new page with the same name as the feature" do
             expect(Page).to receive(:new).with({
-              title: feature.name,
               feature: feature
             }).and_call_original
-            
+
             expect do
               command.call
             end.to change { Page.count }.by(1)

--- a/decidim-pages/spec/commands/update_page_spec.rb
+++ b/decidim-pages/spec/commands/update_page_spec.rb
@@ -11,7 +11,6 @@ module Decidim
         let(:page) { create(:page, feature: feature) }
         let(:form_params) do
           {
-            "title" => page.title,
             "body" => page.body,
             "page" => {
               "commentable" => false

--- a/decidim-pages/spec/factories.rb
+++ b/decidim-pages/spec/factories.rb
@@ -3,7 +3,6 @@ require "decidim/comments/test/factories"
 
 FactoryGirl.define do
   factory :page, class: Decidim::Pages::Page do
-    title { Decidim::Faker::Localized.sentence(3) }
     body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     feature { build(:feature, manifest_name: "pages") }
   end

--- a/decidim-pages/spec/features/admin_spec.rb
+++ b/decidim-pages/spec/features/admin_spec.rb
@@ -9,16 +9,8 @@ describe "Edit a page", type: :feature do
 
   describe "admin page" do
     before do
-      create(:page, feature: feature, title: title, body: body)
+      create(:page, feature: feature, body: body)
       visit_feature_admin
-    end
-
-    let(:title) do
-      {
-        "en" => "Hello world",
-        "ca" => "Hola món",
-        "es" => "Hola mundo"
-      }
     end
 
     let(:body) do
@@ -30,12 +22,6 @@ describe "Edit a page", type: :feature do
     end
 
     it "updates the page" do
-      new_title = {
-        en: "New title",
-        ca: "Nou títol",
-        es: "Nuevo título"
-      }
-
       new_body = {
         en: "<p>New body</p>",
         ca: "<p>Nou cos</p>",
@@ -43,7 +29,6 @@ describe "Edit a page", type: :feature do
       }
 
       within "form.edit_page" do
-        fill_in_i18n(:page_title, "#title-tabs", new_title)
         fill_in_i18n_editor(:page_body, "#body-tabs", new_body)
         find("*[type=submit]").click
       end
@@ -54,7 +39,6 @@ describe "Edit a page", type: :feature do
 
       visit_feature
 
-      expect(page).to have_title("New title")
       expect(page).to have_content("New body")
     end
   end

--- a/decidim-pages/spec/features/page_show_spec.rb
+++ b/decidim-pages/spec/features/page_show_spec.rb
@@ -6,14 +6,6 @@ describe "Show a page", type: :feature do
   include_context "feature"
   let(:manifest_name) { "pages" }
 
-  let(:title) do
-    {
-      "en" => "Hello world",
-      "ca" => "Hola món",
-      "es" => "Hola mundo"
-    }
-  end
-
   let(:body) do
     {
       "en" => "<p>Content</p>",
@@ -22,7 +14,7 @@ describe "Show a page", type: :feature do
     }
   end
 
-  let!(:page_feature) { create(:page, feature: feature, title: title, body: body) }
+  let!(:page_feature) { create(:page, feature: feature, body: body) }
 
   describe "page show" do
     before do
@@ -30,7 +22,6 @@ describe "Show a page", type: :feature do
     end
 
     it "renders the content of the page" do
-      expect(page).to have_title("Hello world")
       expect(page).to have_content("Content")
     end
   end

--- a/decidim-pages/spec/forms/page_form_spec.rb
+++ b/decidim-pages/spec/forms/page_form_spec.rb
@@ -8,14 +8,6 @@ module Decidim
       describe PageForm do
         let(:current_organization) { create(:organization) }
 
-        let(:title) do
-          {
-            "en" => "Hello world",
-            "ca" => "Hola món",
-            "es" => "Hola mundo"
-          }
-        end
-
         let(:body) do
           {
             "en" => "<p>Content</p>",
@@ -29,7 +21,6 @@ module Decidim
         let(:attributes) do
           {
             "page" => {
-              "title" => title,
               "body" => body,
               "commentable" => commentable
             }
@@ -44,18 +35,6 @@ module Decidim
 
         context "when everything is OK" do
           it { is_expected.to be_valid }
-        end
-
-        context "when any title translation is blank" do
-          let(:title) do
-            {
-              "en" => "Hello world",
-              "ca" => "Hola món",
-              "es" => ""
-            }
-          end
-
-          it { is_expected.not_to be_valid }
         end
       end
     end

--- a/decidim-pages/spec/models/page_spec.rb
+++ b/decidim-pages/spec/models/page_spec.rb
@@ -24,10 +24,6 @@ module Decidim
       it "has an associated feature" do
         expect(page.feature).to be_a(Decidim::Feature)
       end
-
-      it "has an I18n title" do
-        expect(page.title).to be_a(Hash)
-      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Removes duplicated title on page features.

#### :pushpin: Related Issues
- Fixes #994 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/e5aoJZu.png)

Left tab is current master (currently deployed in Barcelona). Right tab is a page feature (called "Page", from the seeds), showing that the title is not repeated.