### PR TITLE
Ensure devise controllers have the correct Ability class

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
+++ b/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "active_support/concern"
+
+module Decidim
+  # This concern groups methods and helpers needed by Devise controllers.
+  module DeviseControllers
+    extend ActiveSupport::Concern
+
+    included do
+      include Decidim::NeedsOrganization
+      include Decidim::LocaleSwitcher
+
+      include NeedsAuthorization
+      skip_authorization_check
+
+      helper Decidim::TranslationsHelper
+      helper Decidim::MetaTagsHelper
+      helper Decidim::DecidimFormHelper
+      helper Decidim::LanguageChooserHelper
+      helper Decidim::CookiesHelper
+      helper Decidim::ReplaceButtonsHelper
+
+      layout "layouts/decidim/application"
+    end
+  end
+end

--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -12,7 +12,7 @@ module Decidim
     helper Decidim::DecidimFormHelper
 
     layout "layouts/decidim/user_profile", only: [:index]
-    skip_before_filter :store_current_location
+    skip_before_action :store_current_location
 
     def new; end
 

--- a/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
@@ -5,7 +5,9 @@ module Decidim
     class ConfirmationsController < ::Devise::ConfirmationsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+
       include NeedsAuthorization
+      skip_authorization_check
 
       helper Decidim::TranslationsHelper
       helper Decidim::MetaTagsHelper

--- a/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
@@ -3,20 +3,7 @@ module Decidim
   module Devise
     # Custom Devise ConfirmationsController to avoid namespace problems.
     class ConfirmationsController < ::Devise::ConfirmationsController
-      include Decidim::NeedsOrganization
-      include Decidim::LocaleSwitcher
-
-      include NeedsAuthorization
-      skip_authorization_check
-
-      helper Decidim::TranslationsHelper
-      helper Decidim::MetaTagsHelper
-      helper Decidim::DecidimFormHelper
-      helper Decidim::LanguageChooserHelper
-      helper Decidim::CookiesHelper
-      helper Decidim::ReplaceButtonsHelper
-
-      layout "layouts/decidim/application"
+      include Decidim::DeviseControllers
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/confirmations_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     class ConfirmationsController < ::Devise::ConfirmationsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+      include NeedsAuthorization
 
       helper Decidim::TranslationsHelper
       helper Decidim::MetaTagsHelper

--- a/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
@@ -3,20 +3,7 @@ module Decidim
   module Devise
     # This controller customizes the behaviour of Devise::Invitiable.
     class InvitationsController < ::Devise::InvitationsController
-      include Decidim::NeedsOrganization
-      include Decidim::LocaleSwitcher
-
-      include NeedsAuthorization
-      skip_authorization_check
-
-      helper Decidim::TranslationsHelper
-      helper Decidim::MetaTagsHelper
-      helper Decidim::DecidimFormHelper
-      helper Decidim::LanguageChooserHelper
-      helper Decidim::CookiesHelper
-      helper Decidim::ReplaceButtonsHelper
-
-      layout "layouts/decidim/application"
+      include Decidim::DeviseControllers
 
       # We don't users to create invitations, so we just redirect them to the
       # homepage.

--- a/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     class InvitationsController < ::Devise::InvitationsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+      include NeedsAuthorization
 
       helper Decidim::TranslationsHelper
       helper Decidim::MetaTagsHelper

--- a/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/invitations_controller.rb
@@ -5,7 +5,9 @@ module Decidim
     class InvitationsController < ::Devise::InvitationsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+
       include NeedsAuthorization
+      skip_authorization_check
 
       helper Decidim::TranslationsHelper
       helper Decidim::MetaTagsHelper

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -7,7 +7,9 @@ module Decidim
 
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+
       include NeedsAuthorization
+      skip_authorization_check
 
       helper Decidim::TranslationsHelper
       helper Decidim::MetaTagsHelper

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -7,6 +7,7 @@ module Decidim
 
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+      include NeedsAuthorization
 
       helper Decidim::TranslationsHelper
       helper Decidim::MetaTagsHelper

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -4,21 +4,7 @@ module Decidim
     # This controller customizes the behaviour of Devise::Omniauthable.
     class OmniauthRegistrationsController < ::Devise::OmniauthCallbacksController
       include FormFactory
-
-      include Decidim::NeedsOrganization
-      include Decidim::LocaleSwitcher
-
-      include NeedsAuthorization
-      skip_authorization_check
-
-      helper Decidim::TranslationsHelper
-      helper Decidim::MetaTagsHelper
-      helper Decidim::DecidimFormHelper
-      helper Decidim::LanguageChooserHelper
-      helper Decidim::CookiesHelper
-      helper Decidim::ReplaceButtonsHelper
-
-      layout "layouts/decidim/application"
+      include Decidim::DeviseControllers
 
       def new
         @form = form(OmniauthRegistrationForm).from_params(params[:user])

