### PR TITLE
Correctly show rich text for proposal answers

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -57,7 +57,7 @@
         <div class="section">
           <div class="callout success">
             <h5><%= t(".proposal_accepted_reason") %></h5>
-            <p><%= translated_attribute @proposal.answer %></p>
+            <p><%== translated_attribute @proposal.answer %></p>
           </div>
         </div>
       <% else %>


### PR DESCRIPTION
#### :tophat: What? Why?
Correctly handles the HTML-rich proposal answers, so that no HTML is shown in plain text and it is correctly rendered.

See the report here: https://github.com/AjuntamentdeBarcelona/decidim/issues/875#issuecomment-288701983

#### :pushpin: Related Issues
- Fixes #875

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/bU6womd.png)
