### PR TITLE
Count both processes and process groups

### DIFF
--- a/decidim-core/app/controllers/decidim/participatory_process_groups_controller.rb
+++ b/decidim-core/app/controllers/decidim/participatory_process_groups_controller.rb
@@ -3,7 +3,7 @@ require_dependency "decidim/application_controller"
 
 module Decidim
   class ParticipatoryProcessGroupsController < ApplicationController
-    helper_method :participatory_processes, :group
+    helper_method :participatory_processes, :group, :collection
 
     def show
       authorize! :read, ParticipatoryProcessGroup
@@ -14,6 +14,7 @@ module Decidim
     def participatory_processes
       @participatory_processes ||= group.participatory_processes.published
     end
+    alias_method :collection, :participatory_processes
 
     def group
       Decidim::ParticipatoryProcessGroup.find(params[:id])

--- a/decidim-core/app/views/decidim/participatory_processes/_order_by_processes.html.erb
+++ b/decidim-core/app/views/decidim/participatory_processes/_order_by_processes.html.erb
@@ -1,3 +1,3 @@
 <div class="row collapse order-by">
-  <h2 class="order-by__text section-heading"><%= t(".processes", scope: "layouts", count: participatory_processes.count) %></h2>
+  <h2 class="order-by__text section-heading"><%= t(".processes", scope: "layouts", count: collection.count) %></h2>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Fix the processes counter, as it was only counting processes but showing both processes and process groups. See the related issue for a screenshot of the old behaviour, and the screenshot right here for the fixed behaviour.

#### :pushpin: Related Issues
- Fixes #1190

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![Description](https://i.imgur.com/JiJdRlr.png)
