### PR TITLE
add missing foundation init

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/line_items/update_budget.js.erb
+++ b/decidim-budgets/app/views/decidim/budgets/line_items/update_budget.js.erb
@@ -11,6 +11,7 @@ morphdom($orderProgress[0], '<%= j(render partial: 'decidim/budgets/projects/ord
 morphdom($budgetConfirm[0], '<%= j(render partial: 'decidim/budgets/projects/budget_confirm') %>')
 
 $("#order-progress").foundation();
+$(".budget-summary__selected").foundation();
 
 if ($projectItem.length > 0) {
   morphdom($projectItem[0], '<%= j(render partial: 'decidim/budgets/projects/project', locals: { project: project }) %>');


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the "Selected projects" dropdown when the user visits the budgets index and select a couple of them forcing to refresh the foundation function.

#### :pushpin: Related Issues
- Fixes #1050

### :camera: Screenshots (optional)
<img width="1188" alt="screen shot 2017-02-28 at 16 02 04" src="https://cloud.githubusercontent.com/assets/953911/23410353/443be13e-fdcf-11e6-968b-2361cb8966b7.png">

#### :ghost: GIF
![]()
