### PR TITLE
Update all resource helper locales

### DIFF
--- a/decidim-budgets/config/locales/ca.yml
+++ b/decidim-budgets/config/locales/ca.yml
@@ -105,6 +105,9 @@ ca:
       destroy:
         error: S'ha produït un error en cancel·lar el seu vot
         success: El seu vot ha estat cancel·lat correctament
+    resource_links:
+      included_proposals:
+        project_proposals: 'Propostes incloses en aquest projecte:'
   index:
     confirmed_orders_count: Nombre de vots
   total_budget: Pressupost total

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -112,9 +112,6 @@ en:
       destroy:
         error: An error ocurred while canceling your vote
         success: Your vote has been canceled successfully
-    resource_links:
-      included_proposals:
-        project_proposals: 'Proposals included in this project'
   index:
     confirmed_orders_count: Orders count
   total_budget: Total budget

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -112,6 +112,9 @@ en:
       destroy:
         error: An error ocurred while canceling your vote
         success: Your vote has been canceled successfully
+    resource_links:
+      included_proposals:
+        project_proposals: 'Proposals included in this project'
   index:
     confirmed_orders_count: Orders count
   total_budget: Total budget

--- a/decidim-budgets/config/locales/es.yml
+++ b/decidim-budgets/config/locales/es.yml
@@ -105,6 +105,9 @@ es:
       destroy:
         error: Ha habido un error al cancelar tu voto
         success: Tu voto ha sido cancelado correctamente
+    resource_links:
+      included_proposals:
+        project_proposals: 'Propuestas incluidas en este proyecto:'
   index:
     confirmed_orders_count: Nombre de votos
   total_budget: Presupuesto total

--- a/decidim-core/app/helpers/decidim/resource_helper.rb
+++ b/decidim-core/app/helpers/decidim/resource_helper.rb
@@ -41,7 +41,8 @@ module Decidim
       safe_join(linked_resources.map do |klass, resources|
         resource_manifest = klass.constantize.resource_manifest
         content_tag(:div, class: "section") do
-          content_tag(:h3, I18n.t(resource_manifest.name, scope: "decidim.resource_links.#{link_name}"), class: "section-heading") +
+          i18n_name = "#{resource.class.name.demodulize.underscore}_#{resource_manifest.name}"
+          content_tag(:h3, I18n.t(i18n_name, scope: "decidim.resource_links.#{link_name}"), class: "section-heading") +
             render(partial: resource_manifest.template, locals: { resources: resources })
         end
       end)

--- a/decidim-dev/config/locales/en.yml
+++ b/decidim-dev/config/locales/en.yml
@@ -2,4 +2,4 @@ en:
   decidim:
     resource_links:
       test_link:
-        dummy: Related dummy
+        dummy_resource_dummy: Related dummy

--- a/decidim-meetings/config/locales/ca.yml
+++ b/decidim-meetings/config/locales/ca.yml
@@ -81,6 +81,8 @@ ca:
             title: Títol
     resource_links:
       meetings_through_proposals:
-        results: 'Resultats relacionats:'
+        meeting_results: 'Resultats relacionats:'
+        result_meetings: 'Trobades relacionades:'
       proposals_from_meeting:
-        proposals: Propostes relacionades
+        meeting_proposals: 'Propostes relacionades:'
+        proposal_meetings: 'Trobades relacionades:'

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -83,6 +83,8 @@ en:
             title: Title
     resource_links:
       meetings_through_proposals:
-        results: 'Related results:'
+        meeting_results: 'Related results:'
+        result_meetings: 'Related meetings:'
       proposals_from_meeting:
-        proposals: Related proposals
+        meeting_proposals: 'Related proposals:'
+        proposal_meetings: 'Related meetings:'

--- a/decidim-meetings/config/locales/es.yml
+++ b/decidim-meetings/config/locales/es.yml
@@ -81,6 +81,8 @@ es:
             title: Título
     resource_links:
       meetings_through_proposals:
-        results: 'Resultados relacionados:'
+        meeting_results: 'Resultados relacionados:'
+        result_meetings: 'Encuentros relacionados:'
       proposals_from_meeting:
-        proposals: Propuestas relacionadas
+        meeting_proposals: 'Propuestas relacionadas:'
+        proposal_meetings: 'Encuentros relacionados:'

--- a/decidim-proposals/config/locales/ca.yml
+++ b/decidim-proposals/config/locales/ca.yml
@@ -135,6 +135,7 @@ ca:
             votes: Suports
     resource_links:
       included_proposals:
-        results: 'La proposta apareix en aquests resultats:'
+        proposal_results: 'La proposta apareix en aquests resultats:'
+        proposal_projects: 'La proposta apareix en aquests projectes:'
       proposals_from_meeting:
-        meetings: Trobades relacionades
+        proposal_meetings: Trobades relacionades

--- a/decidim-proposals/config/locales/ca.yml
+++ b/decidim-proposals/config/locales/ca.yml
@@ -138,4 +138,4 @@ ca:
         proposal_results: 'La proposta apareix en aquests resultats:'
         proposal_projects: 'La proposta apareix en aquests projectes:'
       proposals_from_meeting:
-        proposal_meetings: Trobades relacionades
+        proposal_meetings: 'Trobades relacionades:'

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -137,12 +137,7 @@ en:
             votes: Votes
     resource_links:
       included_proposals:
