### PR TITLE
Add missing translation for projects & proposals

### DIFF
--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -137,6 +137,7 @@ en:
             votes: Votes
     resource_links:
       included_proposals:
+        projects: 'Proposal appearing in these projects:'
         results: 'Proposal appearing in these results:'
       proposals_from_meeting:
         meetings: Related meetings


### PR DESCRIPTION
#### :tophat: What? Why?

There's a missing translation when a proposal has related projects.

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/s43ieQB.png)
