### PR TITLE
Skip csrf token in api controller

### DIFF
--- a/decidim-api/app/controllers/decidim/api/application_controller.rb
+++ b/decidim-api/app/controllers/decidim/api/application_controller.rb
@@ -3,6 +3,7 @@ module Decidim
   module Api
     # Base controller for `decidim-api`. All other controllers inherit from this.
     class ApplicationController < ::DecidimController
+      skip_before_filter :verify_authenticity_token
       include NeedsOrganization
     end
   end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/feature.rb
@@ -35,6 +35,7 @@ module Decidim
     def show
       @commentable = DummyResource.find(params[:id])
       render inline: %{
+        <%= csrf_meta_tags %>
         <%= display_flash_messages %>
         <div class="reveal" id="loginModal" data-reveal></div>
         <%= javascript_include_tag 'application' %>

--- a/decidim-dev/lib/generators/decidim/dummy_generator.rb
+++ b/decidim-dev/lib/generators/decidim/dummy_generator.rb
@@ -58,6 +58,11 @@ module Decidim
         template "autoprefixer_initializer.rb", "#{dummy_path}/config/initializers/autoprefixer.rb"
       end
 
+      def test_env
+        gsub_file "#{dummy_path}/config/environments/test.rb",
+          /allow_forgery_protection = (.*)/, 'allow_forgery_protection = true'
+      end
+
       private
 
       def dummy_path


### PR DESCRIPTION
#### :tophat: What? Why?

This fixes the API QueriesController so Apollo requests don't return an error.

#### :pushpin: Related Issues
- Related to #1194 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
