### PR TITLE
Add icon link helper

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
@@ -2,11 +2,22 @@
 module Decidim
   module Admin
     module IconLinkHelper
-      def icon_link_to(icon_name, link, title, klass, method, data={})
+      # This helper adds the necessary boilerplate for the admin icon links.
+      # 
+      # icon_name - A String representing the icon name from Iconic
+      #             http://useiconic.com/open
+      # link      - The path or url where the link should point to.
+      # title     - A String that will be shown when hovering the icon.
+      # options   - An optional Hash containing extra data for the link:
+      #             method - Symbol of HTTP verb. Supported verbs are :post, :get, :delete, :patch, and :put.
+      #             class  - Any extra class that will be added to the link.
+      #             data   - This option can be used to add custom data attributes.
+      #
+      def icon_link_to(icon_name, link, title, options = {})
         link_to(link,
-                method: method,
-                class: "action-icon " + klass,
-                data: { tooltip: true, disable_hover: false }.merge(data),
+                method: @options[:method],
+                class: "action-icon " + @options[:class],
+                data: { tooltip: true, disable_hover: false }.merge(@options[:data] || {}),
                 tooltip: true,
                 disable_hover: false,
                 title: title) do
@@ -15,4 +26,3 @@ module Decidim
       end
     end
   end
-end

--- a/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
@@ -2,8 +2,9 @@
 module Decidim
   module Admin
     module IconLinkHelper
