### PR TITLE
Respond with html when adding or removing projects

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/line_items_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/line_items_controller.rb
@@ -11,26 +11,32 @@ module Decidim
       def create
         authorize_action! "vote"
 
-        AddLineItem.call(current_order, project, current_user) do
-          on(:ok) do |order|
-            self.current_order = order
-            render "update_budget"
-          end
+        respond_to do |format|
+          AddLineItem.call(current_order, project, current_user) do
+            on(:ok) do |order|
+              self.current_order = order
+              format.html { redirect_to :back }
+              format.js { render "update_budget" }
+            end
 
-          on(:invalid) do
-            render nothing: true, status: 422
+            on(:invalid) do
+              render nothing: true, status: 422
+            end
           end
         end
       end
 
       def destroy
-        RemoveLineItem.call(current_order, project) do
-          on(:ok) do |_order|
-            render "update_budget"
-          end
+        respond_to do |format|
+          RemoveLineItem.call(current_order, project) do
+            on(:ok) do |_order|
+              format.html { redirect_to :back }
+              format.js { render "update_budget" }
+            end
 
-          on(:invalid) do
-            render nothing: true, status: 422
+            on(:invalid) do
+              render nothing: true, status: 422
+            end
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

This solves the problem when adding or removing a project from an order when javascript is disabled or not loaded yet.

**Important:** In order to checkout the order you still need JS enabled.

#### :pushpin: Related Issues
- Fixes #1208 

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
None

#### :ghost: GIF
None
