### PR TITLE
Remove deprecation warning on Rails 5.1

### DIFF
--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -15,7 +15,7 @@ module Decidim
     # right page. If we're on a devise page, we don't want to store that as the
     # place to return to (for example, we don't want to return to the sign in page
     # after signing in), which is what the :unless prevents
-    before_filter :store_current_location, unless: :devise_controller?
+    before_action :store_current_location, unless: :devise_controller?
 
     protect_from_forgery with: :exception, prepend: true
     after_action :add_vary_header


### PR DESCRIPTION
#### :tophat: What? Why?
Remove a deprecation waring in Rails 5.1

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None