### PR TITLE
Use decidim controller only if defined

### DIFF
--- a/decidim-core/app/controllers/decidim/application_controller.rb
+++ b/decidim-core/app/controllers/decidim/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Decidim
   # The main application controller that inherits from Rails.
-  class ApplicationController < ::DecidimController
+  class ApplicationController < Decidim.base_controller
     include Decidim::NeedsOrganization
     include Decidim::LocaleSwitcher
     include NeedsAuthorization

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -142,6 +142,20 @@ module Decidim
     end
   end
 
+  # Public: Returns a base controller class from which to inherit from. If the
+  # user application defines a `DecidimController`, it will be used. This gives
+  # the opportunity to add filters, headers, and any other kind of customization
+  # at the controller level.
+  #
+  # Returns a Class.
+  def self.base_controller
+    @base_controller ||= begin
+                           ::DecidimController
+                         rescue NameError
+                           ActionController::Base
+                         end
+  end
+
   # Private: Stores all the resource manifest across all feature manifest.
   #
   # Returns an Array[ResourceManifest]


### PR DESCRIPTION
#### :tophat: What? Why?
This uses `DecidimController` only if defined. It makes sense that we don't bother the user unless she needs to override behavior. This also eases the upgrade path to early adopters, which is nice.

In any case, new app generations include the `DecidimController` file so the behavior is mostly the same.

#### :pushpin: Related Issues
- Related to #1100

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/RlBtYmW0BGUHS/giphy.gif)
