### PR TITLE
Reuse organization on seeds if found

### DIFF
--- a/decidim-core/db/seeds.rb
+++ b/decidim-core/db/seeds.rb
@@ -2,7 +2,7 @@
 if !Rails.env.production? || ENV["SEED"]
   require "decidim/faker/localized"
 
-  organization = Decidim::Organization.create!(
+  organization = Decidim::Organization.first || Decidim::Organization.create!(
     name: Faker::Company.name,
     twitter_handler: Faker::Hipster.word,
     facebook_handler: Faker::Hipster.word,


### PR DESCRIPTION
#### :tophat: What? Why?
This will reuse a previously existing organization on seeds, if found. This way we can create an organization with the logo & other content before running seeds.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/GGnIMdwJqoAb6/giphy.gif)
