### PR TITLE
Use example.org emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Decidim [![Gem](https://img.shields.io/gem/v/decidim.svg)](https://rubygems.org/gems/decidim) [![Gem](https://img.shields.io/gem/dt/decidim.svg)](https://rubygems.org/gems/decidim) [![GitHub contributors](https://img.shields.io/github/contributors/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/graphs/contributors) [![License: AGPL v3](https://img.shields.io/github/license/AjuntamentdeBarcelona/decidim.svg)](https://github.com/AjuntamentdeBarcelona/decidim/blob/master/LICENSE-AGPLv3.txt)
 
-[![Demo](https://img.shields.io/badge/demo-staging-orange.svg?style=flat)](http://staging.decidim.codegram.com) 
-[[![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://rubydoc.info/github/AjuntamentdeBarcelona/decidim/master)](http://www.rubydoc.info/github/AjuntamentdeBarcelona/decidim/master) 
+[![Demo](https://img.shields.io/badge/demo-staging-orange.svg?style=flat)](http://staging.decidim.codegram.com)
+[[![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://rubydoc.info/github/AjuntamentdeBarcelona/decidim/master)](http://www.rubydoc.info/github/AjuntamentdeBarcelona/decidim/master)
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/AjuntamentdeBarcelona/decidim)
 
 
@@ -62,7 +62,7 @@ $ rails db:setup
 
 This will also create some default data so you can start testing the app:
 
-* A `Decidim::System::Admin` with email `system@decidim.org` and password
+* A `Decidim::System::Admin` with email `system@example.org` and password
  `decidim123456`, to log in at `/system`.
 * A `Decidim::Organization` named `Decidim Staging`. You probably want to
   change its name and hostname to match your needs.

--- a/decidim-admin/db/seeds.rb
+++ b/decidim-admin/db/seeds.rb
@@ -4,7 +4,7 @@ if !Rails.env.production? || ENV["SEED"]
 
   process_admin = Decidim::User.create!(
     name: "Process Admin",
-    email: "process_admin@decidim.org",
+    email: "process_admin@example.org",
     password: "decidim123456",
     password_confirmation: "decidim123456",
     confirmed_at: Time.current,

--- a/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_admins_spec.rb
@@ -23,7 +23,7 @@ describe "Organization admins", type: :feature do
 
       within ".new_user" do
         fill_in :user_name, with: "New admin"
-        fill_in :user_email, with: "newadmin@decidim.org"
+        fill_in :user_email, with: "newadmin@example.org"
 
         find("*[type=submit]").click
       end

--- a/decidim-budgets/spec/shared/admin_shared_context.rb
+++ b/decidim-budgets/spec/shared/admin_shared_context.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context "admin" do
   let(:organization) { create(:organization) }
-  let!(:user) { create(:user, :admin, :confirmed, organization: organization, email: "admin@decidim.org") }
+  let!(:user) { create(:user, :admin, :confirmed, organization: organization, email: "admin@example.org") }
   let(:participatory_process) { create(:participatory_process, :with_steps, organization: organization) }
   let(:process_admin) { create :user, :confirmed, organization: organization }
   let!(:user_role) { create :participatory_process_user_role, user: process_admin, participatory_process: participatory_process }

--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -29,7 +29,7 @@ if !Rails.env.production? || ENV["SEED"]
 
   Decidim::User.create!(
     name: Faker::Name.name,
-    email: "admin@decidim.org",
+    email: "admin@example.org",
     password: "decidim123456",
     password_confirmation: "decidim123456",
     organization: organization,
@@ -43,7 +43,7 @@ if !Rails.env.production? || ENV["SEED"]
 
   Decidim::User.create!(
     name: Faker::Name.name,
-    email: "collaborator@decidim.org",
+    email: "collaborator@example.org",
     password: "decidim123456",
     password_confirmation: "decidim123456",
     organization: organization,
@@ -57,7 +57,7 @@ if !Rails.env.production? || ENV["SEED"]
 
   Decidim::User.create!(
     name: Faker::Name.name,
-    email: "user@decidim.org",
+    email: "user@example.org",
     password: "decidim123456",
     password_confirmation: "decidim123456",
     confirmed_at: Time.current,

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
   end
 
   sequence(:email) do |n|
-    "user#{n}@decidim.org"
+    "user#{n}@example.org"
   end
 
   sequence(:slug) do |n|

--- a/decidim-core/spec/commands/decidim/create_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_registration_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
         let(:sign_up_as) { "user" }
         let(:name) { "Username" }
-        let(:email) { "user@decidim.org" }
+        let(:email) { "user@example.org" }
         let(:password) { "password1234" }
         let(:password_confirmation) { password }
         let(:tos_agreement) { "1" }

--- a/decidim-core/spec/controllers/registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/registrations_controller_spec.rb
@@ -4,13 +4,13 @@ require "spec_helper"
 module Decidim
   describe Decidim::Devise::RegistrationsController, type: :controller do
     let(:organization) { create(:organization) }
-    
+
     before do
       @request.env["decidim.current_organization"] = organization
     end
-    
+
     describe "POST create" do
-      let(:email) { "test@decidim.org" }
+      let(:email) { "test@example.org" }
       let(:params) do
         {
           user: {
@@ -18,13 +18,13 @@ module Decidim
             name: "User",
             email: email,
             password: "password1234",
-            password_confirmation: "password1234",            
+            password_confirmation: "password1234",
             tos_agreement: "1",
             newsletter_notifications: "1"
           }
         }
       end
-      
+
       context "when the user created is active for authentication" do
         before do
           expect_any_instance_of(Decidim::User)
@@ -44,10 +44,10 @@ module Decidim
         let(:email) { nil }
 
         it "should render the new template" do
-          post :create, params: params        
+          post :create, params: params
           expect(controller).to render_template "new"
         end
       end
-    end 
+    end
   end
 end

--- a/decidim-core/spec/forms/invite_admin_form_spec.rb
+++ b/decidim-core/spec/forms/invite_admin_form_spec.rb
@@ -19,7 +19,7 @@ module Decidim
 
     let(:attributes) do
       {
-        email: "NewAdmin@Decidim.org",
+        email: "NewAdmin@example.org",
         name: "New Admin",
         invitation_instructions: "invite_admin",
         roles: %w(admin),
@@ -33,12 +33,12 @@ module Decidim
     end
 
     it "downcases the email" do
-      expect(subject.email).to eq("newadmin@decidim.org")
+      expect(subject.email).to eq("newadmin@example.org")
     end
 
     context "when an admin exists for the given email" do
       before do
-        create(:user, :admin, email: "newadmin@decidim.org", organization: current_organization)
+        create(:user, :admin, email: "newadmin@example.org", organization: current_organization)
       end
 
       it { is_expected.to be_invalid }

--- a/decidim-core/spec/forms/registration_form_spec.rb
+++ b/decidim-core/spec/forms/registration_form_spec.rb
@@ -14,7 +14,7 @@ module Decidim
     let(:organization) { create(:organization) }
     let(:sign_up_as) { "user" }
     let(:name) { "User" }
-    let(:email) { "user@decidim.org" }
+    let(:email) { "user@example.org" }
     let(:password) { "password1234" }
     let(:password_confirmation) { password }
     let(:tos_agreement) { "1" }
@@ -48,7 +48,7 @@ module Decidim
     end
 
     context "when the sign_up_as is different from 'user' and 'user_group'" do
-      let(:sign_up_as) { "community" }      
+      let(:sign_up_as) { "community" }
       it { is_expected.to be_invalid }
     end
 
@@ -58,27 +58,27 @@ module Decidim
     end
 
     context "when the email is not present" do
-      let(:email) { nil }      
+      let(:email) { nil }
       it { is_expected.to be_invalid }
     end
-    
+
     context "when the email already exists" do
       let!(:user) { create(:user, organization: organization, email: email) }
       it { is_expected.to be_invalid }
     end
 
     context "when the password is not present" do
-      let(:password) { nil }      
+      let(:password) { nil }
       it { is_expected.to be_invalid }
     end
 
     context "when the password confirmation is different from password" do
-      let(:password_confirmation) { "invalid" }      
+      let(:password_confirmation) { "invalid" }
       it { is_expected.to be_invalid }
     end
 
     context "when the tos_agreement is not accepted" do
-      let(:tos_agreement) { "0" }      
+      let(:tos_agreement) { "0" }
       it { is_expected.to be_invalid }
     end
 
@@ -99,12 +99,12 @@ module Decidim
       end
 
       context "when user_group_document_number is not present" do
-        let(:user_group_document_number) { nil }        
+        let(:user_group_document_number) { nil }
         it { is_expected.to be_invalid }
       end
 
       context "when user_group_phone is not present" do
-        let(:user_group_phone) { nil }        
+        let(:user_group_phone) { nil }
         it { is_expected.to be_invalid }
       end
     end

--- a/decidim-meetings/spec/shared/admin_shared_context.rb
+++ b/decidim-meetings/spec/shared/admin_shared_context.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context "admin" do
   let(:organization) { create(:organization) }
-  let!(:user) { create(:user, :admin, :confirmed, organization: organization, email: "admin@decidim.org") }
+  let!(:user) { create(:user, :admin, :confirmed, organization: organization, email: "admin@example.org") }
   let(:participatory_process) { create(:participatory_process, organization: organization) }
   let(:process_admin) { create :user, :confirmed, organization: organization }
   let!(:user_role) { create :participatory_process_user_role, user: process_admin, participatory_process: participatory_process }

--- a/decidim-proposals/lib/decidim/proposals/feature.rb
+++ b/decidim-proposals/lib/decidim/proposals/feature.rb
@@ -77,7 +77,7 @@ Decidim.register_feature(:proposals) do |feature|
         end
 
         rand(3).times do |m|
-          email = "vote-author-#{process.id}-#{n}-#{m}@decidim.org"
+          email = "vote-author-#{process.id}-#{n}-#{m}@example.org"
           name = "#{Faker::Name.name} #{process.id} #{n} #{m}"
 
           author = Decidim::User.create!(email: email,

--- a/decidim-results/spec/shared/admin_shared_context.rb
+++ b/decidim-results/spec/shared/admin_shared_context.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context "admin" do
   let(:organization) { create(:organization) }
-  let!(:user) { create(:user, :admin, :confirmed, organization: organization, email: "admin@decidim.org") }
+  let!(:user) { create(:user, :admin, :confirmed, organization: organization, email: "admin@example.org") }
   let(:participatory_process) { create(:participatory_process, :with_steps, organization: organization) }
   let(:process_admin) { create :user, :confirmed, organization: organization }
   let!(:user_role) { create :participatory_process_user_role, user: process_admin, participatory_process: participatory_process }

--- a/decidim-system/db/seeds.rb
+++ b/decidim-system/db/seeds.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 if !Rails.env.production? || ENV["SEED"]
   Decidim::System::Admin.create!(
-    email: "system@decidim.org",
+    email: "system@example.org",
     password: "decidim123456",
     password_confirmation: "decidim123456"
   )


### PR DESCRIPTION
#### :tophat: What? Why?
[RFC 2066](https://tools.ietf.org/html/rfc2606) reserves some domains, either top-level and secondary-level, for documentation purposes. This PR uses `example.org` for emails so that everyone understands that these emails do not exist and need to be changed, and are there for documentation/testing purposes.

#### :pushpin: Related Issues
- Fixes #1045

#### :clipboard: Subtasks
None