-      def icon_link_to(icon_name, link, title, klass, data={})
+      def icon_link_to(icon_name, link, title, klass, method, data={})
         link_to(link,
+                method: method,
                 class: "action-icon " + klass,
                 data: { tooltip: true, disable_hover: false }.merge(data),
                 tooltip: true,

--- a/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Decidim
+  module Admin
+    module IconLinkHelper
+      def icon_link_to(icon_name, link, title, klass)
+        link_to(link,
+                class: "action-icon " + klass,
+                data: { tooltip: true, disable_hover: false },
+                tooltip: true,
+                disable_hover: false,
+                title: title) do
+          icon(icon_name)
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
@@ -2,10 +2,10 @@
 module Decidim
   module Admin
     module IconLinkHelper
-      def icon_link_to(icon_name, link, title, klass)
+      def icon_link_to(icon_name, link, title, klass, data={})
         link_to(link,
                 class: "action-icon " + klass,
-                data: { tooltip: true, disable_hover: false },
+                data: { tooltip: true, disable_hover: false }.merge(data),
                 tooltip: true,
                 disable_hover: false,
                 title: title) do

--- a/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/icon_link_helper.rb
@@ -15,9 +15,9 @@ module Decidim
       #
       def icon_link_to(icon_name, link, title, options = {})
         link_to(link,
-                method: @options[:method],
-                class: "action-icon " + @options[:class],
-                data: { tooltip: true, disable_hover: false }.merge(@options[:data] || {}),
+                method: options[:method],
+                class: "action-icon " + options[:class],
+                data: { tooltip: true, disable_hover: false }.merge(options[:data] || {}),
                 tooltip: true,
                 disable_hover: false,
                 title: title) do
@@ -26,3 +26,4 @@ module Decidim
       end
     end
   end
+end

--- a/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
@@ -9,25 +9,25 @@
   </td>
   <td class="table-list__actions">
     <% if feature.manifest.admin_engine %>
-      <%= icon_link_to "pencil", manage_feature_path(participatory_process, feature), t("actions.manage", scope: "decidim.admin"), "action-icon--manage", :get %>
+      <%= icon_link_to "pencil", manage_feature_path(participatory_process, feature), t("actions.manage", scope: "decidim.admin"), class: "action-icon--manage" %>
     <% end %>
 
     <% if can?(:update, feature) %>
       <% if feature.published? %>
-        <%= icon_link_to "cloud-download", url_for(action: :unpublish, id: feature, controller: "features"), t("actions.unpublish", scope: "decidim.admin"), "action-icon--unpublish", :put %>
+        <%= icon_link_to "cloud-download", url_for(action: :unpublish, id: feature, controller: "features"), t("actions.unpublish", scope: "decidim.admin"), class: "action-icon--unpublish", method: :put %>
       <% else %>
-        <%= icon_link_to "cloud-upload", url_for(action: :publish, id: feature, controller: "features"), t("actions.publish", scope: "decidim.admin"), "action-icon--publish", :put %>
+        <%= icon_link_to "cloud-upload", url_for(action: :publish, id: feature, controller: "features"), t("actions.publish", scope: "decidim.admin"), class: "action-icon--publish", method: :put %>
       <% end %>
     <% end %>
 
     <% if can? :update, feature %>
-      <%= icon_link_to "cog", url_for(action: :edit, id: feature, controller: "features"), t("actions.configure", scope: "decidim.admin"), "action-icon--configure", :get %>
+      <%= icon_link_to "cog", url_for(action: :edit, id: feature, controller: "features"), t("actions.configure", scope: "decidim.admin"), class: "action-icon--configure" %>
     <% end %>
 
     <% if can? :update, feature %>
-      <%= icon_link_to "key", edit_participatory_process_feature_permissions_path(feature_id: feature), t("actions.permissions", scope: "decidim.admin"), "action-icon--permissions", :get %>
+      <%= icon_link_to "key", edit_participatory_process_feature_permissions_path(feature_id: feature), t("actions.permissions", scope: "decidim.admin"), class: "action-icon--permissions" %>
     <% end %>
 
-    <%= icon_link_to "circle-x", url_for(action: :destroy, id: feature, controller: "features"), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete %>
+    <%= icon_link_to "circle-x", url_for(action: :destroy, id: feature, controller: "features"), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete %>
   </td>
 </tr>

--- a/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
@@ -9,25 +9,25 @@
   </td>
   <td class="table-list__actions">
     <% if feature.manifest.admin_engine %>
-      <%= icon_link_to "pencil", manage_feature_path(participatory_process, feature), t("actions.manage", scope: "decidim.admin"), "action-icon--manage" %>
+      <%= icon_link_to "pencil", manage_feature_path(participatory_process, feature), t("actions.manage", scope: "decidim.admin"), "action-icon--manage", :get %>
     <% end %>
 
     <% if can?(:update, feature) %>
       <% if feature.published? %>
-        <%= icon_link_to "cloud-download", url_for(action: :unpublish, id: feature, controller: "features"), t("actions.unpublish", scope: "decidim.admin"), "action-icon--unpublish" %>
+        <%= icon_link_to "cloud-download", url_for(action: :unpublish, id: feature, controller: "features"), t("actions.unpublish", scope: "decidim.admin"), "action-icon--unpublish", :put %>
       <% else %>
-        <%= icon_link_to "cloud-upload", url_for(action: :publish, id: feature, controller: "features"), t("actions.publish", scope: "decidim.admin"), "action-icon--publish" %>
+        <%= icon_link_to "cloud-upload", url_for(action: :publish, id: feature, controller: "features"), t("actions.publish", scope: "decidim.admin"), "action-icon--publish", :put %>
       <% end %>
     <% end %>
 
     <% if can? :update, feature %>
-      <%= icon_link_to "cog", url_for(action: :edit, id: feature, controller: "features"), t("actions.configure", scope: "decidim.admin"), "action-icon--configure" %>
+      <%= icon_link_to "cog", url_for(action: :edit, id: feature, controller: "features"), t("actions.configure", scope: "decidim.admin"), "action-icon--configure", :get %>
     <% end %>
 
     <% if can? :update, feature %>
-      <%= icon_link_to "key", edit_participatory_process_feature_permissions_path(feature_id: feature), t("actions.permissions", scope: "decidim.admin"), "action-icon--permissions" %>
+      <%= icon_link_to "key", edit_participatory_process_feature_permissions_path(feature_id: feature), t("actions.permissions", scope: "decidim.admin"), "action-icon--permissions", :get %>
     <% end %>
 
-    <%= icon_link_to "circle-x", url_for(action: :destroy, id: feature, controller: "features"), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
+    <%= icon_link_to "circle-x", url_for(action: :destroy, id: feature, controller: "features"), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete %>
   </td>
 </tr>

--- a/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
+++ b/decidim-admin/app/views/decidim/admin/features/_feature.html.erb
@@ -9,37 +9,25 @@
   </td>
   <td class="table-list__actions">
     <% if feature.manifest.admin_engine %>
-      <%= link_to manage_feature_path(participatory_process, feature), data: { tooltip: true, disable_hover: false }, title: t("actions.manage", scope: "decidim.admin"), class: "action-icon action-icon--manage" do %>
-        <%= icon "pencil" %>
-      <% end %>
+      <%= icon_link_to "pencil", manage_feature_path(participatory_process, feature), t("actions.manage", scope: "decidim.admin"), "action-icon--manage" %>
     <% end %>
 
     <% if can?(:update, feature) %>
       <% if feature.published? %>
-        <%= link_to url_for(action: :unpublish, id: feature, controller: "features"), data: { tooltip: true, disable_hover: false }, title: t("actions.unpublish", scope: "decidim.admin"), class: "action-icon action-icon--unpublish", method: :put do %>
-          <%= icon "cloud-download" %>
-        <% end %>
+        <%= icon_link_to "cloud-download", url_for(action: :unpublish, id: feature, controller: "features"), t("actions.unpublish", scope: "decidim.admin"), "action-icon--unpublish" %>
       <% else %>
-        <%= link_to url_for(action: :publish, id: feature, controller: "features"), data: { tooltip: true, disable_hover: false }, title: t("actions.publish", scope: "decidim.admin"), class: "action-icon action-icon--publish", method: :put do %>
-          <%= icon "cloud-upload" %>
-        <% end %>
+        <%= icon_link_to "cloud-upload", url_for(action: :publish, id: feature, controller: "features"), t("actions.publish", scope: "decidim.admin"), "action-icon--publish" %>
       <% end %>
     <% end %>
 
     <% if can? :update, feature %>
-      <%= link_to url_for(action: :edit, id: feature, controller: "features"), data: { tooltip: true, disable_hover: false }, title: t("actions.configure", scope: "decidim.admin"), class: "action-icon action-icon--configure" do %>
-        <%= icon "cog" %>
-      <% end %>
+      <%= icon_link_to "cog", url_for(action: :edit, id: feature, controller: "features"), t("actions.configure", scope: "decidim.admin"), "action-icon--configure" %>
     <% end %>
 
     <% if can? :update, feature %>
-      <%= link_to edit_participatory_process_feature_permissions_path(feature_id: feature), data: { tooltip: true, disable_hover: false }, title: t("actions.permissions", scope: "decidim.admin"), class: "action-icon action-icon--permissions" do %>
-        <%= icon "key" %>
-      <% end %>
+      <%= icon_link_to "key", edit_participatory_process_feature_permissions_path(feature_id: feature), t("actions.permissions", scope: "decidim.admin"), "action-icon--permissions" %>
     <% end %>
 
-    <%= link_to url_for(action: :destroy, id: feature, controller: "features"), method: :delete, data: { confirm: t("actions.confirm_destroy"), tooltip: true, disable_hover: false }, aria_haspopup: true, title: t("actions.destroy", scope: "decidim.admin"), class: "action-icon action-icon--remove" do %>
-      <%= icon "circle-x" %>
-    <% end %>
+    <%= icon_link_to "circle-x", url_for(action: :destroy, id: feature, controller: "features"), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
   </td>
 </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
@@ -22,13 +22,13 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, group %>
-                  <%= icon_link_to "pencil", ['edit', group], t("actions.edit", scope: "decidim.admin"), "action-icon--edit" %>
+                  <%= icon_link_to "pencil", ['edit', group], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :put %>
                 <% end %>
 
-                <%= icon_link_to "eye", decidim.participatory_process_group_path(group), t("actions.preview", scope: "decidim.admin"), "action-icon--preview" %>
+                <%= icon_link_to "eye", decidim.participatory_process_group_path(group), t("actions.preview", scope: "decidim.admin"), "action-icon--preview", :get %>
 
                 <% if can? :destroy, group %>
-                  <%= icon_link_to "circle-x", group, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                  <%= icon_link_to "circle-x", group, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
@@ -22,13 +22,13 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, group %>
-                  <%= icon_link_to "pencil", ['edit', group], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :get %>
+                  <%= icon_link_to "pencil", ['edit', group], t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
                 <% end %>
 
-                <%= icon_link_to "eye", decidim.participatory_process_group_path(group), t("actions.preview", scope: "decidim.admin"), "action-icon--preview", :get %>
+                <%= icon_link_to "eye", decidim.participatory_process_group_path(group), t("actions.preview", scope: "decidim.admin"), class: "action-icon--preview" %>
 
                 <% if can? :destroy, group %>
-                  <%= icon_link_to "circle-x", group, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                  <%= icon_link_to "circle-x", group, t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
@@ -28,8 +28,7 @@
                 <%= icon_link_to "eye", decidim.participatory_process_group_path(group), t("actions.preview", scope: "decidim.admin"), "action-icon--preview" %>
 
                 <% if can? :destroy, group %>
-                  <%= icon_link_to "circle-x", group, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
-                    <%# confirm: t("actions.confirm_destroy", scope: "decidim.admin"), %>
+                  <%= icon_link_to "circle-x", group, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
@@ -22,19 +22,14 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, group %>
-                  <%= link_to ['edit', group], data: { tooltip: true, disable_hover: false }, :'aria-haspopup' => true, title: t("actions.edit", scope: "decidim.admin"), class: "action-icon edit" do %>
-                    <%= icon "pencil" %>
-                  <% end %>
+                  <%= icon_link_to "pencil", ['edit', group], t("actions.edit", scope: "decidim.admin"), "action-icon--edit" %>
                 <% end %>
 
-                <%= link_to decidim.participatory_process_group_path(group), data: { tooltip: true, disable_hover: false }, title: t("actions.preview", scope: "decidim.admin"), class: "action-icon preview" do %>
-                  <%= icon "eye" %>
-                <% end %>
+                <%= icon_link_to "eye", decidim.participatory_process_group_path(group), t("actions.preview", scope: "decidim.admin"), "action-icon--preview" %>
 
                 <% if can? :destroy, group %>
-                  <%= link_to group, method: :delete, class: "small alert button", data: { tooltip: true, disable_hover: false, confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, title: t("actions.destroy", scope: "decidim.admin"), class: "action-icon action-icon--remove" do %>
-                    <%= icon "circle-x" %>
-                  <% end %>
+                  <%= icon_link_to "circle-x", group, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
+                    <%# confirm: t("actions.confirm_destroy", scope: "decidim.admin"), %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_groups/index.html.erb
@@ -22,7 +22,7 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, group %>
-                  <%= icon_link_to "pencil", ['edit', group], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :put %>
+                  <%= icon_link_to "pencil", ['edit', group], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :get %>
                 <% end %>
 
                 <%= icon_link_to "eye", decidim.participatory_process_group_path(group), t("actions.preview", scope: "decidim.admin"), "action-icon--preview", :get %>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
@@ -41,21 +41,15 @@
                 </td>
                 <td class="table-list__actions">
                   <% if can?(:activate, step) && !step.active? %>
-                    <%= link_to  participatory_process_step_activate_path(participatory_process, step), method: :post, class: "action-icon action-icon--activate", data: { tooltip: true,  disable_hover: false }, title: t("actions.activate", scope: "decidim.admin") do %>
-                      <%= icon "circle-check" %>
-                    <% end %>
+                    <%= icon_link_to "circle-check", participatory_process_step_activate_path(participatory_process, step), t("actions.activate", scope: "decidim.admin"), "action-icon--activate" %>
                   <% end %>
 
                   <% if can? :update, step %>
-                    <%= link_to edit_participatory_process_step_path(participatory_process, step), class: "action-icon action-icon--edit", data: { tooltip: true,  disable_hover: false }, title: t("actions.edit", scope: "decidim.admin") do %>
-                      <%= icon "pencil" %>
-                    <% end %>
+                    <%= icon_link_to "pencil", edit_participatory_process_step_path(participatory_process, step), t("actions.edit", scope: "decidim.admin"), "action-icon--edit" %>
                   <% end %>
 
                   <% if can? :destroy, step %>
-                    <%= link_to participatory_process_step_path(participatory_process, step), method: :delete, class: "action-icon action-icon--remove", data: { confirm: t("actions.confirm_destroy", tooltip: true, disable_hover: false ), :'aria_haspopup' =>  true, title: t("actions.destroy", scope: "decidim.admin") } do%>
-                      <%= icon "circle-x" %>
-                    <% end %>
+                    <%= icon_link_to "circle-x", participatory_process_step_path(participatory_process, step), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
                   <% end %>
                 </td>
               </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
@@ -41,15 +41,15 @@
                 </td>
                 <td class="table-list__actions">
                   <% if can?(:activate, step) && !step.active? %>
-                    <%= icon_link_to "circle-check", participatory_process_step_activate_path(participatory_process, step), t("actions.activate", scope: "decidim.admin"), "action-icon--activate" %>
+                    <%= icon_link_to "circle-check", participatory_process_step_activate_path(participatory_process, step), t("actions.activate", scope: "decidim.admin"), "action-icon--activate", :put %>
                   <% end %>
 
                   <% if can? :update, step %>
-                    <%= icon_link_to "pencil", edit_participatory_process_step_path(participatory_process, step), t("actions.edit", scope: "decidim.admin"), "action-icon--edit" %>
+                    <%= icon_link_to "pencil", edit_participatory_process_step_path(participatory_process, step), t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :put %>
                   <% end %>
 
                   <% if can? :destroy, step %>
-                    <%= icon_link_to "circle-x", participatory_process_step_path(participatory_process, step), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                    <%= icon_link_to "circle-x", participatory_process_step_path(participatory_process, step), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, :delete %>
                   <% end %>
                 </td>
               </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
@@ -41,15 +41,15 @@
                 </td>
                 <td class="table-list__actions">
                   <% if can?(:activate, step) && !step.active? %>
-                    <%= icon_link_to "circle-check", participatory_process_step_activate_path(participatory_process, step), t("actions.activate", scope: "decidim.admin"), "action-icon--activate", :post %>
+                    <%= icon_link_to "circle-check", participatory_process_step_activate_path(participatory_process, step), t("actions.activate", scope: "decidim.admin"), class: "action-icon--activate", method: :post %>
                   <% end %>
 
                   <% if can? :update, step %>
-                    <%= icon_link_to "pencil", edit_participatory_process_step_path(participatory_process, step), t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :get %>
+                    <%= icon_link_to "pencil", edit_participatory_process_step_path(participatory_process, step), t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
                   <% end %>
 
                   <% if can? :destroy, step %>
-                    <%= icon_link_to "circle-x", participatory_process_step_path(participatory_process, step), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                    <%= icon_link_to "circle-x", participatory_process_step_path(participatory_process, step), t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                   <% end %>
                 </td>
               </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
@@ -41,15 +41,15 @@
                 </td>
                 <td class="table-list__actions">
                   <% if can?(:activate, step) && !step.active? %>
-                    <%= icon_link_to "circle-check", participatory_process_step_activate_path(participatory_process, step), t("actions.activate", scope: "decidim.admin"), "action-icon--activate", :put %>
+                    <%= icon_link_to "circle-check", participatory_process_step_activate_path(participatory_process, step), t("actions.activate", scope: "decidim.admin"), "action-icon--activate", :post %>
                   <% end %>
 
                   <% if can? :update, step %>
-                    <%= icon_link_to "pencil", edit_participatory_process_step_path(participatory_process, step), t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :put %>
+                    <%= icon_link_to "pencil", edit_participatory_process_step_path(participatory_process, step), t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :get %>
                   <% end %>
 
                   <% if can? :destroy, step %>
-                    <%= icon_link_to "circle-x", participatory_process_step_path(participatory_process, step), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, :delete %>
+                    <%= icon_link_to "circle-x", participatory_process_step_path(participatory_process, step), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                   <% end %>
                 </td>
               </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_process_steps/index.html.erb
@@ -49,7 +49,7 @@
                   <% end %>
 
                   <% if can? :destroy, step %>
-                    <%= icon_link_to "circle-x", participatory_process_step_path(participatory_process, step), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
+                    <%= icon_link_to "circle-x", participatory_process_step_path(participatory_process, step), t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                   <% end %>
                 </td>
               </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
@@ -38,11 +38,11 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, process %>
-                  <%= icon_link_to "pencil", edit_participatory_process_path(process), t("actions.configure", scope: "decidim.admin"), "action-icon--new" %>
+                  <%= icon_link_to "pencil", edit_participatory_process_path(process), t("actions.configure", scope: "decidim.admin"), "action-icon--new", :put %>
                 <% end %>
 
                 <% if can? :preview, process %>
-                  <%= icon_link_to "eye", decidim.participatory_process_path(process), t("actions.preview", scope: "decidim.admin"), "action-icon--preview" %>
+                  <%= icon_link_to "eye", decidim.participatory_process_path(process), t("actions.preview", scope: "decidim.admin"), "action-icon--preview", :get %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
@@ -38,14 +38,11 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, process %>
-                  <%= link_to edit_participatory_process_path(process), class: "action-icon action-icon--new", data: { tooltip: true, disable_hover: false }, aria_haspopup: true, title: t("actions.configure", scope: "decidim.admin") do %>
-                    <%= icon "pencil" %>
-                  <% end %>
+                  <%= icon_link_to "pencil", edit_participatory_process_path(process), t("actions.configure", scope: "decidim.admin"), "action-icon--new" %>
                 <% end %>
+
                 <% if can? :preview, process %>
-                  <%= link_to decidim.participatory_process_path(process), class: "action-icon action-icon--preview", data: { tooltip: true, disable_hover: false }, aria_haspopup: true, title: t("actions.preview", scope: "decidim.admin") do %>
-                    <%= icon "eye" %>
-                  <% end %>
+                  <%= icon_link_to "eye", decidim.participatory_process_path(process), t("actions.preview", scope: "decidim.admin"), "action-icon--preview" %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_processes/index.html.erb
@@ -38,11 +38,11 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, process %>
-                  <%= icon_link_to "pencil", edit_participatory_process_path(process), t("actions.configure", scope: "decidim.admin"), "action-icon--new", :put %>
+                  <%= icon_link_to "pencil", edit_participatory_process_path(process), t("actions.configure", scope: "decidim.admin"), class: "action-icon--new", method: :put %>
                 <% end %>
 
                 <% if can? :preview, process %>
-                  <%= icon_link_to "eye", decidim.participatory_process_path(process), t("actions.preview", scope: "decidim.admin"), "action-icon--preview", :get %>
+                  <%= icon_link_to "eye", decidim.participatory_process_path(process), t("actions.preview", scope: "decidim.admin"), class: "action-icon--preview" %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
@@ -23,11 +23,11 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, scope %>
-                  <%= icon_link_to "pencil", ['edit', scope], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :put %>
+                  <%= icon_link_to "pencil", ['edit', scope], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :get %>
                 <% end %>
 
                 <% if can? :destroy, scope %>
-                  <%= icon_link_to "circle-x", scope, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, :delete %>
+                  <%= icon_link_to "circle-x", scope, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
@@ -23,15 +23,12 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, scope %>
-                  <%= link_to ['edit', scope], class: "action-icon edit", data: { tooltip: true,  disable_hover: false }, title: t("actions.edit", scope: "decidim.admin") do %>
-                    <%= icon "pencil" %>
-                  <% end %>
+                  <%= icon_link_to "pencil", ['edit', scope], t("actions.edit", scope: "decidim.admin"), "action-icon--edit" %>
                 <% end %>
 
                 <% if can? :destroy, scope %>
-                  <%= link_to scope, method: :delete, class: "action-icon action-icon--remove", data: { confirm: t("actions.confirm_destroy", tooltip: true, aria_haspopup: true, disable_hover: false ), title: t("actions.destroy", scope: "decidim.admin") } do %>
-                    <%= icon "circle-x" %>
-                  <% end %>
+                  <%= icon_link_to "circle-x", scope, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
+                  <%# data: { confirm: t("actions.confirm_destroy", tooltip: true, aria_haspopup: true, disable_hover: false ), %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
@@ -27,8 +27,7 @@
                 <% end %>
 
                 <% if can? :destroy, scope %>
-                  <%= icon_link_to "circle-x", scope, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
-                  <%# data: { confirm: t("actions.confirm_destroy", tooltip: true, aria_haspopup: true, disable_hover: false ), %>
+                  <%= icon_link_to "circle-x", scope, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
@@ -23,11 +23,11 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, scope %>
-                  <%= icon_link_to "pencil", ['edit', scope], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :get %>
+                  <%= icon_link_to "pencil", ['edit', scope], t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit", method: :get, data: {} %>
                 <% end %>
 
                 <% if can? :destroy, scope %>
-                  <%= icon_link_to "circle-x", scope, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                  <%= icon_link_to "circle-x", scope, t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
@@ -23,11 +23,11 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, scope %>
-                  <%= icon_link_to "pencil", ['edit', scope], t("actions.edit", scope: "decidim.admin"), "action-icon--edit" %>
+                  <%= icon_link_to "pencil", ['edit', scope], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :put %>
                 <% end %>
 
                 <% if can? :destroy, scope %>
-                  <%= icon_link_to "circle-x", scope, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                  <%= icon_link_to "circle-x", scope, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, :delete %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
@@ -23,13 +23,13 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, page %>
-                  <%= icon_link_to "pencil", ['edit', page], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :put %>
+                  <%= icon_link_to "pencil", ['edit', page], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :get %>
                 <% end %>
 
                 <%= icon_link_to "eye", decidim.page_path(page), t("actions.view", scope: "decidim.admin.static_pages"), "action-icon--preview", :get %>
 
                 <% if can? :destroy, page %>
-                  <%= icon_link_to "circle-x", page, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, :delete %>
+                  <%= icon_link_to "circle-x", page, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
@@ -23,19 +23,14 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, page %>
-                  <%= link_to ['edit', page], data: { tooltip: true, disable_hover: false }, :'aria-haspopup' => true, title: t("actions.edit", scope: "decidim.admin"), class: "action-icon edit" do %>
-                    <%= icon "pencil" %>
-                  <% end %>
+                  <%= icon_link_to "pencil", ['edit', page], t("actions.edit", scope: "decidim.admin"), "action-icon--edit" %>
                 <% end %>
 
-                <%= link_to decidim.page_path(page), data: { tooltip: true, disable_hover: false }, title: t("actions.view", scope: "decidim.admin.static_pages"), class: "action-icon preview" do %>
-                  <%= icon "eye" %>
-                <% end %>
+                <%= icon_link_to "eye", decidim.page_path(page), t("actions.view", scope: "decidim.admin.static_pages"), "action-icon--preview" %>
 
                 <% if can? :destroy, page %>
-                  <%= link_to page, method: :delete, data: { tooltip: true, disable_hover: false, confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, title: t("actions.destroy", scope: "decidim.admin"), class: "action-icon action-icon--remove" do %>
-                    <%= icon "circle-x" %>
-                  <% end %>
+                  <%= icon_link_to "circle-x", page, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
+                  <%# confirm: t("actions.confirm_destroy", scope: "decidim.admin") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
@@ -29,8 +29,7 @@
                 <%= icon_link_to "eye", decidim.page_path(page), t("actions.view", scope: "decidim.admin.static_pages"), "action-icon--preview" %>
 
                 <% if can? :destroy, page %>
-                  <%= icon_link_to "circle-x", page, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
-                  <%# confirm: t("actions.confirm_destroy", scope: "decidim.admin") %>
+                  <%= icon_link_to "circle-x", page, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
@@ -23,13 +23,13 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, page %>
-                  <%= icon_link_to "pencil", ['edit', page], t("actions.edit", scope: "decidim.admin"), "action-icon--edit" %>
+                  <%= icon_link_to "pencil", ['edit', page], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :put %>
                 <% end %>
 
-                <%= icon_link_to "eye", decidim.page_path(page), t("actions.view", scope: "decidim.admin.static_pages"), "action-icon--preview" %>
+                <%= icon_link_to "eye", decidim.page_path(page), t("actions.view", scope: "decidim.admin.static_pages"), "action-icon--preview", :get %>
 
                 <% if can? :destroy, page %>
-                  <%= icon_link_to "circle-x", page, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                  <%= icon_link_to "circle-x", page, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, :delete %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/index.html.erb
@@ -23,13 +23,13 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, page %>
-                  <%= icon_link_to "pencil", ['edit', page], t("actions.edit", scope: "decidim.admin"), "action-icon--edit", :get %>
+                  <%= icon_link_to "pencil", ['edit', page], t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit" %>
                 <% end %>
 
-                <%= icon_link_to "eye", decidim.page_path(page), t("actions.view", scope: "decidim.admin.static_pages"), "action-icon--preview", :get %>
+                <%= icon_link_to "eye", decidim.page_path(page), t("actions.view", scope: "decidim.admin.static_pages"), class: "action-icon--preview" %>
 
                 <% if can? :destroy, page %>
-                  <%= icon_link_to "circle-x", page, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                  <%= icon_link_to "circle-x", page, t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -42,11 +42,11 @@
               <td><%= l user.created_at, format: :short %></td>
               <td class="table-list__actions">
                 <% if can?(:invite, user) && user.invited_to_sign_up? %>
-                  <%= icon_link_to "reload", ['resend_invitation', user], t("actions.resend_invitation", scope: "decidim.admin"), "resend-invitation" %>
+                  <%= icon_link_to "reload", ['resend_invitation', user], t("actions.resend_invitation", scope: "decidim.admin"), "resend-invitation", :put %>
                 <% end %>
 
                 <% if can? :destroy, user %>
-                  <%= icon_link_to "circle-x", user, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                  <%= icon_link_to "circle-x", user, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, :delete %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -42,15 +42,12 @@
               <td><%= l user.created_at, format: :short %></td>
               <td class="table-list__actions">
                 <% if can?(:invite, user) && user.invited_to_sign_up? %>
-                  <%= link_to ['resend_invitation', user], method: :post, data: { tooltip: true, disable_hover: false }, :'aria-haspopup' => true, title: t("actions.resend_invitation", scope: "decidim.admin"), class: "action-icon resend-invitation" do %>
-                    <%= icon "reload" %>
-                  <% end %>
+                  <%= icon_link_to "reload", ['resend_invitation', user], t("actions.resend_invitation", scope: "decidim.admin"), "resend-invitation" %>
                 <% end %>
 
                 <% if can? :destroy, user %>
-                  <%= link_to user, method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin"), tooltip: true, disable_hover: false }, :'aria-haspopup' => true, title: t("actions.destroy", scope: "decidim.admin"), class: "action-icon action-icon--remove" do %>
-                    <%= icon "circle-x" %>
-                  <% end %>
+                  <%= icon_link_to "circle-x", user, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
+                  <%# confirm: t("actions.confirm_destroy", scope: "decidim.admin") %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -42,11 +42,11 @@
               <td><%= l user.created_at, format: :short %></td>
               <td class="table-list__actions">
                 <% if can?(:invite, user) && user.invited_to_sign_up? %>
-                  <%= icon_link_to "reload", ['resend_invitation', user], t("actions.resend_invitation", scope: "decidim.admin"), "resend-invitation", :post %>
+                  <%= icon_link_to "reload", ['resend_invitation', user], t("actions.resend_invitation", scope: "decidim.admin"), class: "resend-invitation", method: :post %>
                 <% end %>
 
                 <% if can? :destroy, user %>
-                  <%= icon_link_to "circle-x", user, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                  <%= icon_link_to "circle-x", user, t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -42,11 +42,11 @@
               <td><%= l user.created_at, format: :short %></td>
               <td class="table-list__actions">
                 <% if can?(:invite, user) && user.invited_to_sign_up? %>
-                  <%= icon_link_to "reload", ['resend_invitation', user], t("actions.resend_invitation", scope: "decidim.admin"), "resend-invitation", :put %>
+                  <%= icon_link_to "reload", ['resend_invitation', user], t("actions.resend_invitation", scope: "decidim.admin"), "resend-invitation", :post %>
                 <% end %>
 
                 <% if can? :destroy, user %>
-                  <%= icon_link_to "circle-x", user, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") }, :delete %>
+                  <%= icon_link_to "circle-x", user, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", :delete, { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -46,8 +46,7 @@
                 <% end %>
 
                 <% if can? :destroy, user %>
-                  <%= icon_link_to "circle-x", user, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove" %>
-                  <%# confirm: t("actions.confirm_destroy", scope: "decidim.admin") %>
+                  <%= icon_link_to "circle-x", user, t("actions.destroy", scope: "decidim.admin"), "action-icon--remove", { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
                 <% end %>
               </td>
             </tr>

--- a/decidim-admin/config/i18n-tasks.yml
+++ b/decidim-admin/config/i18n-tasks.yml
@@ -95,6 +95,7 @@ ignore_unused:
  - activemodel.attributes.*
  - decidim.admin.participatory_process_steps.default_title
  - activemodel.errors.messages.*
+ - actions.confirm_destroy
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/decidim-admin/spec/features/admin_manages_organization_scopes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_scopes_spec.rb
@@ -46,7 +46,7 @@ describe "Organization scopes", type: :feature do
 
       it "can edit them" do
         within find("tr", text: scope.name) do
-          page.find('a.action-icon.edit').click
+          page.find('a.action-icon.action-icon--edit').click
         end
 
         within ".edit_scope" do

--- a/decidim-admin/spec/features/admin_manages_participatory_process_groups_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_process_groups_spec.rb
@@ -56,7 +56,7 @@ describe "Admin manage participatory process groups", type: :feature do
 
     it "can edit them" do
       within find("tr", text: participatory_process_group.name["en"]) do
-        page.find('.action-icon.edit').click
+        page.find('.action-icon.action-icon--edit').click
       end
 
       within ".edit_participatory_process_group" do
@@ -92,7 +92,7 @@ describe "Admin manage participatory process groups", type: :feature do
 
     it "can destroy them" do
       within find("tr", text: participatory_process_group.name["en"]) do
-        page.find('.action-icon.action-icon--remove').click        
+        page.find('.action-icon.action-icon--remove').click
       end
 
       within ".callout-wrapper" do

--- a/decidim-admin/spec/features/static_pages_spec.rb
+++ b/decidim-admin/spec/features/static_pages_spec.rb
@@ -79,7 +79,7 @@ describe "Content pages", type: :feature do
 
       it "can edit them" do
         within find("tr", text: translated(decidim_page.title)) do
-          page.find('.action-icon.edit').click
+          page.find('.action-icon.action-icon--edit').click
         end
 
         within ".edit_static_page" do
@@ -126,7 +126,7 @@ describe "Content pages", type: :feature do
 
       it "can visit them" do
         within find("tr", text: translated(decidim_page.title)) do
-          page.find('.action-icon.preview').click
+          page.find('.action-icon.action-icon--preview').click
         end
 
         expect(page).to have_content(translated(decidim_page.title))


### PR DESCRIPTION
#### :tophat: What? Why?
This adds a helper to create icon links in a more easy way, right now it is quite tedious to add an icon link. This should improve the dev experience.

I intend to update all the existing icons in the admin in this PR as well.

#### :pushpin: Related Issues
- Related to #1101

* [x] Use helper in existing links
* [x] Add methods
* [x] Add optional data

#### :ghost: GIF
![](https://media.giphy.com/media/HRBGF8jusON0c/giphy.gif)
