### PR TITLE
User registration when exists in another organization

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -63,7 +63,8 @@ module Decidim
     def create_identity
       @user.identities.create!(
         provider: form.provider,
-        uid: form.uid
+        uid: form.uid,
+        organization: organization
       )
     end
 

--- a/decidim-core/app/models/decidim/identity.rb
+++ b/decidim-core/app/models/decidim/identity.rb
@@ -9,5 +9,14 @@ module Decidim
     validates :user, presence: true
     validates :provider, presence: true
     validates :uid, presence: true, uniqueness: { scope: [:provider, :organization] }
+
+    validate :same_organization
+
+    private
+
+    def same_organization
+      return if organization == user&.organization
+      errors.add(:organization, :invalid)
+    end
   end
 end

--- a/decidim-core/app/models/decidim/identity.rb
+++ b/decidim-core/app/models/decidim/identity.rb
@@ -4,9 +4,10 @@ module Decidim
   # Store user's social identities
   class Identity < ApplicationRecord
     belongs_to :user, foreign_key: :decidim_user_id, class_name: Decidim::User
+    belongs_to :organization, foreign_key: :decidim_organization_id, class_name: Decidim::Organization
 
     validates :user, presence: true
     validates :provider, presence: true
-    validates :uid, presence: true, uniqueness: { scope: :provider }
+    validates :uid, presence: true, uniqueness: { scope: [:provider, :organization] }
   end
 end

--- a/decidim-core/db/migrate/20170405091801_change_decidim_user_email_index_uniqueness.rb
+++ b/decidim-core/db/migrate/20170405091801_change_decidim_user_email_index_uniqueness.rb
@@ -1,0 +1,6 @@
+class ChangeDecidimUserEmailIndexUniqueness < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :decidim_users, :email
+    add_index :decidim_users, [:email, :decidim_organization_id], unique: true
+  end
+end

--- a/decidim-core/db/migrate/20170405094028_add_organization_to_identities.rb
+++ b/decidim-core/db/migrate/20170405094028_add_organization_to_identities.rb
@@ -1,0 +1,5 @@
+class AddOrganizationToIdentities < ActiveRecord::Migration[5.0]
+  def change
+    add_reference :decidim_identities, :decidim_organization, index: true, foreign_key: true
+  end
+end

--- a/decidim-core/db/migrate/20170405094258_change_decidim_identities_provider_uid_index_uniqueness.rb
+++ b/decidim-core/db/migrate/20170405094258_change_decidim_identities_provider_uid_index_uniqueness.rb
@@ -1,0 +1,12 @@
+class ChangeDecidimIdentitiesProviderUidIndexUniqueness < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :decidim_identities, [:provider, :uid]
+    add_index :decidim_identities, [:provider, :uid, :decidim_organization_id], unique: true,
+    name: "decidim_identities_provider_uid_organization_unique"
+
+    Decidim::Identity.includes(:user).find_each do |identity|
+      identity.organization = identity.user.organization
+      identity.save!
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -187,6 +187,7 @@ FactoryGirl.define do
     provider "facebook"
     sequence(:uid)
     user
+    organization { user.organization }
   end
 
   factory :authorization, class: Decidim::Authorization do

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -109,6 +109,7 @@ module Decidim
             last_identity = Identity.last
             expect(last_identity.provider).to eq(form.provider)
             expect(last_identity.uid).to eq(form.uid)
+            expect(last_identity.organization).to eq(organization)
           end
 
           it "confirms the user if the email is already verified" do

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -344,4 +344,27 @@ describe "Authentication", type: :feature, perform_enqueued: true do
       end
     end
   end
+
+  context "When a user is already registered in another organization" do
+    let(:user) { create(:user, :confirmed) }
+
+    describe "Sign Up" do
+      context "using the same email" do
+        it "creates a new User" do
+          find(".sign-up-link").click
+
+          within ".new_user" do
+            fill_in :user_email, with: user.email
+            fill_in :user_name, with: "Responsible Citizen"
+            fill_in :user_password, with: "123456"
+            fill_in :user_password_confirmation, with: "123456"
+            check :user_tos_agreement
+            find("*[type=submit]").click
+          end
+
+          expect(page).to have_content("confirmation link")
+        end
+      end
+    end
+  end
 end

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -345,7 +345,7 @@ describe "Authentication", type: :feature, perform_enqueued: true do
     end
   end
 
