### PR TITLE
Improve generated app's README

### DIFF
--- a/lib/generators/decidim/templates/README.md.erb
+++ b/lib/generators/decidim/templates/README.md.erb
@@ -1,26 +1,26 @@
-# README
+# <%= app_name %>
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+Citizen Participation and Open Govermnment application.
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+This is the open-source repository for <%= app_name %>, based on [Decidim](https://github.com/AjuntamentdeBarcelona/decidim).
 
-Things you may want to cover:
+## Deploying the app
 
-* Ruby version
+An opinionated guide to deploy this app to Heroku can be found at [https://github.com/codegram/decidim-deploy-heroku](https://github.com/codegram/decidim-deploy-heroku).
 
-* System dependencies
+## Setting up the application
 
-* Configuration
+You will need to do some steps before having the app working properly once you've deployed it:
 
-* Database creation
+1. Open a Rails console in the server: `bundle exec rails console`
+1. Create a System Admin user: 
+```ruby
+user = Decidim::System::Admin.new(email: <email>, password: <password>, password_confirmation: <password>)
+user.save!
+```
+1. Visit `<your app url>/system` and login with your system admin credentials
+1. Create a new organization. Check the locales you want to use for that organization, and select a default locale.
+1. Set the correct default host for the organization, otherwise the app will not work properly. Note that you need to include any subdomain you might be using.
+1. Fill the rest of the form and submit it.
 
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+You're good to go!

--- a/lib/generators/decidim/templates/README.md.erb
+++ b/lib/generators/decidim/templates/README.md.erb
@@ -13,14 +13,14 @@ An opinionated guide to deploy this app to Heroku can be found at [https://githu
 You will need to do some steps before having the app working properly once you've deployed it:
 
 1. Open a Rails console in the server: `bundle exec rails console`
-1. Create a System Admin user: 
+2. Create a System Admin user: 
 ```ruby
 user = Decidim::System::Admin.new(email: <email>, password: <password>, password_confirmation: <password>)
 user.save!
 ```
-1. Visit `<your app url>/system` and login with your system admin credentials
-1. Create a new organization. Check the locales you want to use for that organization, and select a default locale.
-1. Set the correct default host for the organization, otherwise the app will not work properly. Note that you need to include any subdomain you might be using.
-1. Fill the rest of the form and submit it.
+3. Visit `<your app url>/system` and login with your system admin credentials
+4. Create a new organization. Check the locales you want to use for that organization, and select a default locale.
+5. Set the correct default host for the organization, otherwise the app will not work properly. Note that you need to include any subdomain you might be using.
+6. Fill the rest of the form and submit it.
 
 You're good to go!


### PR DESCRIPTION
#### :tophat: What? Why?
This PR improves the generated app's README, so that it includes instructions on how to deploy and set up the application.

Can be improved further, but I'd like a basic version merged soon.

#### :pushpin: Related Issues
- Related to #1152

#### :clipboard: Subtasks
None