### PR TITLE
Update process header layout

### DIFF
--- a/decidim-core/app/models/decidim/participatory_process.rb
+++ b/decidim-core/app/models/decidim/participatory_process.rb
@@ -81,5 +81,9 @@ module Decidim
     def documents
       @documents ||= attachments.select(&:document?)
     end
+
+    def hashtag
+      attributes["hashtag"].to_s.gsub("#", "")
+    end
   end
 end

--- a/decidim-core/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_process_header.html.erb
@@ -3,17 +3,19 @@
        style="background-image:url(<%= current_participatory_process.banner_image.url %>);">
     <div class="process-header__container row">
       <div class="columns mediumlarge-9 process-header__info">
-        <h1 class="text-highlight heading2">
-          <%= translated_attribute(current_participatory_process.title) %>
-        </h1>
-      </div>
-      <div class="show-for-medium">
-        <h2 class="text-highlight heading-small">
-          <span class="process-header__hashtag">
-            <%= current_participatory_process.hashtag %>
-          </span>
-          <%= translated_attribute(current_participatory_process.subtitle) %>
-        </h2>
+        <div>
+          <h1 class="text-highlight heading2">
+            <%= translated_attribute(current_participatory_process.title) %>
+          </h1>
+        </div>
+        <div>
+          <h2 class="text-highlight heading-small">
+            <span class="process-header__hashtag">
+              <%= current_participatory_process.hashtag %>
+            </span>
+            <%= translated_attribute(current_participatory_process.subtitle) %>
+          </h2>
+        </div>
       </div>
       <%= render partial: "layouts/decidim/process_header_steps", locals: { participatory_process: current_participatory_process } %>
     </div>

--- a/decidim-core/app/views/layouts/decidim/_process_header.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_process_header.html.erb
@@ -10,9 +10,11 @@
         </div>
         <div>
           <h2 class="text-highlight heading-small">
-            <span class="process-header__hashtag">
-              <%= current_participatory_process.hashtag %>
-            </span>
+            <% if current_participatory_process.hashtag.present? %>
+              <span class="process-header__hashtag">
+                <%= link_to "##{current_participatory_process.hashtag}", "https://twitter.com/hashtag/#{current_participatory_process.hashtag}" %>
+              </span>
+            <% end %>
             <%= translated_attribute(current_participatory_process.subtitle) %>
           </h2>
         </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the process header layout. The problems were due to the design having two different layouts for this same section, depending if you were at the process show page or at the steps index page. I've opened an issue at decidim-design (https://github.com/AjuntamentdeBarcelona/decidim-design/issues/151) in order to discuss this, but this PR will fix the weird positioning of the elements.

#### :pushpin: Related Issues
- Fixes #1166 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
Desktop version:

![Description](https://i.imgur.com/AdZuhgG.png)

Mobile version:

![](https://i.imgur.com/trija1s.png)