### PR TITLE
Add pagination on Feature lists in the admin panel.

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
@@ -57,7 +57,7 @@ module Decidim
         private
 
         def projects
-          @projects ||= Project.where(feature: current_feature)
+          @projects ||= Project.where(feature: current_feature).page(params[:page]).per(15)
         end
 
         def orders

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/index.html.erb
@@ -44,6 +44,7 @@
           <% end %>
         </tbody>
       </table>
+      <%= paginate projects, theme: "decidim" %>
     </div>
   </div>
   <div class="card-divider">

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/application_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/application_controller.rb
@@ -11,7 +11,7 @@ module Decidim
         helper_method :meetings, :meeting
 
         def meetings
-          @meetings ||= Meeting.where(feature: current_feature)
+          @meetings ||= Meeting.where(feature: current_feature).page(params[:page]).per(15)
         end
 
         def meeting

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -68,6 +68,7 @@
           <% end %>
         </tbody>
       </table>
+      <%= paginate meetings, theme: "decidim" %>
     </div>
   </div>
 <div>

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -32,7 +32,7 @@ module Decidim
         private
 
         def proposals
-          @proposals ||= Proposal.where(feature: current_feature)
+          @proposals ||= Proposal.where(feature: current_feature).page(params[:page]).per(15)
         end
 
         def proposal

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -57,6 +57,7 @@
           <% end %>
         </tbody>
       </table>
+      <%= paginate proposals, theme: "decidim" %>
     </div>
   </div>
 </div>

--- a/decidim-results/app/controllers/decidim/results/admin/results_controller.rb
+++ b/decidim-results/app/controllers/decidim/results/admin/results_controller.rb
@@ -57,7 +57,7 @@ module Decidim
         private
 
         def results
-          @results ||= Result.where(feature: current_feature)
+          @results ||= Result.where(feature: current_feature).page(params[:page]).per(15)
         end
 
         def result

--- a/decidim-results/app/views/decidim/results/admin/results/index.html.erb
+++ b/decidim-results/app/views/decidim/results/admin/results/index.html.erb
@@ -36,6 +36,7 @@
           <% end %>
         </tbody>
       </table>
+      <%= paginate results, theme: "decidim" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Some feature lists aren't paginated in the admin panel, causing timeouts on deployments with several thousands of them.

#### :pushpin: Related Issues
- Fixes #1197  
- Fixes #1198 
- Fixes #1199 
- Fixes Budgets admin pagination.

### :camera: Screenshots (optional)
<img width="1066" alt="screen shot 2017-03-30 at 15 42 55" src="https://cloud.githubusercontent.com/assets/953911/24507336/757b6e38-1560-11e7-93dd-71c72e96b73e.png">
<img width="1066" alt="screen shot 2017-03-30 at 15 42 55" src="https://cloud.githubusercontent.com/assets/953911/24507337/771c7ffc-1560-11e7-89be-bea9112896b7.png">
<img width="1066" alt="screen shot 2017-03-30 at 15 42 55" src="https://cloud.githubusercontent.com/assets/953911/24507355/85aef680-1560-11e7-8b4e-1515f6d78de4.png">
<img width="1066" alt="screen shot 2017-03-30 at 15 42 55" src="https://cloud.githubusercontent.com/assets/953911/24507356/85ccc70a-1560-11e7-8260-80b4292b489a.png">

#### :ghost: GIF
![](https://media.giphy.com/media/Ad98iIEmobBcs/giphy.gif)
