### PR TITLE
Fix edit and destroy steps links

### DIFF
--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/show.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/show.html.erb
@@ -2,8 +2,8 @@
 
 <div class="actions">
   <hr />
-  <%= link_to t("decidim.admin.actions.edit"), ['edit', @participatory_process_step] if can? :update, @participatory_process_step %>
-  <%= link_to t("decidim.admin.actions.destroy"), @participatory_process_step, method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } if can? :destroy, @participatory_process_step %>
+  <%= link_to t("decidim.admin.actions.edit"), edit_participatory_process_step_path(participatory_process, @participatory_process_step) if can? :update, @participatory_process_step %>
+  <%= link_to t("decidim.admin.actions.destroy"), participatory_process_step_path(participatory_process, @participatory_process_step), method: :delete, class: "alert button", data: { confirm: t("decidim.admin.actions.confirm_destroy") } if can? :destroy, @participatory_process_step %>
 </div>
 
 <dl>


### PR DESCRIPTION
#### :tophat: What? Why?

Fix admin links for edit and destroy participatory processes steps.

#### :pushpin: Related Issues
- Fixes #1072 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
