### PR TITLE
Add votes_enabled and show_votes settings for budgets

### DIFF
--- a/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
+++ b/decidim-budgets/app/commands/decidim/budgets/add_line_item.rb
@@ -22,7 +22,7 @@ module Decidim
       # Returns nothing.
       def call
         transaction do
-          return broadcast(:invalid) if order.checked_out?
+          return broadcast(:invalid) if votes_disabled? || order.checked_out?
           add_line_item
           broadcast(:ok, order)
         end
@@ -39,6 +39,14 @@ module Decidim
           order.projects << @project
           order.save!
         end
+      end
+
+      def feature
+        @project.feature
+      end
+
+      def votes_disabled?
+        !feature.active_step_settings.votes_enabled?
       end
     end
   end

--- a/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
@@ -15,7 +15,7 @@
         <span class="card--list__data__number budget-list__number">
           <%= budget_to_currency(project.budget) %>
         </span>
-        <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget }, disabled: current_order_checked_out?, class: "button tiny budget--list__action success" do %>
+        <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button tiny budget--list__action success" do %>
           <%= icon("check", class: "icon--small", aria_label: t('.remove'), role: "img") %>
         <% end %>
       </div>
@@ -24,7 +24,7 @@
         <span class="card--list__data__number budget-list__number">
           <%= budget_to_currency(project.budget) %>
         </span>
-        <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true }, disabled: current_order_checked_out?, class: "button tiny hollow budget--list__action" do %>
+        <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button tiny hollow budget--list__action" do %>
           <%= icon("check", class: "icon--small", aria_label: t('.add'), role: "img") %>
         <% end %>
       </div>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_project.html.erb
@@ -18,6 +18,11 @@
         <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button tiny budget--list__action success" do %>
           <%= icon("check", class: "icon--small", aria_label: t('.remove'), role: "img") %>
         <% end %>
+        <% if current_settings.show_votes? %>
+          <div class="card__support" style="width: 7em">
+            <span><%= t('.count', count: project.confirmed_orders_count) %></span>
+          </div>
+        <% end %>
       </div>
     <% else %>
       <div class="card--list__data budget-list__data">
@@ -26,6 +31,11 @@
         </span>
         <%= action_authorized_button_to "vote", order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button tiny hollow budget--list__action" do %>
           <%= icon("check", class: "icon--small", aria_label: t('.add'), role: "img") %>
+        <% end %>
+        <% if current_settings.show_votes? %>
+          <div class="card__support" style="width: 7em">
+            <span><%= t('.count', count: project.confirmed_orders_count) %></span>
+          </div>
         <% end %>
       </div>
     <% end %>
@@ -37,6 +47,11 @@
       <a href="#" class="button tiny hollow budget--list__action disabled" data-toggle="loginModal">
         <%= icon("check", class: "icon--small", aria_label: t('.add'), role: "img") %>
       </a>
+      <% if current_settings.show_votes? %>
+        <div class="card__support" style="width: 7em">
+          <span><%= t('.count', count: project.confirmed_orders_count) %></span>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_project_budget_button.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_project_budget_button.html.erb
@@ -1,8 +1,8 @@
 <% if current_user.present? %>
   <% if current_order && current_order.projects.include?(project) %>
-    <%= action_authorized_button_to "vote", t('.added'), order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget }, disabled: current_order_checked_out?, class: "button expanded button--sc success budget--list__action" %>
+    <%= action_authorized_button_to "vote", t('.added'), order_line_item_path(project_id: project), method: :delete, remote: true, data: { disable: true, budget: project.budget }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button expanded button--sc success budget--list__action" %>
   <% else %>
-    <%= action_authorized_button_to "vote", t('.add'), order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true }, disabled: current_order_checked_out?, class: "button expanded button--sc budget--list__action" %>
+    <%= action_authorized_button_to "vote", t('.add'), order_line_item_path(project_id: project), method: :post, remote: true, data: { disable: true, budget: project.budget, add: true }, disabled: !current_settings.votes_enabled? || current_order_checked_out?, class: "button expanded button--sc budget--list__action" %>
   <% end %>
 <% else %>
   <button class="button expanded button--sc disabled" data-toggle="loginModal"><%= t('.add') %></button>

