### PR TITLE
Fix problem with constants autoload for ActionAuthorization

### DIFF
--- a/decidim-core/app/controllers/concerns/decidim/action_authorization.rb
+++ b/decidim-core/app/controllers/concerns/decidim/action_authorization.rb
@@ -65,7 +65,7 @@ module Decidim
     end
 
     def _action_authorizer(action_name)
-      ActionAuthorizer.new(current_user, current_feature, action_name)
+      ::Decidim::ActionAuthorizer.new(current_user, current_feature, action_name)
     end
 
     class Unauthorized < StandardError; end


### PR DESCRIPTION
#### :tophat: What? Why?

This enhances the developer experience solving an issue while saving a file and an error was raised:

`A copy of Decidim::ActionAuthorization has been removed from the module tree but is still active!`

#### :pushpin: Related Issues
None

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