-<<<<<<< HEAD
-        projects: 'Proposal appearing in these projects:'
-        results: 'Proposal appearing in these results:'
-=======
         proposal_results: 'Proposal appearing in these results:'
         proposal_projects: 'Proposal appearing in these projects:'
->>>>>>> Update all respective locales
       proposals_from_meeting:
         proposal_meetings: Related meetings

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -137,7 +137,12 @@ en:
             votes: Votes
     resource_links:
       included_proposals:
+<<<<<<< HEAD
         projects: 'Proposal appearing in these projects:'
         results: 'Proposal appearing in these results:'
+=======
+        proposal_results: 'Proposal appearing in these results:'
+        proposal_projects: 'Proposal appearing in these projects:'
+>>>>>>> Update all respective locales
       proposals_from_meeting:
-        meetings: Related meetings
+        proposal_meetings: Related meetings

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -137,7 +137,7 @@ en:
             votes: Votes
     resource_links:
       included_proposals:
-        proposal_results: 'Proposal appearing in these results:'
         proposal_projects: 'Proposal appearing in these projects:'
+        proposal_results: 'Proposal appearing in these results:'
       proposals_from_meeting:
         proposal_meetings: Related meetings

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -135,6 +135,7 @@ es:
             votes: Votos
     resource_links:
       included_proposals:
-        results: 'Propuesta formulada en estos resultados:'
+        proposals_results: 'Propuesta formulada en estos resultados:'
+        proposals_projects: 'Propuesta formulada en estos proyectos:'
       proposals_from_meeting:
-        meetings: Encuentros relacionados
+        proposal_meetings: Encuentros relacionados

--- a/decidim-results/config/locales/ca.yml
+++ b/decidim-results/config/locales/ca.yml
@@ -13,7 +13,7 @@ ca:
         result_proposals: Propostes incloses en aquest resultat
         result_projects: Projectes inclosos en aquest resultat
       meetings_through_proposals:
-        result_meetings: Trobades relacionades
+        result_meetings: 'Trobades relacionades:'
     results:
       actions:
         confirm_destroy: Esteu segur que voleu suprimir aquest resultat?

--- a/decidim-results/config/locales/ca.yml
+++ b/decidim-results/config/locales/ca.yml
@@ -10,9 +10,10 @@ ca:
             comments_blocked: Comentaris bloquejats
     resource_links:
       included_proposals:
-        proposals: Propostes incloses en aquest resultat
+        result_proposals: Propostes incloses en aquest resultat
+        result_projects: Projectes inclosos en aquest resultat
       meetings_through_proposals:
-        meetings: Trobades relacionades
+        result_meetings: Trobades relacionades
     results:
       actions:
         confirm_destroy: Esteu segur que voleu suprimir aquest resultat?

--- a/decidim-results/config/locales/en.yml
+++ b/decidim-results/config/locales/en.yml
@@ -11,9 +11,10 @@ en:
             comments_blocked: Comments blocked
     resource_links:
       included_proposals:
-        proposals: Proposals included in this result
+        result_proposals: Proposals included in this result
+        result_projects: Projects included in this result
       meetings_through_proposals:
-        meetings: Related meetings
+        result_meetings: Related meetings
     results:
       actions:
         confirm_destroy: Are you sure you want to delete this result?

--- a/decidim-results/config/locales/en.yml
+++ b/decidim-results/config/locales/en.yml
@@ -12,7 +12,7 @@ en:
     resource_links:
       included_proposals:
         result_proposals: Proposals included in this result
-        result_projects: Projects included in this result
+        result_proposals: Projects included in this result
       meetings_through_proposals:
         result_meetings: Related meetings
     results:

--- a/decidim-results/config/locales/es.yml
+++ b/decidim-results/config/locales/es.yml
@@ -10,9 +10,10 @@ es:
             comments_blocked: Comentarios bloqueados
     resource_links:
       included_proposals:
-        proposals: Propuestas incluidas en este resultado
+        result_proposals: Propuestas incluidas en este resultado
+        result_projects: Proyectos incluidas en este resultado
       meetings_through_proposals:
-        meetings: Encuentros relacionados
+        result_meetings: Encuentros relacionados
     results:
       actions:
         confirm_destroy: '¿Está seguro de que quiere eliminar este resultado?'


### PR DESCRIPTION
#### :tophat: What? Why?
This PR reviews and fixed all the text that resource_helper was managing. Adding an extra word to the generated label, that match with the specific resource the helper is dealing.

So as a result we have some strings more that we can match with the specific resource.

#### :pushpin: Related Issues
- Fixes #1023

### :camera: Screenshots (optional)
#### Propostes
![proposta](https://cloud.githubusercontent.com/assets/953911/23218381/6b71d3f6-f91c-11e6-9292-1279f93be732.png)
#### Projectes
![projectes](https://cloud.githubusercontent.com/assets/953911/23218399/75537afa-f91c-11e6-9024-c6d12d1d68fb.png)
#### Meetings
![meetings](https://cloud.githubusercontent.com/assets/953911/23218416/838807f8-f91c-11e6-9446-53998af6861a.png)
#### Resultats
![resultats](https://cloud.githubusercontent.com/assets/953911/23218417/83c3ea66-f91c-11e6-9460-bb42dba9b04a.png)

