### PR TITLE
Read missing official image inputs

### DIFF
--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -45,7 +45,7 @@
     <%= form.file_field :homepage_image %>
     <% if current_organization.homepage_image.present? %>
       <label><%= t('.current_image') %></label>
-      <%= image_tag current_organization.homepage_image.url %>
+      <%= image_tag current_organization.homepage_image.big.url %>
       <label><%= t('.url') %></label>
       <%= link_to current_organization.homepage_image.file.filename, current_organization.homepage_image.url, target: "_blank" %>
     <% end %>
@@ -55,7 +55,7 @@
     <%= form.file_field :logo %>
     <% if current_organization.logo.present? %>
       <label><%= t('.current_image') %></label>
-      <%= image_tag current_organization.logo.url %>
+      <%= image_tag current_organization.logo.medium.url %>
       <label><%= t('.url') %></label>
       <%= link_to current_organization.logo.file.filename, current_organization.logo.url, target: "_blank" %>
     <% end %>
@@ -65,7 +65,7 @@
     <%= form.file_field :favicon %>
     <% if current_organization.favicon.present? %>
       <label><%= t('.current_image') %></label>
-      <%= image_tag current_organization.favicon.url %>
+      <%= image_tag current_organization.favicon.big.url %>
       <label><%= t('.url') %></label>
       <%= link_to current_organization.favicon.file.filename, current_organization.favicon.url, target: "_blank" %>
     <% end %>

--- a/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/_form.html.erb
@@ -74,6 +74,28 @@
 
 <div class="row">
   <div class="columns xlarge-6">
+    <%= form.file_field :official_img_header %>
+    <% if current_organization.official_img_header.present? %>
+      <label><%= t('.current_image') %></label>
+      <%= image_tag current_organization.official_img_header.url %>
+      <label><%= t('.url') %></label>
+      <%= link_to current_organization.official_img_header.file.filename, current_organization.official_img_header.url, target: "_blank" %>
+    <% end %>
+  </div>
+
+  <div class="columns xlarge-6">
+    <%= form.file_field :official_img_footer %>
+    <% if current_organization.official_img_footer.present? %>
+      <label><%= t('.current_image') %></label>
+      <%= image_tag current_organization.official_img_footer.url %>
+      <label><%= t('.url') %></label>
+      <%= link_to current_organization.official_img_footer.file.filename, current_organization.official_img_footer.url, target: "_blank" %>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="columns xlarge-6">
     <%= form.text_field :reference_prefix %>
   </div>
 

--- a/decidim-admin/spec/features/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/features/admin_manages_organization_spec.rb
@@ -30,7 +30,21 @@ describe "Admin manages ogranization", type: :feature do
         ca: "El meu súper text de benvinguda"
       }
 
+      %w(Twitter Facebook Instagram YouTube GitHub).each do |network|
+        click_link network
+        fill_in "organization_#{network.downcase}_handler", with: "decidim"
+      end
+
       click_button "Update organization"
+      select "Castellano", from: "Default locale"
+      fill_in "Reference prefix", with: "ABC"
+      fill_in "Official organization url", with: "http://www.example.com"
+
+      attach_file "Homepage image", Decidim::Dev.asset("city.jpeg")
+      attach_file "Logo", Decidim::Dev.asset("city2.jpeg")
+      attach_file "Icon", Decidim::Dev.asset("city3.jpeg")
+      attach_file "Official logo header", Decidim::Dev.asset("city2.jpeg")
+      attach_file "Official logo footer", Decidim::Dev.asset("city3.jpeg")
 
       expect(page).to have_content("updated successfully")
     end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb
@@ -23,7 +23,7 @@ module TranslationHelpers
   #
   # field - the name of the field that should be filled, without the
   #   locale-related part (e.g. `:participatory_process_title`)
-  # tab_slector - a String representing the ID of the HTML element that holds
+  # tab_selector - a String representing the ID of the HTML element that holds
   #   the tabs for this input. It ususally is `"#<attribute_name>-tabs" (e.g.
   #   "#title-tabs")
   # localized_values - a Hash where the keys are the locales IDs and the values


### PR DESCRIPTION
#### :tophat: What? Why?
During #1101 we accidentally removed the inputs for organization `official_img_header` and `official_img_footer` images. We missed them because there were no tests checking for those inputs. This PR readds those inputs and adds some tests for all the inputs in that section:

![](https://i.imgur.com/zDdtEfW.png)

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None