### PR TITLE
adds badges for accessibility and HTML issues found in Rocket Validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [![Dependency Status](https://img.shields.io/gemnasium/AjuntamentdeBarcelona/decidim.svg)](https://gemnasium.com/github.com/AjuntamentdeBarcelona/decidim)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/decidim/localized.svg)](https://crowdin.com/project/decidim/invite)
 [![Inline docs](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim.svg?branch=master)](http://inch-ci.org/github/AjuntamentdeBarcelona/decidim)
+[![Accessibility issues](https://rocketvalidator.com/badges/a11y_issues.svg?url=https://decidim.barcelona)](https://rocketvalidator.com/badges/link?url=https://decidim.barcelona&report=a11y)
+[![HTML issues](https://rocketvalidator.com/badges/html_issues.svg?url=https://decidim.barcelona)](https://rocketvalidator.com/badges/link?url=https://decidim.barcelona&report=html)
 
 ### Project management [[See on Waffle.io]](https://waffle.io/AjuntamentdeBarcelona/decidim)
 [![Stories in Discussion](https://img.shields.io/waffle/label/AjuntamentdeBarcelona/decidim/discussion.svg)](https://github.com/AjuntamentdeBarcelona/decidim/issues?q=is%3Aopen+is%3Aissue+label%3Adiscussion)


### PR DESCRIPTION
#### :tophat: What? Why?

This adds badges on the README to show the latest accessibility and HTML issues found on https://decidim.barcelona, so that developers can be aware of and fix them.

#### :pushpin: Related Issues
- Related to https://github.com/AjuntamentdeBarcelona/decidim/issues/1116

### :camera: Screenshots (optional)
![Screenshot of badges](https://www.dropbox.com/s/epfxpnlyc913yj2/Captura%20de%20pantalla%202017-03-18%2021.58.23.png?dl=1)

#### :ghost: GIF
![Accessibility matters!](https://3.bp.blogspot.com/-SyqyqCoD3Zg/VraBXb20PRI/AAAAAAAACPs/NW8OyNw2BEU/s1600/Web_Accessibility_Meme2.jpeg)
