### PR TITLE
Add orders_count to budgets

### DIFF
--- a/decidim-admin/app/assets/stylesheets/decidim/admin/_tables.scss
+++ b/decidim-admin/app/assets/stylesheets/decidim/admin/_tables.scss
@@ -2,6 +2,9 @@ table{
   td.actions, th.actions{
     text-align: right;
   }
+  td.center, th.center{
+    text-align: center;
+  }
 }
 
 tbody.sortable tr {

--- a/decidim-budgets/app/models/decidim/budgets/order.rb
+++ b/decidim-budgets/app/models/decidim/budgets/order.rb
@@ -24,6 +24,8 @@ module Decidim
         less_than_or_equal_to: :maximum_budget
       }
 
+      scope :finished, -> { where.not(checked_out_at: nil) }
+
       # Public: Returns the sum of project budgets
       def total_budget
         projects.to_a.sum(&:budget)

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -12,6 +12,8 @@ module Decidim
       include Decidim::Comments::Commentable
 
       feature_manifest_name "budgets"
+      has_many :line_items, class_name: Decidim::Budgets::LineItem, foreign_key: "decidim_project_id", dependent: :destroy
+      has_many :orders, through: :line_items, foreign_key: "decidim_project_id", class_name: "Decidim::Budgets::Order"
 
       # Public: Overrides the `commentable?` Commentable concern method.
       def commentable?
@@ -26,6 +28,11 @@ module Decidim
       # Public: Overrides the `comments_have_votes?` Commentable concern method.
       def comments_have_votes?
         true
+      end
+
+      # Public: Returns the number of times an specific project have been checked out.
+      def orders_count
+        orders.where.not(checked_out_at: nil).count
       end
     end
   end

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -32,7 +32,7 @@ module Decidim
 
       # Public: Returns the number of times an specific project have been checked out.
       def confirmed_orders_count
-        orders.where.not(checked_out_at: nil).count
+        orders.finished.count
       end
     end
   end

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -31,7 +31,7 @@ module Decidim
       end
 
       # Public: Returns the number of times an specific project have been checked out.
-      def orders_count
+      def confirmed_orders_count
         orders.where.not(checked_out_at: nil).count
       end
     end

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -8,7 +8,7 @@
   <thead>
     <tr>
       <th><%= t("models.project.fields.title", scope: "decidim.budgets") %></th>
-      <th class="center"><%= t("index.orders_count") %></th>
+      <th class="center"><%= t("index.confirmed_orders_count") %></th>
       <th class="actions"><%= t("actions.title", scope: "decidim.budgets") %></th>
     </tr>
   </thead>
@@ -19,7 +19,7 @@
           <%= link_to translated_attribute(project.title), decidim_budgets.project_path(id: project, feature_id: current_feature, participatory_process_id: current_participatory_process), target: :blank %><br />
         </td>
         <td class='center'>
-         <%= project.orders_count %>
+         <%= project.confirmed_orders_count %>
         </td>
         <td class="actions">
           <%= link_to t("actions.edit", scope: "decidim.budgets"), edit_project_path(project) if can? :update, current_feature %>

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -8,6 +8,7 @@
   <thead>
     <tr>
       <th><%= t("models.project.fields.title", scope: "decidim.budgets") %></th>
+      <th class="center"><%= t("index.orders_count") %></th>
       <th class="actions"><%= t("actions.title", scope: "decidim.budgets") %></th>
     </tr>
   </thead>
@@ -16,6 +17,9 @@
       <tr data-id="<%= project.id %>">
         <td>
           <%= link_to translated_attribute(project.title), decidim_budgets.project_path(id: project, feature_id: current_feature, participatory_process_id: current_participatory_process), target: :blank %><br />
+        </td>
+        <td class='center'>
+         <%= project.orders_count %>
         </td>
         <td class="actions">
           <%= link_to t("actions.edit", scope: "decidim.budgets"), edit_project_path(project) if can? :update, current_feature %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -113,5 +113,5 @@ en:
         error: An error ocurred while canceling your vote
         success: Your vote has been canceled successfully
   index:
-    orders_count: Orders count
+    confirmed_orders_count: Orders count
   total_budget: Total budget

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -112,4 +112,6 @@ en:
       destroy:
         error: An error ocurred while canceling your vote
         success: Your vote has been canceled successfully
+  index:
+    orders_count: Orders count
   total_budget: Total budget

--- a/decidim-budgets/spec/models/project_spec.rb
+++ b/decidim-budgets/spec/models/project_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Budgets::Project do
-  let(:project) { build :project }
+  let(:project) { create :project }
   subject { project }
 
   it { is_expected.to be_valid }
@@ -26,5 +26,18 @@ describe Decidim::Budgets::Project do
     let(:project) { build :project, category: category }
 
     it { is_expected.not_to be_valid }
+  end
+
+  context "#orders_count" do
+    let(:project) { create :project, budget: 75_000_000 }
+    let(:order) { create :order, feature: project.feature }
+    let(:unfinished_order) { create :order, feature: project.feature }
+    let!(:line_item) { create :line_item, project: project, order: order }
+    let!(:line_item_1) { create :line_item, project: project , order: unfinished_order}
+
+    it "return number of finished orders for this project" do
+      order.reload.update_attributes!(checked_out_at: Time.current)
+      expect(project.orders_count).to eq(1)
+    end
   end
 end

--- a/decidim-budgets/spec/models/project_spec.rb
+++ b/decidim-budgets/spec/models/project_spec.rb
@@ -37,7 +37,7 @@ describe Decidim::Budgets::Project do
 
     it "return number of finished orders for this project" do
       order.reload.update_attributes!(checked_out_at: Time.current)
-      expect(project.orders_count).to eq(1)
+      expect(project.confirmed_orders_count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds the amount of times a each project has been added to a checked out order, on the admin panel to give the user some introspection capabilities on budgets.

#### :pushpin: Related Issues
- Fixes #985?

### :camera: Screenshots (optional)
![screen shot 2017-02-21 at 14 32 32](https://cloud.githubusercontent.com/assets/953911/23167354/6157bac6-f844-11e6-9e5a-74aab5d4ba06.png)

#### :ghost: GIF
![](https://media.giphy.com/media/wETt5IIeRluUg/giphy.gif)
