### PR TITLE
Fix comments error on pages without title

### DIFF
--- a/decidim-comments/app/mailers/decidim/comments/comment_notification_mailer.rb
+++ b/decidim-comments/app/mailers/decidim/comments/comment_notification_mailer.rb
@@ -6,6 +6,8 @@ module Decidim
     class CommentNotificationMailer < Decidim::ApplicationMailer
       helper Decidim::ResourceHelper
 
+      helper_method :commentable_title
+
       def comment_created(user, comment, commentable)
         with_user(user) do
           @comment = comment
@@ -25,6 +27,12 @@ module Decidim
           subject = I18n.t("reply_created.subject", scope: "decidim.comments.mailer.comment_notification")
           mail(to: comment.author.email, subject: subject)
         end
+      end
+
+      private
+
+      def commentable_title
+        @commentable.title.kind_of?(Hash) ? @commentable.title[I18n.locale.to_s] : @commentable.title
       end
     end
   end

--- a/decidim-comments/app/views/decidim/comments/comment_notification_mailer/comment_created.html.erb
+++ b/decidim-comments/app/views/decidim/comments/comment_notification_mailer/comment_created.html.erb
@@ -4,7 +4,7 @@
   <%=
     t(".new_comment_html", {
       commenter: @comment.author.name,
-      commentable_link: link_to(@commentable.title, decidim_resource_url(@commentable))
+      commentable_link: link_to(commentable_title, decidim_resource_url(@commentable))
     })
   %>
 </p>

--- a/decidim-comments/app/views/decidim/comments/comment_notification_mailer/reply_created.html.erb
+++ b/decidim-comments/app/views/decidim/comments/comment_notification_mailer/reply_created.html.erb
@@ -4,7 +4,7 @@
   <%=
     t(".new_reply_html", {
       commenter: @reply.author.name,
-      commentable_link: link_to(@commentable.title, decidim_resource_url(@commentable))
+      commentable_link: link_to(commentable_title, decidim_resource_url(@commentable))
     })
   %>
 </p>

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -4,13 +4,16 @@ module Decidim
     # The data store for a Page in the Decidim::Pages component. It stores a
     # title, description and any other useful information to render a custom page.
     class Page < Pages::ApplicationRecord
+      include Decidim::Resourceable
+      include Decidim::HasFeature
       include Decidim::Comments::Commentable
 
-      belongs_to :feature, foreign_key: "decidim_feature_id", class_name: Decidim::Feature
-      has_one :organization, through: :feature
+      feature_manifest_name "pages"
 
-      validates :feature, presence: true
-      validate :feature_manifest_matches
+      # Public: Pages doesn't have title so we assign the feature one to it.
+      def title
+        feature.name
+      end
 
       # Public: Overrides the `commentable?` Commentable concern method.
       def commentable?
@@ -30,13 +33,6 @@ module Decidim
       # Public: Overrides the `comments_have_votes?` Commentable concern method.
       def comments_have_votes?
         true
-      end
-
-      private
-
-      def feature_manifest_matches
-        return unless feature
-        errors.add(:feature, :invalid) unless feature.manifest_name == "pages"
       end
     end
   end

--- a/decidim-pages/lib/decidim/pages/engine.rb
+++ b/decidim-pages/lib/decidim/pages/engine.rb
@@ -8,6 +8,7 @@ module Decidim
       isolate_namespace Decidim::Pages
 
       routes do
+        resources :pages, only: [:show], controller: :application
         root to: "application#show"
       end
     end

--- a/decidim-pages/lib/decidim/pages/feature.rb
+++ b/decidim-pages/lib/decidim/pages/feature.rb
@@ -27,6 +27,10 @@ Decidim.register_feature(:pages) do |feature|
     settings.attribute :comments_blocked, type: :boolean, default: false
   end
 
+  feature.register_resource do |resource|
+    resource.model_class_name = "Decidim::Pages::Page"
+  end
+
   feature.seeds do
     Decidim::ParticipatoryProcess.all.each do |process|
       next unless process.steps.any?

--- a/decidim-pages/spec/models/page_spec.rb
+++ b/decidim-pages/spec/models/page_spec.rb
@@ -7,6 +7,8 @@ module Decidim
       let(:page) { create(:page) }
       subject { page }
 
+      include_examples "has feature"
+
       it { is_expected.to be_valid }
 
       context "without a feature" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the error on creating the email notification for the user when a comment on a page is issued. The issue was that the email template was looking for a tittle to create the url, and page didn't had one. So from now on the page will take the title from the respective ```feature.name```.

To accomplish that we need to refactor a bit the pages engine, @beagleknight  helped me kindly because this required a better understanding of the engine internals.

#### :pushpin: Related Issues
- Fixes #1055

#### :ghost: GIF
![](https://media.giphy.com/media/l4lR6VIszsCpqtZRu/giphy.gif)
