### PR TITLE
Merge steps short_description and description

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_participatory_process_step.rb
@@ -35,7 +35,6 @@ module Decidim
         ParticipatoryProcessStep.create!(
           title: form.title,
           description: form.description,
-          short_description: form.short_description,
           start_date: form.start_date,
           end_date: form.end_date,
           participatory_process: @participatory_process

--- a/decidim-admin/app/commands/decidim/admin/update_participatory_process_step.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_participatory_process_step.rb
@@ -40,8 +40,7 @@ module Decidim
           title: form.title,
           start_date: form.start_date,
           end_date: form.end_date,
-          description: form.description,
-          short_description: form.short_description
+          description: form.description
         }
       end
     end

--- a/decidim-admin/app/forms/decidim/admin/participatory_process_step_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_process_step_form.rb
@@ -9,7 +9,6 @@ module Decidim
 
       translatable_attribute :title, String
       translatable_attribute :description, String
-      translatable_attribute :short_description, String
 
       mimic :participatory_process_step
 

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/_form.html.erb
@@ -3,10 +3,6 @@
 </div>
 
 <div class="field">
-  <%= form.translated :editor, :short_description %>
-</div>
-
-<div class="field">
   <%= form.translated :editor, :description, toolbar: :full, lines: 25 %>
 </div>
 

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/show.html.erb
@@ -9,7 +9,6 @@
 <dl>
   <%= display_for @participatory_process_step,
     :title,
-    :short_description,
     :description
     %>
   <dt><%= display_label(@participatory_process_step, :start_date) %></dt>

--- a/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
+++ b/decidim-admin/spec/forms/participatory_process_step_form_spec.rb
@@ -19,13 +19,6 @@ module Decidim
           ca: "Descripció"
         }
       end
-      let(:short_description) do
-        {
-          en: "Short description",
-          es: "Descripción corta",
-          ca: "Descripció curta"
-        }
-      end
       let(:start_date) {}
       let(:end_date) {}
       let(:attributes) do
@@ -37,9 +30,6 @@ module Decidim
             "description_en" => description[:en],
             "description_es" => description[:es],
             "description_ca" => description[:ca],
-            "short_description_en" => short_description[:en],
-            "short_description_es" => short_description[:es],
-            "short_description_ca" => short_description[:ca],
             "start_date" => start_date,
             "end_date" => end_date,
           }

--- a/decidim-admin/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-admin/spec/shared/manage_process_steps_examples.rb
@@ -26,9 +26,6 @@ RSpec.shared_examples "manage process steps examples" do
       expect(page).to have_content(stripped translated(process_step.title, locale: :en))
       expect(page).to have_content(stripped translated(process_step.title, locale: :es))
       expect(page).to have_content(stripped translated(process_step.title, locale: :ca))
-      expect(page).to have_content(stripped translated(process_step.short_description, locale: :en))
-      expect(page).to have_content(stripped translated(process_step.short_description, locale: :es))
-      expect(page).to have_content(stripped translated(process_step.short_description, locale: :ca))
       expect(page).to have_content(stripped translated(process_step.description, locale: :en))
       expect(page).to have_content(stripped translated(process_step.description, locale: :es))
       expect(page).to have_content(stripped translated(process_step.description, locale: :ca))
@@ -45,13 +42,6 @@ RSpec.shared_examples "manage process steps examples" do
         en: "My participatory process step",
         es: "Mi fase de proceso participativo",
         ca: "La meva fase de procés participatiu"
-      )
-      fill_in_i18n_editor(
-        :participatory_process_step_short_description,
-        "#short_description-tabs",
-        en: "Short description",
-        es: "Descripción corta",
-        ca: "Descripció curta"
       )
       fill_in_i18n_editor(
         :participatory_process_step_description,

--- a/decidim-core/db/migrate/20170220110740_remove_steps_short_description.rb
+++ b/decidim-core/db/migrate/20170220110740_remove_steps_short_description.rb
@@ -1,12 +1,14 @@
 class RemoveStepsShortDescription < ActiveRecord::Migration[5.0]
   def change
-    Decidim::ParticipatoryProcessStep.find_each do |step|
-      step.update_attributes!(
-        description: new_description_for(step)
-      )
-    end
+    Decidim::ParticipatoryProcessStep.transaction do
+      Decidim::ParticipatoryProcessStep.find_each do |step|
+        step.update_attributes!(
+          description: new_description_for(step)
+        )
+      end
 
-    remove_column :decidim_participatory_process_steps, :short_description
+      remove_column :decidim_participatory_process_steps, :short_description
+    end
   end
 
   def new_description_for(step)

--- a/decidim-core/db/migrate/20170220110740_remove_steps_short_description.rb
+++ b/decidim-core/db/migrate/20170220110740_remove_steps_short_description.rb
@@ -1,0 +1,19 @@
+class RemoveStepsShortDescription < ActiveRecord::Migration[5.0]
+  def change
+    Decidim::ParticipatoryProcessStep.find_each do |step|
+      step.update_attributes!(
+        description: new_description_for(step)
+      )
+    end
+
+    remove_column :decidim_participatory_process_steps, :short_description
+  end
+
+  def new_description_for(step)
+    desc = {}
+    step.description.keys.each do |locale|
+      desc[locale] = step.short_description[locale] + step.description[locale]
+    end
+    desc
+  end
+end

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -125,9 +125,6 @@ if !Rails.env.production? || ENV["SEED"]
   Decidim::ParticipatoryProcess.find_each do |process|
     Decidim::ParticipatoryProcessStep.create!(
       title: Decidim::Faker::Localized.sentence(1, false, 2),
-      short_description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
-        Decidim::Faker::Localized.sentence(3)
-      end,
       description: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
         Decidim::Faker::Localized.paragraph(3)
       end,

--- a/decidim-core/lib/decidim/core/api/process_step_type.rb
+++ b/decidim-core/lib/decidim/core/api/process_step_type.rb
@@ -14,11 +14,5 @@ module Decidim
     end
 
     field :title, TranslatedFieldType, "The title of this step"
-
-    field :shortDescription do
-      type TranslatedFieldType
-      description "A short description of the step."
-      property :short_description
-    end
   end
 end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -88,7 +88,6 @@ FactoryGirl.define do
 
   factory :participatory_process_step, class: Decidim::ParticipatoryProcessStep do
     title { Decidim::Faker::Localized.sentence(3) }
-    short_description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(2) } }
     description { Decidim::Faker::Localized.wrapped("<p>", "</p>") { Decidim::Faker::Localized.sentence(4) } }
     start_date 1.month.ago.at_midnight
     end_date 2.month.from_now.at_midnight

--- a/decidim-core/spec/types/process_step_type_spec.rb
+++ b/decidim-core/spec/types/process_step_type_spec.rb
@@ -37,13 +37,5 @@ module Decidim
         expect(response["title"]["locales"]).to include(*process.title.keys)
       end
     end
-
-    describe "shortDescription" do
-      let(:query) { "{ shortDescription { locales } }" }
-
-      it "returns its short description" do
-        expect(response["shortDescription"]["locales"]).to include(*process.short_description.keys)
-      end
-    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Merges the steps short_description and description and removes the `short_description` column, as it wasn't being used publicly.

#### :pushpin: Related Issues
- Fixes #1011 

#### :clipboard: Subtasks
None