--- a/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/index.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.present? %>
+<% if current_user.present? && current_settings.votes_enabled? %>
   <div class="row column">
     <%= render partial: "budget_summary", locals: { include_heading: true } %>
   </div>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -22,6 +22,11 @@
           <span class="definition-data__title"><%= t('.budget') %></span>
           <span class="definition-data__number"><%= budget_to_currency project.budget %></span>
         </div>
+        <% if current_settings.show_votes? %>
+          <div class="card__support__data">
+            <span><%= t('decidim.budgets.projects.project.count', count: project.confirmed_orders_count) %></span>
+          </div>
+        <% end %>
         <div id="project-<%= project.id %>-budget-button">
           <%= render partial: 'project_budget_button', locals: { project: project } %>
         </div>

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -4,7 +4,7 @@
 ) %>
 
 <div class="row column view-header">
-  <% if current_user.present? %>
+  <% if current_user.present? && current_settings.votes_enabled? %>
     <%= render partial: "budget_summary", locals: { include_heading: false } %>
   <% end %>
   <%= link_to projects_path, class: "muted-link" do %>

--- a/decidim-budgets/config/i18n-tasks.yml
+++ b/decidim-budgets/config/i18n-tasks.yml
@@ -3,4 +3,5 @@ locales: [en]
 ignore_unused:
 - "decidim.features.budgets.name"
 - "decidim.features.budgets.settings.*"
+- "decidim.features.budgets.actions.*"
 - "activemodel.attributes.project.*"

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -90,6 +90,9 @@ en:
           view: View
         project:
           add: Add
+          count:
+            one: 1 support
+            other: "%{count} supports"
           remove: Remove
         project_budget_button:
           add: Add
@@ -99,6 +102,8 @@ en:
           view_all_projects: View all projects
     features:
       budgets:
+        actions:
+          vote: Vote
         name: Budgets
         settings:
           global:

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -107,6 +107,7 @@ en:
             vote_threshold_percent: Vote threshold percent
           step:
             comments_blocked: Comments blocked
+            votes_enabled: Votes enabled
     orders:
       checkout:
         error: An error ocurred while processing your vote

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -27,6 +27,7 @@ Decidim.register_feature(:budgets) do |feature|
 
   feature.settings(:step) do |settings|
     settings.attribute :comments_blocked, type: :boolean, default: false
+    settings.attribute :votes_enabled, type: :boolean, default: true
   end
 
   feature.seeds do

--- a/decidim-budgets/lib/decidim/budgets/feature.rb
+++ b/decidim-budgets/lib/decidim/budgets/feature.rb
@@ -28,6 +28,7 @@ Decidim.register_feature(:budgets) do |feature|
   feature.settings(:step) do |settings|
     settings.attribute :comments_blocked, type: :boolean, default: false
     settings.attribute :votes_enabled, type: :boolean, default: true
+    settings.attribute :show_votes, type: :boolean, default: false
   end
 
   feature.seeds do

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -31,6 +31,16 @@ FactoryGirl.define do
         }
       end
     end
+
+    trait :with_show_votes_enabled do
+      step_settings do
+        {
+          participatory_process.active_step.id => {
+            show_votes: true
+          }
+        }
+      end
+    end
   end
 
   factory :project, class: Decidim::Budgets::Project do

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -21,6 +21,16 @@ FactoryGirl.define do
         }
       end
     end
+
+    trait :with_votes_disabled do
+      step_settings do
+        {
+          participatory_process.active_step.id => {
+            votes_enabled: false
+          }
+        }
+      end
+    end
   end
 
   factory :project, class: Decidim::Budgets::Project do

--- a/decidim-budgets/spec/commands/add_line_item_spec.rb
+++ b/decidim-budgets/spec/commands/add_line_item_spec.rb
@@ -2,7 +2,8 @@ require "spec_helper"
 
 describe Decidim::Budgets::AddLineItem do
   let(:user) { create(:user) }
-  let(:feature) { create(:budget_feature, organization: user.organization, settings: settings) }
+  let(:participatory_process) { create :participatory_process, :with_steps, organization: user.organization }
+  let(:feature) { create(:budget_feature, participatory_process: participatory_process, settings: settings) }
   let(:project) { create(:project, feature: feature, budget: 60_000) }
   let(:settings) { { "total_budget" => 100_000, vote_threshold_percent: 50 }}
   let(:order) { nil }
@@ -53,6 +54,14 @@ describe Decidim::Budgets::AddLineItem do
       order.save!
       order
     end
