### PR TITLE
Add share options for processes

### DIFF
--- a/decidim-core/app/views/decidim/participatory_processes/show.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/show.html.erb
@@ -1,6 +1,10 @@
-<% provide :meta_description, translated_attribute(current_participatory_process.short_description) %>
-<% provide :meta_title, translated_attribute(current_participatory_process.title) %>
-<% provide :meta_url, participatory_process_url(current_participatory_process) %>
+<% add_decidim_meta_tags({
+  image_url: current_participatory_process.hero_image.url,
+  description: translated_attribute(current_participatory_process.short_description),
+  title: translated_attribute(current_participatory_process.title),
+  url: participatory_process_url(current_participatory_process),
+  twitter_handler: current_organization.twitter_handler
+}) %>
 
 <div class="row column">
   <div class="row">
@@ -66,5 +70,14 @@
     </div>
   </div>
 
+  <div class="row">
+    <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
+      <%= render partial: "decidim/shared/share_modal" %>
+    </div>
+  </div>
+
   <%= attachments_for current_participatory_process %>
 </div>
+
+<%= javascript_include_tag "decidim/proposals/social_share" %>
+<%= stylesheet_link_tag "decidim/proposals/social_share" %>

--- a/decidim-core/app/views/decidim/shared/_share_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_share_modal.html.erb
@@ -12,11 +12,11 @@
     </button>
   </div>
   <div class="button-group text-center">
-  <%= social_share_button_tag(content_for(:meta_title),
-        url: content_for(:meta_url),
-        image: content_for(:meta_image_url),
-        desc: content_for(:meta_description),
-        via: content_for(:twitter_handler)) %>
+  <%= social_share_button_tag(decidim_page_title,
+        url: decidim_meta_url,
+        image: decidim_meta_image_url,
+        desc: decidim_meta_description,
+        via: decidim_meta_twitter_handler) %>
     <a class="button secondary" data-open="urlShare">
       <%= icon "link-intact" %>
     </a>


### PR DESCRIPTION
#### :tophat: What? Why?
This adds the options for sharing a process and also fixes a small bug on the sharing format.

#### :pushpin: Related Issues
- Fixes #719

### :camera: Screenshots (optional)
The share link gets pushed down because of the details column but I guess that should still be its place for design consitency.

![image](https://cloud.githubusercontent.com/assets/1962966/23742878/eb2be18e-04ae-11e7-9a3e-5b9afbd59515.png)


#### :ghost: GIF
![](https://media.giphy.com/media/RvKfw3vAZFX3i/giphy.gif)
