### PR TITLE
Inherit from app's ApplicationController

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/application_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/application_controller.rb
@@ -10,6 +10,7 @@ module Decidim
       helper Decidim::DecidimFormHelper
       helper Decidim::ReplaceButtonsHelper
       helper Decidim::OrganizationScopesHelper
+      helper Decidim::TranslationsHelper
 
       helper Decidim::LanguageChooserHelper
 

--- a/decidim-core/app/controllers/concerns/decidim/user_profile.rb
+++ b/decidim-core/app/controllers/concerns/decidim/user_profile.rb
@@ -13,6 +13,7 @@ module Decidim
     delegate :user_groups, to: :current_user, prefix: false
 
     included do
+      helper Decidim::UserProfileHelper
       layout "layouts/decidim/user_profile"
 
       helper_method :available_authorization_handlers,

--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Decidim
   # The main application controller that inherits from Rails.
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ::ApplicationController
     include Decidim::NeedsOrganization
     include Decidim::LocaleSwitcher
     include NeedsAuthorization
@@ -10,6 +10,9 @@ module Decidim
     helper Decidim::DecidimFormHelper
     helper Decidim::LanguageChooserHelper
     helper Decidim::ReplaceButtonsHelper
+    helper Decidim::TranslationsHelper
+    helper Decidim::CookiesHelper
+    helper Decidim::AriaSelectedLinkToHelper
 
     # Saves the location before loading each page so we can return to the
     # right page. If we're on a devise page, we don't want to store that as the

--- a/decidim-core/app/controllers/decidim/authorizations_controller.rb
+++ b/decidim-core/app/controllers/decidim/authorizations_controller.rb
@@ -10,6 +10,7 @@ module Decidim
 
     include Decidim::UserProfile
     helper Decidim::DecidimFormHelper
+    helper Decidim::AuthorizationFormHelper
 
     layout "layouts/decidim/user_profile", only: [:index]
     skip_before_action :store_current_location

--- a/decidim-core/app/controllers/decidim/features/base_controller.rb
+++ b/decidim-core/app/controllers/decidim/features/base_controller.rb
@@ -11,11 +11,15 @@ module Decidim
       include FeatureSettings
       include ActionAuthorization
 
+      helper Decidim::FiltersHelper
+      helper Decidim::OrdersHelper
+      helper Decidim::FeatureReferenceHelper
       helper Decidim::TranslationsHelper
       helper Decidim::ParticipatoryProcessHelper
       helper Decidim::ResourceHelper
       helper Decidim::OrganizationScopesHelper
       helper Decidim::ActionAuthorizationHelper
+      helper Decidim::AttachmentsHelper
 
       helper_method :current_feature,
                     :current_manifest

--- a/decidim-core/app/controllers/decidim/participatory_process_steps_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_process_steps_controller.rb
@@ -9,6 +9,8 @@ module Decidim
     layout "layouts/decidim/participatory_process", only: [:index]
     include NeedsParticipatoryProcess
 
+    helper Decidim::ParticipatoryProcessHelper
+
     def index
       authorize! :read, ParticipatoryProcess
     end

--- a/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_processes_controller.rb
@@ -11,6 +11,8 @@ module Decidim
 
     skip_after_action :verify_participatory_process, only: [:index]
 
+    helper Decidim::AttachmentsHelper
+    helper Decidim::ParticipatoryProcessHelper
     helper_method :collection, :promoted_participatory_processes, :participatory_processes
 
     def index

--- a/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
@@ -8,6 +8,7 @@ module Decidim
     # Note that it inherits from `Decidim::Components::BaseController`, which
     # override its layout and provide all kinds of useful methods.
     class ApplicationController < Decidim::Features::BaseController
+      helper Decidim::MapHelper
     end
   end
 end

--- a/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
@@ -8,7 +8,7 @@ module Decidim
     # Note that it inherits from `Decidim::Components::BaseController`, which
     # override its layout and provide all kinds of useful methods.
     class ApplicationController < Decidim::Features::BaseController
-      helper Decidim::MapHelper
+      helper Decidim::Meetings::ApplicationHelper
     end
   end
 end

--- a/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
@@ -5,7 +5,7 @@ module Decidim
       # Custom helpers, scoped to the meetings admin engine.
       #
       module ApplicationHelper
-        include Decidim::Meetings::MapHelper
+        helper Decidim::MapHelper
       end
     end
   end

--- a/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/admin/application_helper.rb
@@ -5,7 +5,7 @@ module Decidim
       # Custom helpers, scoped to the meetings admin engine.
       #
       module ApplicationHelper
-        helper Decidim::MapHelper
+        include Decidim::MapHelper
       end
     end
   end

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -5,7 +5,6 @@ module Decidim
     #
     module ApplicationHelper
       include PaginateHelper
-      include Decidim::Meetings::MapHelper
     end
   end
 end

--- a/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
+++ b/decidim-meetings/app/helpers/decidim/meetings/application_helper.rb
@@ -5,6 +5,8 @@ module Decidim
     #
     module ApplicationHelper
       include PaginateHelper
+      include Decidim::MapHelper
+      include Decidim::Meetings::MapHelper
     end
   end
 end

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -8,6 +8,7 @@ module Decidim
       include PaginateHelper
       include ProposalVotesHelper
       include ProposalOrderHelper
+      include Decidim::MapHelper
       include Decidim::Proposals::MapHelper
 
       # Public: The state of a proposal in a way a human can understand.


### PR DESCRIPTION
#### :tophat: What? Why?
This PR tries to solve the problems arisen from #1070:

- We cannot add context to Sentry
- We cannot add context to lograge

This all is due to decidim not using the app's ApplicationHelper. Also, while doing this I found some problems with missing helper `includes`.

#### :pushpin: Related Issues
- Fixes #1070 

#### :clipboard: Subtasks
- [x] Fix tests
