### PR TITLE
Update graphql due to a yanked version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ PATH
   specs:
     decidim-api (0.0.5)
       graphiql-rails (~> 1.4.1)
-      graphql (~> 1.5.0)
+      graphql (~> 1.5.1)
       rack-cors (~> 0.4.0)
       rails (~> 5.0.2)
       sprockets-es6 (~> 0.9.2)
@@ -308,7 +308,7 @@ GEM
       activesupport (>= 4.1.0)
     graphiql-rails (1.4.1)
       rails
-    graphql (1.5.0)
+    graphql (1.5.1)
     hashdiff (0.3.2)
     hashie (3.5.5)
     high_voltage (3.0.0)

--- a/decidim-api/decidim-api.gemspec
+++ b/decidim-api/decidim-api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_dependency "rails", *Decidim.rails_version
-  s.add_dependency "graphql", "~> 1.5.0"
+  s.add_dependency "graphql", "~> 1.5.1"
   s.add_dependency "graphiql-rails", "~> 1.4.1"
   s.add_dependency "rack-cors", "~> 0.4.0"
   s.add_dependency "sprockets-es6", "~> 0.9.2"


### PR DESCRIPTION
#### :tophat: What? Why?
Graphql `1.5.0` was yanked - this updates to `1.5.1`.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/2Jl7a8ixNlNHa/giphy.gif)
