### PR TITLE
Do not send newsletters to unconfirmed users

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
@@ -28,7 +28,7 @@ module Decidim
         email = NewsletterMailer.newsletter(current_user, @newsletter)
         Premailer::Rails::Hook.perform(email)
 
-        render text: email.html_part.body.decoded
+        render html: email.html_part.body.decoded
       end
 
       def create

--- a/decidim-admin/app/jobs/decidim/admin/newsletter_job.rb
+++ b/decidim-admin/app/jobs/decidim/admin/newsletter_job.rb
@@ -25,7 +25,7 @@ module Decidim
       private
 
       def recipients
-        @recipients ||= User.where(newsletter_notifications: true).where.not(email: nil)
+        @recipients ||= User.where(newsletter_notifications: true).where.not(email: nil, confirmed_at: nil)
       end
     end
   end

--- a/decidim-admin/spec/commands/deliver_newsletter_spec.rb
+++ b/decidim-admin/spec/commands/deliver_newsletter_spec.rb
@@ -13,11 +13,14 @@ module Decidim
         end
 
         let!(:deliverable_users) do
-          create_list(:user, 5, organization: organization, newsletter_notifications: true)
+          create_list(:user, 5, :confirmed, organization: organization, newsletter_notifications: true)
         end
 
         let!(:not_deliverable_users) do
           create_list(:user, 3, organization: organization, newsletter_notifications: false)
+        end
+        let!(:unconfirmed_users) do
+          create_list(:user, 3, organization: organization, newsletter_notifications: true)
         end
 
         let(:command) { described_class.new(newsletter) }

--- a/decidim-admin/spec/features/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_newsletters_spec.rb
@@ -6,7 +6,7 @@ require "spec_helper"
 describe "Admin manages newsletters", type: :feature do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, name: "Sarah Kerrigan", organization: organization) }
-  let!(:deliverable_users) { create_list(:user, 5, newsletter_notifications: true, organization: organization) }
+  let!(:deliverable_users) { create_list(:user, 5, :confirmed, newsletter_notifications: true, organization: organization) }
 
   before do
     switch_to_host(organization.host)

--- a/decidim-admin/spec/jobs/newsletter_job_spec.rb
+++ b/decidim-admin/spec/jobs/newsletter_job_spec.rb
@@ -7,10 +7,12 @@ module Decidim
       let!(:newsletter) { create(:newsletter, organization: organization, total_deliveries: 0) }
       let!(:organization) { create(:organization) }
       let!(:deliverable_user) { create(:user, :confirmed, newsletter_notifications: true, organization: organization) }
+      let!(:undeliverable_user) { create(:user, newsletter_notifications: true, organization: organization) }
       let!(:non_deliverable_user) { create(:user, :confirmed, newsletter_notifications: false, organization: organization) }
 
       it "delivers a newsletter to a the eligible users" do
         expect(NewsletterDeliveryJob).to receive(:perform_later).with(deliverable_user, newsletter)
+        expect(NewsletterDeliveryJob).not_to receive(:perform_later).with(undeliverable_user, newsletter)
 
         NewsletterJob.perform_now(newsletter)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
We are sending newsletters to unconfirmed users. These users can be unconfirmed due to:

1. they have received the email, but haven't clicked the confirmation link
2. they haven't received the email

In option 2, we rely on Sendgrid (in Decidim Barcelona, where this issue was found) or other 3rd parties, so we'll consider that they won't have any downtime. So the only option I can think of is the email is unreachable due to a typing error (`gamil.com`, `hormail.com`, etc). We could try to autosuggest the user to fix these addresses, but that's another issue.

In short, if they haven't confirmed is mostly because the user has a typo in the email field. So the email does not exist, and will bounce. Anyway, we shouldn't send anything to unconfirmed users (apart from the confirmation mail, that is), so this PR is good.

#### :pushpin: Related Issues
- Fixes #1211

#### :clipboard: Subtasks
None