### PR TITLE
Add Decidim.base_uploads_path

### DIFF
--- a/decidim-core/app/uploaders/decidim/application_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/application_uploader.rb
@@ -7,7 +7,10 @@ module Decidim
     # Override the directory where uploaded files will be stored.
     # This is a sensible default for uploaders that are meant to be mounted:
     def store_dir
-      "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      default_path = "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+
+      return File.join(Decidim.base_uploads_path, default_path) if Decidim.base_uploads_path.present?
+      default_path
     end
   end
 end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -96,6 +96,12 @@ module Decidim
   # The number of reports which an object can receive before hiding it
   config_accessor :max_reports_before_hiding { 3 }
 
+  # A base path for the uploads. If set, make sure it ends in a slash.
+  # Uploads will be set to `<base_path>/uploads/`. This can be useful if you
+  # want to use the same uploads place for both staging and production
+  # environments, but in different folders.
+  config_accessor :base_uploads_path { nil }
+
   # Public: Registers a feature, usually held in an external library or in a
   # separate folder in the main repository. Exposes a DSL defined by
   # `Decidim::FeatureManifest`.


### PR DESCRIPTION
#### :tophat: What? Why?
Add `Decidim.base_uploads_path` so that apps can define a base path for uploads. Needed to fix review apps.

#### :pushpin: Related Issues
https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/83

#### :clipboard: Subtasks
None