### PR TITLE
Filter by global scope

### DIFF
--- a/decidim-budgets/app/services/decidim/budgets/project_search.rb
+++ b/decidim-budgets/app/services/decidim/budgets/project_search.rb
@@ -19,11 +19,6 @@ module Decidim
           .or(query.where(localized_search_text_in(:description), text: "%#{search_text}%"))
       end
 
-      # Handle the scope_id filter
-      def search_scope_id
-        query.where(decidim_scope_id: scope_id)
-      end
-
       # Returns the random projects for the current page.
       def results
         @projects ||= Project.transaction do

--- a/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <% if current_organization.scopes.any? && !current_participatory_process.scope %>
-    <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t('.scopes') %>
+    <%= form.collection_check_boxes :scope_id, search_organization_scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t('.scopes') %>
   <% end %>
 
   <% if current_feature.categories.any? %>

--- a/decidim-budgets/spec/services/project_search_spec.rb
+++ b/decidim-budgets/spec/services/project_search_spec.rb
@@ -65,6 +65,15 @@ describe Decidim::Budgets::ProjectSearch do
           expect(subject.results).to match_array [project1,project2]
         end
       end
+
+      context "when `global` is being sent" do
+        let!(:resource_without_scope) { create(:project, feature: current_feature, scope: nil)}
+        let(:params) { default_params.merge(scope_id: ["global"]) }
+
+        it "returns resources without a scope" do
+          expect(subject.results).to eq [resource_without_scope]
+        end
+      end
     end
 
     context "category_id" do

--- a/decidim-core/app/helpers/decidim/organization_scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/organization_scopes_helper.rb
@@ -9,7 +9,7 @@ module Decidim
     # If you need to show scopes in a search form backed by a `Searchlight::Search`
     # class, see the `search_organization_scopes` helper method.
     #
-    # organization - a Decidim::Organiåtion. Uses the helper `current_organization`
+    # organization - a Decidim::Organization. Uses the `current_organization` helper
     #   by default.
     #
     # Returns an Array.
@@ -30,7 +30,7 @@ module Decidim
     # case in the search class. This is far from ideal, but I don't know a better
     # way to do this.
     #
-    # organization - a Decidim::Organiåtion. Uses the helper `current_organization`
+    # organization - a Decidim::Organization. Uses the `current_organization` helper
     #   by default.
     #
     # Returns an Array.

--- a/decidim-core/app/helpers/decidim/organization_scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/organization_scopes_helper.rb
@@ -1,11 +1,39 @@
+# -*- coding: undecided -*-
 # frozen_string_literal: true
 module Decidim
-  # A Helper to render and link to resources.
+  # A Helper to render scopes, including a global scope, for forms.
   module OrganizationScopesHelper
+    # Public: Returns a collection of the given organization scopes, prepending
+    # a global scope. The global scope is at the beginning because it's easier
+    # to be found there. Use this helper in places like `select` elements in forms.
+    # If you need to show scopes in a search form backed by a `Searchlight::Search`
+    # class, see the `search_organization_scopes` helper method.
+    #
+    # organization - a Decidim::Organiåtion. Uses the helper `current_organization`
+    #   by default.
+    #
+    # Returns an Array.
     def organization_scopes(organization = current_organization)
       [Struct.new(:id, :name).new("", I18n.t("decidim.participatory_processes.scopes.global"))] + organization.scopes
     end
 
+    # Public: Returns a collection of the given organization scopes, prepending
+    # a global scope. The global scope is at the beginning because it's easier
+    # to be found there. Use this helper in search forms backed by a
+    # `Searchlight::Search` class. The reason is, in the `organization_scopes`
+    # method we use an empty String as the ID for the Global Scope object, which
+    # works fine in normal forms, but Searchlight ignores parameters that are empty
+    # Arrays, empty Strings, empty Hashes or nil, so if you want to actively filter
+    # those elements that do not have a scope, you cannot send an empty String or
+    # nil because Searchlight will ignore the parameter. The only solution here is
+    # to use a specific String as ID (`"global"`, in our case), and then treat this
+    # case in the search class. This is far from ideal, but I don't know a better
+    # way to do this.
+    #
+    # organization - a Decidim::Organiåtion. Uses the helper `current_organization`
+    #   by default.
+    #
+    # Returns an Array.
     def search_organization_scopes(organization = current_organization)
       [Struct.new(:id, :name).new("global", I18n.t("decidim.participatory_processes.scopes.global"))] + organization.scopes
     end

