### PR TITLE
Return empty string when no transaltion is found

### DIFF
--- a/decidim-core/app/helpers/decidim/translations_helper.rb
+++ b/decidim-core/app/helpers/decidim/translations_helper.rb
@@ -10,7 +10,7 @@ module Decidim
     #
     # Returns a String with the translation.
     def translated_attribute(attribute)
-      attribute.try(:[], I18n.locale.to_s)
+      attribute.try(:[], I18n.locale.to_s) || ""
     end
 
     # Public: Creates a translation for each available language in the list

--- a/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/translations_helper_spec.rb
@@ -11,6 +11,15 @@ module Decidim
 
         expect(helper.translated_attribute(attribute)).to eq("你好")
       end
+
+      context "when therte is no translation for the given locale" do
+        it "returns an empty string" do
+          attribute = { "ca" => "Hola" }
+          I18n.locale = :'zh-CN'
+
+          expect(helper.translated_attribute(attribute)).to eq("")
+        end
+      end
     end
 
     describe "#multi_translation" do


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes a bug that crashed the app when no translation was found for a given locale. Will be superseded by #1057, but we need to fix it meanwhile.

#### :pushpin: Related Issues
- Related to #1062

#### :clipboard: Subtasks
None