### PR TITLE
Fix moderations admin title

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -277,7 +277,7 @@ en:
             users_count: Users count
       moderations:
         index:
-          title: Title
+          title: Moderations
       newsletters:
         create:
           error: There's been an error creating this newsletter.


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the Moderations Admin section title for English, Catalan and Spanish.

#### :pushpin: Related Issues
- Fixes #1167 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/kU9U3mq.png)