-  context "When a user is already registered in another organization" do
+  context "When a user is already registered in another organization with the same email" do
     let(:user) { create(:user, :confirmed) }
 
     describe "Sign Up" do
@@ -363,6 +363,46 @@ describe "Authentication", type: :feature, perform_enqueued: true do
           end
 
           expect(page).to have_content("confirmation link")
+        end
+      end
+    end
+  end
+
+  context "When a user is already registered in another organization with the same fb account" do
+    let(:user) { create(:user, :confirmed) }
+    let(:identity) { create(:identity, user: user, provider: "facebook", uid: "12345") }
+
+    let(:omniauth_hash) {
+        OmniAuth::AuthHash.new({
+          provider: identity.provider,
+          uid: identity.uid,
+          info: {
+            email: user.email,
+            name: "Facebook User",
+            verified: true
+          }
+        })
+      }
+
+    before :each do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:facebook] = omniauth_hash
+    end
+
+    after :each do
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth[:facebook] = nil
+    end
+
+    describe "Sign Up" do
+      context "when the user has confirmed the email in facebook" do
+        it "creates a new User without sending confirmation instructions" do
+          find(".sign-up-link").click
+
+          click_link "Sign in with Facebook"
+
+          expect(page).to have_content("Successfully")
+          expect_user_logged
         end
       end
     end

--- a/decidim-core/spec/models/decidim/identity_spec.rb
+++ b/decidim-core/spec/models/decidim/identity_spec.rb
@@ -4,13 +4,14 @@ require "spec_helper"
 module Decidim
   describe Identity, :db do
     let(:user) { create(:user) }
+    let(:organization) { user&.organization }
     let(:provider) { "facebook" }
     let(:uid) { "123456" }
-    let(:identity) { build(:identity, user: user, provider: provider, uid: uid) }
+    let(:identity) { build(:identity, user: user, provider: provider, uid: uid, organization: organization) }
     subject { identity }
 
     it { is_expected.to be_valid }
-    
+
     it "has an associated user" do
       expect(subject.user).to be_a(Decidim::User)
     end
@@ -28,13 +29,21 @@ module Decidim
 
       context "when the uid is not present" do
         let(:uid) { nil }
-        it { is_expected.to be_invalid }        
+        it { is_expected.to be_invalid }
       end
 
-      it "is invalid if the uid already exists for the same provider" do
-        identity.save
-        other_identity = build(:identity, provider: identity.provider, uid: identity.uid)
-        expect(other_identity).to be_invalid
+      context "when the uid already exists for the same provider" do
+        it "is valid for another organization" do
+          identity.save
+          other_identity = build(:identity, provider: identity.provider, uid: identity.uid)
+          expect(other_identity).to be_valid
+        end
+
+        it "is invalid for the same organization" do
+          identity.save
+          other_identity = build(:identity, provider: identity.provider, uid: identity.uid, organization: organization)
+          expect(other_identity).to be_invalid
+        end
       end
     end
   end

--- a/decidim-core/spec/models/decidim/identity_spec.rb
+++ b/decidim-core/spec/models/decidim/identity_spec.rb
@@ -32,6 +32,11 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
+      context "when the organization is different than the user's organization" do
+        let(:organization) { create :organization }
+        it { is_expected.to be_invalid }
+      end
+
       context "when the uid already exists for the same provider" do
         it "is valid for another organization" do
           identity.save

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -79,7 +79,7 @@ module Decidim
     describe "validation scopes" do
       context "when a user with the same email exists in another organization" do
         let(:email) { "foo@bar.com" }
-        let(:user) { build(:user, email: email) }
+        let(:user) { create(:user, email: email) }
 
         before do
           create(:user, email: email)


### PR DESCRIPTION
#### :tophat: What? Why?

Users should be able to sign up in another organization with the same email or oauth account.

#### :pushpin: Related Issues
- Fixes #1231 

#### :clipboard: Subtasks
- [x] Email registration
- [x] Oauth registration

### :camera: Screenshots (optional)
N/A

#### :ghost: GIF
None