+
+    it "broadcasts invalid" do
+      expect { subject.call }.to broadcast(:invalid)
+    end
+  end
+
+  context "when the votes are not enabled" do
+    let(:feature) { create(:budget_feature, :with_votes_disabled, participatory_process: participatory_process, settings: settings) }
 
     it "broadcasts invalid" do
       expect { subject.call }.to broadcast(:invalid)

--- a/decidim-budgets/spec/features/orders_spec.rb
+++ b/decidim-budgets/spec/features/orders_spec.rb
@@ -32,11 +32,12 @@ describe "Orders", type: :feature do
   context "when the user is logged in" do
     before do
       login_as user, scope: :user
-      visit_feature
     end
 
     context "and has not a pending order" do
       it "adds a project to the current order" do
+        visit_feature
+
         within "#project-#{project.id}-item" do
           page.find('.budget--list__action').click
         end
@@ -62,10 +63,11 @@ describe "Orders", type: :feature do
         feature.update_attribute(:permissions, vote: {
                                    authorization_handler_name: "decidim/dummy_authorization_handler"
                                  })
-        visit_feature
       end
 
       it "shows a modal dialog" do
+        visit_feature
+
         within "#project-#{project.id}-item" do
           page.find('.budget--list__action').click
         end
@@ -80,6 +82,7 @@ describe "Orders", type: :feature do
 
       it "removes a project from the current order" do
         visit_feature
+
         expect(page).to have_content "ASSIGNED: €25,000,000"
 
         within "#project-#{project.id}-item" do
@@ -145,7 +148,7 @@ describe "Orders", type: :feature do
     context "and has a finished order" do
       let!(:order) do
         order = create(:order, user: user, feature: feature)
-        order.projects << projects
+        order.projects = projects
         order.checked_out_at = Time.current
         order.save!
         order
@@ -179,8 +182,35 @@ describe "Orders", type: :feature do
       end
 
       it "cannot create new orders" do
+        visit_feature
+
         expect(page).to have_selector('button.budget--list__action[disabled]', count: 3)
         expect(page).to have_no_selector('.budget-summary')
+      end
+    end
+
+    context "and show votes are enabled" do
+      let!(:feature) do
+        create(:budget_feature,
+              :with_show_votes_enabled,
+              manifest: manifest,
+              participatory_process: participatory_process)
+      end
+
+      let!(:order) do
+        order = create(:order, user: user, feature: feature)
+        order.projects = projects
+        order.checked_out_at = Time.current
+        order.save!
+        order
+      end
+
+      it "displays the number of votes for a project" do
+        visit_feature
+
+        within "#project-#{project.id}-item" do
+          expect(page).to have_content("1 SUPPORT")
+        end
       end
     end
   end

--- a/decidim-budgets/spec/features/orders_spec.rb
+++ b/decidim-budgets/spec/features/orders_spec.rb
@@ -169,6 +169,20 @@ describe "Orders", type: :feature do
         end
       end
     end
+
+    context "and votes are disabled" do
+      let!(:feature) do
+        create(:budget_feature,
+              :with_votes_disabled,
+              manifest: manifest,
+              participatory_process: participatory_process)
+      end
+
+      it "cannot create new orders" do
+        expect(page).to have_selector('button.budget--list__action[disabled]', count: 3)
+        expect(page).to have_no_selector('.budget-summary')
+      end
+    end
   end
 
   describe "show" do


### PR DESCRIPTION
#### :tophat: What? Why?

I added two new step settings for the budgets feature:

- `votes_enabled`: Enable/Disable the creation of new orders disabling the "Add project" button and budget summary.
- `show_votes`: Show/Hide the total amount of votes (confirmed checkout's line items) of each project.

#### :pushpin: Related Issues
- Closes #1040 

#### :clipboard: Subtasks
- [x] `votes_enabled`
- [x] `show_votes`

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/23354242/7e36769c-fcd0-11e6-893b-0d15ac2ce515.png)
![image](https://cloud.githubusercontent.com/assets/106021/23355342/8a5d3b9a-fcd5-11e6-82d9-1546716be4c9.png)
![image](https://cloud.githubusercontent.com/assets/106021/23355316/736a25e2-fcd5-11e6-93e9-00f1adfb2b3d.png)

#### :ghost: GIF
![](https://media.giphy.com/media/3o6Mb2xWWaZEdzdl04/giphy.gif)