### PR TITLE
Split decidim-dev spec helper

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
@@ -29,7 +29,6 @@ require "rails"
 require "active_support/core_ext/string"
 require "decidim/core"
 require "decidim/core/test"
-
 require "#{File.dirname(__FILE__)}/rspec_support/feature.rb"
 
 begin
@@ -40,36 +39,10 @@ rescue LoadError
   exit(-1)
 end
 
-require "rails-controller-testing"
-require "rspec/rails"
-require "factory_girl_rails"
-require "database_cleaner"
-require "byebug"
-require "cancan/matchers"
-require "rectify/rspec"
-require "wisper/rspec/stub_wisper_publisher"
-require "db-query-matchers"
-
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
-Dir["#{File.dirname(__FILE__)}/rspec_support/**/*.rb"].each { |f| require f }
 Dir["#{engine_spec_dir}/support/**/*.rb"].each { |f| require f }
 Dir["#{engine_spec_dir}/shared/**/*.rb"].each { |f| require f }
 
-RSpec.configure do |config|
-  config.color = true
-  config.fail_fast = ENV["FAIL_FAST"] || false
-  config.infer_spec_type_from_file_location!
-  config.mock_with :rspec
-  config.raise_errors_for_deprecations!
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, comment the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = false
-
-  config.include TranslationHelpers
-  config.include Rectify::RSpec::Helpers
-end
-
+require_relative "spec_helper"
 require_relative "i18n_spec"

--- a/decidim-dev/lib/decidim/dev/test/spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/spec_helper.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+ENV["RAILS_ENV"] ||= "test"
+
+require "rails"
+require "active_support/core_ext/string"
+require "decidim/core"
+require "decidim/core/test"
+
+require "rails-controller-testing"
+require "rspec/rails"
+require "factory_girl_rails"
+require "database_cleaner"
+require "byebug"
+require "cancan/matchers"
+require "rectify/rspec"
+require "wisper/rspec/stub_wisper_publisher"
+require "db-query-matchers"
+
+# Requires supporting files with custom matchers and macros, etc,
+# in ./support/ and its subdirectories.
+Dir["#{File.dirname(__FILE__)}/rspec_support/**/*.rb"].each { |f| require f }
+
+RSpec.configure do |config|
+  config.color = true
+  config.fail_fast = ENV["FAIL_FAST"] || false
+  config.infer_spec_type_from_file_location!
+  config.mock_with :rspec
+  config.raise_errors_for_deprecations!
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, comment the following line or assign false
+  # instead of true.
+  config.use_transactional_fixtures = false
+
+  config.include TranslationHelpers
+  config.include Rectify::RSpec::Helpers
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This splits `decidim-dev`'s spec helper into two separate files, so part of it can be included without depending on the engine structure.

This is useful when trying to include `decidim` factories or other support files when the context isn't an engine. I'd consider renaming `base_spec_helper` to `feature_spec_helper` in the future so it's more explicit, but right now I wanted to avoid breaking the API.

#### :pushpin: Related Issues
* https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/65

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/it9G9wyWuIXdK/giphy.gif)