### PR TITLE
Use filename instead of identifier

### DIFF
--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -47,7 +47,7 @@
       <label><%= t('.current_image') %></label>
       <%= image_tag current_organization.homepage_image.url %>
       <label><%= t('.url') %></label>
-      <%= link_to current_organization.homepage_image.file.identifier, current_organization.homepage_image.url, target: "_blank" %>
+      <%= link_to current_organization.homepage_image.file.filename, current_organization.homepage_image.url, target: "_blank" %>
     <% end %>
   </div>
 
@@ -57,7 +57,7 @@
       <label><%= t('.current_image') %></label>
       <%= image_tag current_organization.logo.url %>
       <label><%= t('.url') %></label>
-      <%= link_to current_organization.logo.file.identifier, current_organization.logo.url, target: "_blank" %>
+      <%= link_to current_organization.logo.file.filename, current_organization.logo.url, target: "_blank" %>
     <% end %>
   </div>
 
@@ -67,7 +67,7 @@
       <label><%= t('.current_image') %></label>
       <%= image_tag current_organization.favicon.url %>
       <label><%= t('.url') %></label>
-      <%= link_to current_organization.favicon.file.identifier, current_organization.favicon.url, target: "_blank" %>
+      <%= link_to current_organization.favicon.file.filename, current_organization.favicon.url, target: "_blank" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?

In the admin organization edit form we were using `file.identifier` which it only works with local uploads, not with the fog ones.

I used `file.filename` which it is an abstraction and will work with both.

#### :pushpin: Related Issues
- Related to https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/93