--- a/decidim-core/app/helpers/decidim/organization_scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/organization_scopes_helper.rb
@@ -1,4 +1,4 @@
-# -*- coding: undecided -*-
+# -*- coding: utf-8 -*-
 # frozen_string_literal: true
 module Decidim
   # A Helper to render scopes, including a global scope, for forms.

--- a/decidim-core/app/helpers/decidim/organization_scopes_helper.rb
+++ b/decidim-core/app/helpers/decidim/organization_scopes_helper.rb
@@ -5,5 +5,9 @@ module Decidim
     def organization_scopes(organization = current_organization)
       [Struct.new(:id, :name).new("", I18n.t("decidim.participatory_processes.scopes.global"))] + organization.scopes
     end
+
+    def search_organization_scopes(organization = current_organization)
+      [Struct.new(:id, :name).new("global", I18n.t("decidim.participatory_processes.scopes.global"))] + organization.scopes
+    end
   end
 end

--- a/decidim-core/app/services/decidim/resource_search.rb
+++ b/decidim-core/app/services/decidim/resource_search.rb
@@ -40,7 +40,7 @@ module Decidim
     # `Decidim::OrganizationScopesHelper`, to render the collection needed for the
     # `collection_check_boxes` form method.
     def search_scope_id
-      clean_scope_ids = scope_id.map{ |id| id == "global" ? nil : id }
+      clean_scope_ids = [scope_id].flatten.map{ |id| id == "global" ? nil : id }
       query.where(decidim_scope_id: clean_scope_ids)
     end
 

--- a/decidim-core/app/services/decidim/resource_search.rb
+++ b/decidim-core/app/services/decidim/resource_search.rb
@@ -7,7 +7,7 @@ module Decidim
     #
     # scope   - The scope used to create the base query
     # options - A hash of options to modify the search. These options will be
-    #          converted to methods by SearchLight so they can be used on filter #
+    #          converted to methods by SearchLight so they can be used on filter
     #          methods. (Default {})
     def initialize(scope, options = {})
       super(options)
@@ -26,6 +26,22 @@ module Decidim
     # Handle the category_id filter
     def search_category_id
       query.where(decidim_category_id: category_ids)
+    end
+
+    # Handles the scope_id filter. When we want to show only those that do not
+    # have a scope_id set, we cannot pass an empty String or nil because Searchlight
+    # will automatically filter out these params, se the method will not be used.
+    # Instead, we need to passa fake ID and then convert it inside. In this case,
+    # in order to select those elements that do not have a scope_id set we use
+    # `"global"` as parameter, and in the method we do the needed changes to search
+    # properly.
+    #
+    # You can use the `search_organization_scopes` helper method, defined in
+    # `Decidim::OrganizationScopesHelper`, to render the collection needed for the
+    # `collection_check_boxes` form method.
+    def search_scope_id
+      clean_scope_ids = scope_id.map{ |id| id == "global" ? nil : id }
+      query.where(decidim_scope_id: clean_scope_ids)
     end
 
     private

--- a/decidim-core/app/services/decidim/resource_search.rb
+++ b/decidim-core/app/services/decidim/resource_search.rb
@@ -30,8 +30,8 @@ module Decidim
 
     # Handles the scope_id filter. When we want to show only those that do not
     # have a scope_id set, we cannot pass an empty String or nil because Searchlight
-    # will automatically filter out these params, se the method will not be used.
-    # Instead, we need to passa fake ID and then convert it inside. In this case,
+    # will automatically filter out these params, so the method will not be used.
+    # Instead, we need to pass a fake ID and then convert it inside. In this case,
     # in order to select those elements that do not have a scope_id set we use
     # `"global"` as parameter, and in the method we do the needed changes to search
     # properly.

--- a/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_search.rb
@@ -29,11 +29,6 @@ module Decidim
         end
       end
 
-      # Handle the scope_id filter
-      def search_scope_id
-        query.where(decidim_scope_id: scope_id)
-      end
-
       private
 
       # Internal: builds the needed query to search for a text in the organization's

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   <% if !current_participatory_process.scope && current_organization.scopes.any? %>
-    <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t(".scopes") %>
+    <%= form.collection_check_boxes :scope_id, search_organization_scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t(".scopes") %>
   <% end %>
 
   <% if current_feature.categories.any? %>

--- a/decidim-meetings/spec/services/meeting_search_spec.rb
+++ b/decidim-meetings/spec/services/meeting_search_spec.rb
@@ -101,6 +101,15 @@ describe Decidim::Meetings::MeetingSearch do
           expect(subject.results).to match_array [meeting1, meeting2]
         end
       end
