### PR TITLE
Validate avatar filesize and dimensions in profile form

### DIFF
--- a/decidim-core/app/commands/decidim/update_account.rb
+++ b/decidim-core/app/commands/decidim/update_account.rb
@@ -18,9 +18,16 @@ module Decidim
       update_avatar
       update_password
 
-      @user.save!
-      @form.remove_avatar = false
-      broadcast(:ok, @user.unconfirmed_email.present?)
+      if @user.valid?
+        @user.save!
+        @form.remove_avatar = false
+        broadcast(:ok, @user.unconfirmed_email.present?)
+      else
+        if @user.errors.has_key? :avatar
+          @form.errors.add :avatar, @user.errors[:avatar]
+        end
+        broadcast(:invalid)
+      end
     end
 
     private

--- a/decidim-core/app/commands/decidim/update_account.rb
+++ b/decidim-core/app/commands/decidim/update_account.rb
@@ -17,8 +17,8 @@ module Decidim
       update_personal_data
       update_avatar
       update_password
-      @user.save!
 
+      @user.save!
       @form.remove_avatar = false
       broadcast(:ok, @user.unconfirmed_email.present?)
     end

--- a/decidim-core/app/controllers/decidim/account_controller.rb
+++ b/decidim-core/app/controllers/decidim/account_controller.rb
@@ -19,10 +19,10 @@ module Decidim
       UpdateAccount.call(current_user, @account) do
         on(:ok) do |_account, unconfirmed_email|
           flash.now[:notice] = if unconfirmed_email
-                                t("account.update.success_with_email_confirmation", scope: "decidim")
-                              else
-                                t("account.update.success", scope: "decidim")
-                              end
+                                 t("account.update.success_with_email_confirmation", scope: "decidim")
+                               else
+                                 t("account.update.success", scope: "decidim")
+                               end
 
           bypass_sign_in(current_user)
         end

--- a/decidim-core/app/controllers/decidim/account_controller.rb
+++ b/decidim-core/app/controllers/decidim/account_controller.rb
@@ -16,24 +16,20 @@ module Decidim
       authorize! :update, current_user
       @account = form(AccountForm).from_params(params)
 
-      begin
-        UpdateAccount.call(current_user, @account) do
-          on(:ok) do |_account, unconfirmed_email|
-            flash.now[:notice] = if unconfirmed_email
-                                  t("account.update.success_with_email_confirmation", scope: "decidim")
-                                else
-                                  t("account.update.success", scope: "decidim")
-                                end
+      UpdateAccount.call(current_user, @account) do
+        on(:ok) do |_account, unconfirmed_email|
+          flash.now[:notice] = if unconfirmed_email
+                                t("account.update.success_with_email_confirmation", scope: "decidim")
+                              else
+                                t("account.update.success", scope: "decidim")
+                              end
 
-            bypass_sign_in(current_user)
-          end
-
-          on(:invalid) do
-            flash.now[:alert] = t("account.update.error", scope: "decidim")
-          end
+          bypass_sign_in(current_user)
         end
-      rescue ActiveRecord::RecordInvalid => msg
-        flash.now[:alert] = msg
+
+        on(:invalid) do
+          flash.now[:alert] = t("account.update.error", scope: "decidim")
+        end
       end
 
       render action: :show

--- a/decidim-core/app/controllers/decidim/account_controller.rb
+++ b/decidim-core/app/controllers/decidim/account_controller.rb
@@ -16,20 +16,24 @@ module Decidim
       authorize! :update, current_user
       @account = form(AccountForm).from_params(params)
 
-      UpdateAccount.call(current_user, @account) do
-        on(:ok) do |_account, unconfirmed_email|
-          flash.now[:notice] = if unconfirmed_email
-                                 t("account.update.success_with_email_confirmation", scope: "decidim")
-                               else
-                                 t("account.update.success", scope: "decidim")
-                               end
+      begin
+        UpdateAccount.call(current_user, @account) do
+          on(:ok) do |_account, unconfirmed_email|
+            flash.now[:notice] = if unconfirmed_email
+                                  t("account.update.success_with_email_confirmation", scope: "decidim")
+                                else
+                                  t("account.update.success", scope: "decidim")
+                                end
 
-          bypass_sign_in(current_user)
-        end
+            bypass_sign_in(current_user)
+          end
 
-        on(:invalid) do
-          flash.now[:alert] = t("account.update.error", scope: "decidim")
+          on(:invalid) do
+            flash.now[:alert] = t("account.update.error", scope: "decidim")
+          end
         end
+      rescue ActiveRecord::RecordInvalid => msg
+        flash.now[:alert] = msg
       end
 
       render action: :show

--- a/decidim-core/app/forms/decidim/account_form.rb
+++ b/decidim-core/app/forms/decidim/account_form.rb
@@ -19,6 +19,7 @@ module Decidim
     validates :password, confirmation: true
     validates :password, length: { in: Decidim::User.password_length, allow_blank: true }
     validates :password_confirmation, presence: true, if: :password_present
+    validates :avatar, file_size: { less_than_or_equal_to: ->(_record) { Decidim::User::MAXIMUM_AVATAR_FILE_SIZE } }
 
     validate :unique_email
 

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -4,6 +4,8 @@ require_dependency "devise/models/decidim_validatable"
 module Decidim
   # A User is a citizen that wants to join the platform to participate.
   class User < ApplicationRecord
+    MAXIMUM_AVATAR_FILE_SIZE = 5.megabytes
+
     devise :invitable, :database_authenticatable, :registerable, :confirmable,
            :recoverable, :rememberable, :trackable, :decidim_validatable,
            :omniauthable, omniauth_providers: [:facebook, :twitter, :google_oauth2]
@@ -19,7 +21,7 @@ module Decidim
     validates :organization, :name, presence: true
     validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }, allow_blank: true
     validates :tos_agreement, acceptance: true, allow_nil: false, on: :create
-    validates :avatar, file_size: { less_than_or_equal_to: 5.megabytes }
+    validates :avatar, file_size: { less_than_or_equal_to: MAXIMUM_AVATAR_FILE_SIZE }
     validates :email, uniqueness: { scope: :organization }
     validate :all_roles_are_valid
     mount_uploader :avatar, Decidim::AvatarUploader

--- a/decidim-core/spec/commands/decidim/update_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_account_spec.rb
@@ -102,6 +102,21 @@ module Decidim
           expect(user.reload.valid_password?("test123")).to eq(true)
         end
       end
+
+      describe "when the avatar dimensions are too big" do
+        let(:message) { "Avatar is too big." }
+        before do
+          expect(user).to receive(:valid?).and_return(false)
+          expect(user).to receive(:errors).and_return({
+            avatar: message
+          }).at_least(:once)
+          allow(form).to receive_message_chain(:errors, :add).with(:avatar, message)
+        end
+
+        it "broadcasts invalid" do
+          expect { command.call }.to broadcast(:invalid)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

An error was raised when the avatar wasn't valid and we were not capturing the exception.

#### :pushpin: Related Issues
- Fixes #1142 

#### :clipboard: Subtasks
- [x] Validate file size
- [x] Validate image dimensions

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/24350328/11b20b80-12e2-11e7-81d5-b741921e7fbf.png)
![image](https://cloud.githubusercontent.com/assets/106021/24351846/a02075c8-12e7-11e7-8c5c-8d79627721b9.png)

#### :ghost: GIF
![](https://media.giphy.com/media/Snil1KvtjhnIQ/giphy.gif)
