### PR TITLE
Make ApplicationController inherit from DecidimController at Admin and API engines.

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/application_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/application_controller.rb
@@ -2,7 +2,7 @@
 module Decidim
   module Admin
     # The main application controller that inherits from Rails.
-    class ApplicationController < ActionController::Base
+    class ApplicationController < ::DecidimController
       include NeedsOrganization
       include NeedsAuthorization
       include FormFactory

--- a/decidim-admin/app/controllers/decidim/admin/application_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/application_controller.rb
@@ -8,6 +8,11 @@ module Decidim
       include FormFactory
       include LocaleSwitcher
       include PayloadInfo
+      helper Decidim::Admin::ApplicationHelper
+      helper Decidim::Admin::AttributesDisplayHelper
+      helper Decidim::Admin::FeatureSettingsHelper
+      helper Decidim::Admin::ProcessGroupsForSelectHelper
+      helper Decidim::Admin::ProcessesForSelectHelper
       helper Decidim::DecidimFormHelper
       helper Decidim::ReplaceButtonsHelper
       helper Decidim::OrganizationScopesHelper

--- a/decidim-api/app/controllers/decidim/api/application_controller.rb
+++ b/decidim-api/app/controllers/decidim/api/application_controller.rb
@@ -2,7 +2,7 @@
 module Decidim
   module Api
     # Base controller for `decidim-api`. All other controllers inherit from this.
-    class ApplicationController < ActionController::Base
+    class ApplicationController < ::DecidimController
       include NeedsOrganization
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
We lack of some context in a few bug reports by sentry. This PR fixes this making Admin and API engines from DecidimController which have to configure such service.

#### :pushpin: Related Issues
- Fixes #1187

#### :clipboard: Subtasks
- [x] Update API Engine ApplicationController
- [x] Update Admin Engine ApplicationController