### PR TITLE
Add decidim's version to Graphql API

### DIFF
--- a/decidim-core/lib/decidim/core/api.rb
+++ b/decidim-core/lib/decidim/core/api.rb
@@ -8,4 +8,5 @@ module Decidim
   autoload :SessionType, "decidim/core/api/session_type"
   autoload :UserGroupType, "decidim/core/api/user_group_type"
   autoload :UserType, "decidim/core/api/user_type"
+  autoload :DecidimType, "decidim/core/api/decidim_type"
 end

--- a/decidim-core/lib/decidim/core/api/decidim_type.rb
+++ b/decidim-core/lib/decidim/core/api/decidim_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Decidim
+  # This type represents a ParticipatoryProcess.
+  DecidimType = GraphQL::ObjectType.define do
+    name "Decidim"
+    description "Decidim's framework-related properties."
+
+    field :version, !types.String, "The current decidim's version of this deployment." do
+      resolve ->(obj, _args, _ctx) { obj.version }
+    end
+  end
+end

--- a/decidim-core/lib/decidim/query_extensions.rb
+++ b/decidim-core/lib/decidim/query_extensions.rb
@@ -27,6 +27,10 @@ module Decidim
             ctx[:current_user]
           }
         end
+
+        field :decidim, DecidimType, "Decidim's framework properties." do
+          resolve ->(_obj, _args, ctx) { Decidim }
+        end
       end
     end
   end

--- a/decidim-core/spec/types/decidim_type_spec.rb
+++ b/decidim-core/spec/types/decidim_type_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "decidim/api/test/type_context"
+
+module Decidim
+  describe DecidimType do
+    include_context "graphql type"
+
+    let(:model) do
+      Decidim
+    end
+
+    describe "version" do
+      let(:query) { "{ version }" }
+
+      it "returns the version" do
+        expect(response).to eq("version" => Decidim.version)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This adds a new `decidim` endpoint to our GraphQL api that exposes decidim's version - this way, we can build powerful tools to monitor which deployments are updated, amongst other things.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/tQvluDRrisvg4/giphy.gif)
