### PR TITLE
Escape html for social share description

### DIFF
--- a/decidim-core/app/views/decidim/shared/_share_modal.html.erb
+++ b/decidim-core/app/views/decidim/shared/_share_modal.html.erb
@@ -15,7 +15,7 @@
   <%= social_share_button_tag(decidim_page_title,
         url: decidim_meta_url,
         image: decidim_meta_image_url,
-        desc: decidim_meta_description,
+        desc: h(decidim_meta_description),
         via: decidim_meta_twitter_handler) %>
     <a class="button secondary" data-open="urlShare">
       <%= icon "link-intact" %>


### PR DESCRIPTION
#### :tophat: What? Why?

I used the `html_escape` method to escape problematic characters for the description in the social share modal.

#### :pushpin: Related Issues
- Fixes #1118 
- Opened a discussion here https://github.com/huacnlee/social-share-button/issues/129

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
![](https://media.giphy.com/media/bbaCYgmNawbwk/giphy.gif)
