### PR TITLE
Fix typo in generated README

### DIFF
--- a/lib/generators/decidim/templates/README.md.erb
+++ b/lib/generators/decidim/templates/README.md.erb
@@ -1,6 +1,6 @@
 # <%= app_name %>
 
-Citizen Participation and Open Govermnment application.
+Citizen Participation and Open Government application.
 
 This is the open-source repository for <%= app_name %>, based on [Decidim](https://github.com/AjuntamentdeBarcelona/decidim).
 


### PR DESCRIPTION
#### :tophat: What? Why?
We had a typo in the generated README file.

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None