### PR TITLE
Make Decidim inherit from a generated DecidimController

### DIFF
--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Decidim
   # The main application controller that inherits from Rails.
-  class ApplicationController < ::ApplicationController
+  class ApplicationController < ::DecidimController
     include Decidim::NeedsOrganization
     include Decidim::LocaleSwitcher
     include NeedsAuthorization

--- a/lib/generators/decidim/app_generator.rb
+++ b/lib/generators/decidim/app_generator.rb
@@ -50,6 +50,10 @@ module Decidim
         template "database.yml.erb", "config/database.yml", force: true
       end
 
+      def decidim_controller
+        template "decidim_controller.rb.erb", "app/controllers/decidim_controller.rb", force: true
+      end
+
       def docker
         template "Dockerfile.erb", "Dockerfile"
         template "docker-compose.yml.erb", "docker-compose.yml"

--- a/lib/generators/decidim/templates/decidim_controller.rb.erb
+++ b/lib/generators/decidim/templates/decidim_controller.rb.erb
@@ -1,0 +1,5 @@
+# Entry point for Decidim. It will use the `DecidimController` as
+# entry point, but you can change what controller it inherits from
+# so you can customize some methods.
+class DecidimController < ApplicationController
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Once #1099 was merged, @deivid-rodriguez [made us notice](https://github.com/AjuntamentdeBarcelona/decidim/pull/1099#issuecomment-285685176) that inheriting directly from `ApplicationController` might not be the best solution to what we wanted to achieve. In order to fix this, this PR makes the app generator create a `DecidimController` that inherits from `ApplicationController`, but that can be changed as long as the name is kept. This way we add a layer between the application and `decidim`.

#### :pushpin: Related Issues
- Improved #1099 

#### :clipboard: Subtasks
None