### PR TITLE
Highlight errors on i18n fields

### DIFF
--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -49,8 +49,8 @@ module Decidim
             locales.each_with_index.inject("".html_safe) do |string, (locale, index)|
               string + content_tag(:li, class: tab_element_class_for("title", index)) do
                 title = I18n.with_locale(locale) { I18n.t("name", scope: "locale") }
-                element_class = ""
-                element_class += "alert" if error?(name_with_locale(name, locale))
+                element_class = nil
+                element_class = "is-tab-error" if error?(name_with_locale(name, locale))
                 content_tag(:a, title, href: "##{name}-panel-#{index}", class: element_class)
               end
             end


### PR DESCRIPTION
#### :tophat: What? Why?
Since the new admin layout, we lost track of errors on i18n fields. This PR fixes the class name for errored locales so that they highlight properly (see screenshots).

#### :pushpin: Related Issues
- Fixes #1201 

#### :clipboard: Subtasks
- [x] Fix layout

### :camera: Screenshots (optional)
Unselected labels with errors:
![Description](https://i.imgur.com/MvT1ixT.png)
Selected label with error:
![](https://i.imgur.com/TUbkozu.png)