--- a/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
@@ -5,7 +5,9 @@ module Decidim
     class PasswordsController < ::Devise::PasswordsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+
       include NeedsAuthorization
+      skip_authorization_check
 
       helper Decidim::TranslationsHelper
       helper Decidim::MetaTagsHelper

--- a/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     class PasswordsController < ::Devise::PasswordsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+      include NeedsAuthorization
 
       helper Decidim::TranslationsHelper
       helper Decidim::MetaTagsHelper

--- a/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
@@ -3,20 +3,7 @@ module Decidim
   module Devise
     # Custom Devise PasswordsController to avoid namespace problems.
     class PasswordsController < ::Devise::PasswordsController
-      include Decidim::NeedsOrganization
-      include Decidim::LocaleSwitcher
-
-      include NeedsAuthorization
-      skip_authorization_check
-
-      helper Decidim::TranslationsHelper
-      helper Decidim::MetaTagsHelper
-      helper Decidim::DecidimFormHelper
-      helper Decidim::LanguageChooserHelper
-      helper Decidim::CookiesHelper
-      helper Decidim::ReplaceButtonsHelper
-
-      layout "layouts/decidim/application"
+      include Decidim::DeviseControllers
     end
   end
 end

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -6,8 +6,10 @@ module Decidim
     class RegistrationsController < ::Devise::RegistrationsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
-      include NeedsAuthorization
       include FormFactory
+
+      include NeedsAuthorization
+      skip_authorization_check
 
       helper Decidim::TranslationsHelper
       helper Decidim::OmniauthHelper

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -6,6 +6,7 @@ module Decidim
     class RegistrationsController < ::Devise::RegistrationsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+      include NeedsAuthorization
       include FormFactory
 
       helper Decidim::TranslationsHelper

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -4,24 +4,12 @@ module Decidim
     # This controller customizes the behaviour of Devise's
     # RegistrationsController so we can specify a custom layout.
     class RegistrationsController < ::Devise::RegistrationsController
-      include Decidim::NeedsOrganization
-      include Decidim::LocaleSwitcher
       include FormFactory
+      include Decidim::DeviseControllers
 
-      include NeedsAuthorization
-      skip_authorization_check
-
-      helper Decidim::TranslationsHelper
       helper Decidim::OmniauthHelper
-      helper Decidim::MetaTagsHelper
-      helper Decidim::DecidimFormHelper
-      helper Decidim::LanguageChooserHelper
-      helper Decidim::CookiesHelper
-      helper Decidim::ReplaceButtonsHelper
-
       helper_method :terms_and_conditions_page
 
-      layout "layouts/decidim/application"
       before_action :configure_permitted_parameters
       helper_method :terms_and_conditions_page
 

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -3,21 +3,8 @@ module Decidim
   module Devise
     # Custom Devise SessionsController to avoid namespace problems.
     class SessionsController < ::Devise::SessionsController
-      include Decidim::NeedsOrganization
-      include Decidim::LocaleSwitcher
-
-      include NeedsAuthorization
-      skip_authorization_check
-
-      helper Decidim::TranslationsHelper
+      include Decidim::DeviseControllers
       helper Decidim::OmniauthHelper
-      helper Decidim::MetaTagsHelper
-      helper Decidim::DecidimFormHelper
-      helper Decidim::LanguageChooserHelper
-      helper Decidim::CookiesHelper
-      helper Decidim::ReplaceButtonsHelper
-
-      layout "layouts/decidim/application"
 
       def after_sign_in_path_for(user)
         return first_login_authorizations_path if first_login_and_not_authorized?(user) &&

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -5,7 +5,9 @@ module Decidim
     class SessionsController < ::Devise::SessionsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+
       include NeedsAuthorization
+      skip_authorization_check
 
       helper Decidim::TranslationsHelper
       helper Decidim::OmniauthHelper

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -5,6 +5,7 @@ module Decidim
     class SessionsController < ::Devise::SessionsController
       include Decidim::NeedsOrganization
       include Decidim::LocaleSwitcher
+      include NeedsAuthorization
 
       helper Decidim::TranslationsHelper
       helper Decidim::OmniauthHelper


### PR DESCRIPTION
#### :tophat: What? Why?
Adds the `NeedsAuthorization` module to devise controllers

#### :pushpin: Related Issues
- Fixes #1085 

#### :clipboard: Subtasks
None