### PR TITLE
Add category select prompt

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_filters.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   <% if current_feature.categories.any? %>
-    <%= form.categories_select :category_id, current_feature.categories, legend_title: t('.category'), disable_parents: false, label: false, include_blank: true %>
+    <%= form.categories_select :category_id, current_feature.categories, legend_title: t('.category'), disable_parents: false, label: false, prompt: t('.category_prompt')  %>
   <% end %>
 
   <%= form.hidden_field :random_seed %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
             other: "%{count} projects"
         filters:
           category: Category
+          category_prompt: Select a category
           scopes: Scopes
           search: Search
         filters_small_view:

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_filters.html.erb
@@ -21,6 +21,6 @@
   <% end %>
 
   <% if current_feature.categories.any? %>
-    <%= form.categories_select :category_id, current_feature.categories, legend_title: t(".category"), disable_parents: false, label: false, include_blank: true %>
+    <%= form.categories_select :category_id, current_feature.categories, legend_title: t(".category"), disable_parents: false, label: false, prompt: t('.category_prompt') %>
   <% end %>
 <% end %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
       meetings:
         filters:
           category: Category
+          category_prompt: Select a category
           date: Date
           past: Past
           scopes: Scopes

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_filters.html.erb
@@ -33,7 +33,7 @@
   <% end %>
 
   <% if current_feature.categories.any? %>
-    <%= form.categories_select :category_id, current_feature.categories, legend_title: t('.category'), disable_parents: false, label: false, include_blank: true %>
+    <%= form.categories_select :category_id, current_feature.categories, legend_title: t('.category'), disable_parents: false, label: false, prompt: t('.category_prompt') %>
   <% end %>
 
   <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
           activity: Activity
           all: All
           category: Category
+          category_prompt: Select a category
           citizenship: Citizenship
           official: Official
           origin: Origin

--- a/decidim-results/app/views/decidim/results/results/_filters.html.erb
+++ b/decidim-results/app/views/decidim/results/results/_filters.html.erb
@@ -17,6 +17,6 @@
   <% end %>
 
   <% if current_feature.categories.any? %>
-    <%= form.categories_select :category_id, current_feature.categories, legend_title: t('.category'), disable_parents: false, label: false, include_blank: true %>
+    <%= form.categories_select :category_id, current_feature.categories, legend_title: t('.category'), disable_parents: false, label: false, prompt: t('.category_prompt') %>
   <% end %>
 <% end %>

--- a/decidim-results/config/locales/en.yml
+++ b/decidim-results/config/locales/en.yml
@@ -61,6 +61,7 @@ en:
             other: "%{count} results"
         filters:
           category: Category
+          category_prompt: Select a category
           scopes: Scopes
           search: Search
         filters_small_view:


### PR DESCRIPTION
#### :tophat: What? Why?

We were missing a prompt for category select in `budgets`, `proposals`, `meetings` and `results` filters.

#### :pushpin: Related Issues
- Fixes #1165 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/24349237/a27741d4-12de-11e7-9d2f-7843ec2b08c5.png)

#### :ghost: GIF
![](https://media.giphy.com/media/S52iOJ45N8QPC/giphy.gif)
