### PR TITLE
Fix errors when accepting cookies without JS enabled

### DIFF
--- a/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
+++ b/decidim-core/app/controllers/decidim/cookie_policy_controller.rb
@@ -10,6 +10,11 @@ module Decidim
       response.set_cookie "decidim-cc", value: "true",
                                         path: "/",
                                         expires: 1.year.from_now.utc
+
+      respond_to do |format|
+        format.js
+        format.html { redirect_back fallback_location: root_path }
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
We got these errors:

https://sentry.io/app62347735herokucom/production/issues/226357062/events/5021651910/
https://sentry.io/app62347735herokucom/production/issues/221343068/

```
ActionController::UnknownFormat: Decidim::CookiePolicyController#accept is missing a template for this request format and variant.

request.formats: ["text/html"]
request.variant: []
```

I could reproduce this by disabling JS and accepting the cookies warning. 

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None