+
+      context "when `global` is being sent" do
+        let!(:resource_without_scope) { create(:meeting, feature: current_feature, scope: nil)}
+        let(:params) { default_params.merge(scope_id: ["global"]) }
+
+        it "returns resources without a scope" do
+          expect(subject.results).to eq [resource_without_scope]
+        end
+      end
     end
 
     context "category_id" do

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -99,7 +99,7 @@ module Decidim
           activity: "",
           category_id: "",
           state: "all",
-          scope_id: "",
+          scope_id: nil,
           related_to: ""
         }
       end

--- a/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
+++ b/decidim-proposals/app/services/decidim/proposals/proposal_search.rb
@@ -44,11 +44,6 @@ module Decidim
         end
       end
 
-      # Handle the scope_id filter
-      def search_scope_id
-        query.where(decidim_scope_id: scope_id)
-      end
-
       # Handle the state filter
       def search_state
         if state == "accepted"

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -40,7 +40,9 @@
         </td>
         <td>
           <% if proposal.scope %>
-            <%= translated_attribute proposal.scope.name %>
+            <%= proposal.scope.name %>
+          <% else %>
+            <%= t("decidim.participatory_processes.scopes.global") %>
           <% end %>
         </td>
         <td>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -29,7 +29,7 @@
   <% end %>
 
   <% if current_organization.scopes.any? && !current_participatory_process.scope %>
-    <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t('.scopes') %>
+    <%= form.collection_check_boxes :scope_id, search_organization_scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t('.scopes') %>
   <% end %>
 
   <% if current_feature.categories.any? %>

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -52,7 +52,8 @@ Decidim.register_feature(:proposals) do |feature|
         }
       )
       categories = feature.participatory_process.categories
-      scopes = feature.organization.scopes
+      # So that we have some with global scope
+      scopes = feature.organization.scopes + [nil]
 
       20.times do |n|
         proposal = Decidim::Proposals::Proposal.create!(

--- a/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
+++ b/decidim-proposals/spec/services/decidim/proposals/proposal_search_spec.rb
@@ -132,6 +132,15 @@ module Decidim
               expect(subject).to match_array [proposal, proposal2]
             end
           end
+
+          context "when `global` is being sent" do
+            let!(:resource_without_scope) { create(:proposal, feature: feature, scope: nil)}
+            let(:scope_id) { ["global"] }
+
+            it "returns resources without a scope" do
+              expect(subject).to eq [resource_without_scope]
+            end
+          end
         end
 
         describe "when the filter includes related_to" do

--- a/decidim-results/app/services/decidim/results/result_search.rb
+++ b/decidim-results/app/services/decidim/results/result_search.rb
@@ -20,11 +20,6 @@ module Decidim
           .or(query.where(localized_search_text_in(:description), text: "%#{search_text}%"))
       end
 
-      # Handle the scope_id filter
-      def search_scope_id
-        query.where(decidim_scope_id: scope_id)
-      end
-
       private
 
       # Internal: builds the needed query to search for a text in the organization's

--- a/decidim-results/app/views/decidim/results/results/_filters.html.erb
+++ b/decidim-results/app/views/decidim/results/results/_filters.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <% if current_organization.scopes.any? && !current_participatory_process.scope %>
-    <%= form.collection_check_boxes :scope_id, current_organization.scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t('.scopes') %>
+    <%= form.collection_check_boxes :scope_id, search_organization_scopes, lambda {|scope| scope.id.to_s}, :name, legend_title: t('.scopes') %>
   <% end %>
 
   <% if current_feature.categories.any? %>

--- a/decidim-results/spec/services/result_search_spec.rb
+++ b/decidim-results/spec/services/result_search_spec.rb
@@ -65,6 +65,15 @@ describe Decidim::Results::ResultSearch do
           expect(subject.results).to match_array [result1,result2]
         end
       end
+
+      context "when `global` is being sent" do
+        let!(:resource_without_scope) { create(:result, feature: current_feature, scope: nil)}
+        let(:params) { default_params.merge(scope_id: ["global"]) }
+
+        it "returns resources without a scope" do
+          expect(subject.results).to eq [resource_without_scope]
+        end
+      end
     end
 
     context "category_id" do


### PR DESCRIPTION
#### :tophat: What? Why?
Lets users show only those resource elements that do not belong to any scope

#### :pushpin: Related Issues
- Fixes #750 

#### :clipboard: Subtasks
- [x] Modify the filters so that the feature works
- [x] Add docs
- [x] Add specs

### :camera: Screenshots (optional)
`Global scope` option always shows on top:
![Description](https://i.imgur.com/oP57i1k.png)

