### PR TITLE
Removing rails_12factor gem from Gemfile template

### DIFF
--- a/lib/generators/decidim/templates/Gemfile.erb
+++ b/lib/generators/decidim/templates/Gemfile.erb
@@ -34,9 +34,5 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-group :production do
-  gem "rails_12factor"
-end
-
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
#### :tophat: What? Why?
Removes rails_12factor, no longer necessary on Rails 5: https://github.com/heroku/rails_12factor#new-rails-5-apps

>     New Rails 5 Apps
>     If you are starting a new application with Rails 5, you do not need this gem.

#### :pushpin: Related Issues
- Fixes #1095 

#### :ghost: GIF
![](https://media.giphy.com/media/vzBrf0TsVEcpO/giphy.gif)
