### PR TITLE
Add raise exceptions when using I18n.t instead of t

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -35,6 +35,7 @@ require "geocoder"
 require "decidim/api"
 
 require "decidim/query_extensions"
+require "decidim/i18n_exceptions"
 
 module Decidim
   module Core

--- a/decidim-core/lib/decidim/i18n_exceptions.rb
+++ b/decidim-core/lib/decidim/i18n_exceptions.rb
@@ -1,0 +1,15 @@
+unless Rails.env.production?
+  module I18n
+    class JustRaiseExceptionHandler < ExceptionHandler
+      def call(exception, locale, key, options)
+        if exception.is_a?(MissingTranslationData) || exception.is_a?(MissingTranslation)
+          raise exception.to_exception
+        else
+          super
+        end
+      end
+    end
+  end
+
+  I18n.exception_handler = I18n::JustRaiseExceptionHandler.new
+end


### PR DESCRIPTION
#### :tophat: What? Why?

We were having a differnt behavior when using `I18n.t` instead of `t`. The latest was rising exceptions in dev/test environments but the first wasn't.

Following the Rails documentation http://guides.rubyonrails.org/i18n.html#using-different-exception-handlers I added another initializer to handle the first case.

#### :pushpin: Related Issues

#1191 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
![](https://media.giphy.com/media/2YABv8z0Lm5ZC/giphy.gif)
