### PR TITLE
Avoid deleting banner and home images when updating a participatory process

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_participatory_process.rb
@@ -34,7 +34,7 @@ module Decidim
 
       private
 
-      attr_reader :form
+      attr_reader :form, :participatory_process
 
       def update_participatory_process
         @participatory_process.assign_attributes(attributes)
@@ -47,8 +47,8 @@ module Decidim
           subtitle: form.subtitle,
           slug: form.slug,
           hashtag: form.hashtag,
-          hero_image: form.hero_image,
-          banner_image: form.banner_image,
+          hero_image: form.hero_image || participatory_process.hero_image,
+          banner_image: form.banner_image || participatory_process.banner_image,
           promoted: form.promoted,
           description: form.description,
           short_description: form.short_description,

--- a/decidim-admin/spec/commands/update_participatory_process_spec.rb
+++ b/decidim-admin/spec/commands/update_participatory_process_spec.rb
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# frozen_string_literal: true
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe UpdateParticipatoryProcess, :db do
+      describe "call" do
+        let(:my_process) { create :participatory_process }
+        let(:params) do
+          {
+            participatory_process: {
+              id: my_process.id,
+              title_en: 'Foo title',
+              title_ca: 'Foo title',
+              title_es: 'Foo title',
+              subtitle_en: my_process.subtitle,
+              subtitle_ca: my_process.subtitle,
+              subtitle_es: my_process.subtitle,
+              slug: my_process.slug,
+              hashtag: my_process.hashtag,
+              meta_scope: my_process.meta_scope,
+              hero_image: nil,
+              banner_image: nil,
+              promoted: my_process.promoted,
+              description_en: my_process.description,
+              description_ca: my_process.description,
+              description_es: my_process.description,
+              short_description_en: my_process.short_description,
+              short_description_ca: my_process.short_description,
+              short_description_es: my_process.short_description,
+              current_organization: my_process.organization,
+              scope: my_process.scope,
+              errors: my_process.errors,
+              participatory_process_group: my_process.participatory_process_group
+            }
+          }
+        end
+        let(:context) do
+          { current_organization: my_process.organization }
+        end
+        let(:form) do
+          ParticipatoryProcessForm.from_params(params).with_context(context)
+        end
+        let(:command) { described_class.new(my_process, form) }
+
+        describe "when the form is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(true)
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "doesn't update the participatory process" do
+            command.call
+            my_process.reload
+
+            expect(my_process.title['en']).not_to eq("Foo title")
+          end
+        end
+
+        describe "when the participatory process is not valid" do
+          before do
+            expect(form).to receive(:invalid?).and_return(false)
+            expect(my_process).to receive(:valid?).at_least(:once).and_return(false)
+            my_process.errors.add(:hero_image, "Image too big")
+            my_process.errors.add(:banner_image, "Image too big")
+          end
+
+          it "broadcasts invalid" do
+            expect { command.call }.to broadcast(:invalid)
+          end
+
+          it "adds errors to the form" do
+            command.call
+
+            expect(form.errors[:hero_image]).not_to be_empty
+            expect(form.errors[:banner_image]).not_to be_empty
+          end
+        end
+
+        describe "when the form is valid" do
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "updates the participatory process" do
+            expect { command.call }.to broadcast(:ok)
+            my_process.reload
+
+            expect(my_process.title['en']).to eq("Foo title")
+          end
+
+          context "when no homepage image is set" do
+            it "does not replace the homepage image" do
+              command.call
+              my_process.reload
+
+              expect(my_process.hero_image).to be_present
+            end
+          end
+
+          context "when no banner image is set" do
+            it "does not replace the banner image" do
+              command.call
+              my_process.reload
+
+              expect(my_process.banner_image).to be_present
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_participatory_processes_spec.rb
@@ -70,6 +70,29 @@ describe "Admin manage participatory processes", type: :feature do
     end
   end
 
+  context "updating a participatory process" do
+    let!(:participatory_process3) { create(:participatory_process, organization: organization) }
+
+    before do
+      visit decidim_admin.participatory_processes_path
+    end
+
+    it "update a participatory process without images does not delete them" do
+      click_link translated(participatory_process3.title)
+      click_processes_menu_link "Settings"
+      click_button "Update participatory process"
+
+      within ".flash" do
+        expect(page).to have_content("successfully")
+      end
+
+      within ".tabs-content" do
+        expect(page).to have_css("img[src*='#{participatory_process3.hero_image.url}']")
+        expect(page).to have_css("img[src*='#{participatory_process3.banner_image.url}']")
+      end
+    end
+  end
+
   context "deleting a participatory process" do
     let!(:participatory_process2) { create(:participatory_process, organization: organization) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
When updating a participatory process the banner and home images will get deleted.
That happened because the form sets an uploader input as nil if no file has been uploaded (as it should). The problem is that such nil value was being saved removing previously set image.

#### :pushpin: Related Issues
- Fixes #1153 