### PR TITLE
Fix login scoping to prevent logging in with the wrong user

### DIFF
--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -53,6 +53,12 @@ module Decidim
       super || I18n.t("decidim.anonymous_user")
     end
 
+    # Check if the user exists with the given email and the current organization
+    #
+    # warden_conditions - A hash with the authentication conditions
+    #                   * email - a String that represents user's email.
+    #                   * env - A Hash containing environment variables.
+    # Returns a User.
     def self.find_for_authentication(warden_conditions)
       organization = warden_conditions.dig(:env, "decidim.current_organization")
       where(

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -8,7 +8,7 @@ module Decidim
 
     devise :invitable, :database_authenticatable, :registerable, :confirmable,
            :recoverable, :rememberable, :trackable, :decidim_validatable,
-           :omniauthable, omniauth_providers: [:facebook, :twitter, :google_oauth2]
+           :omniauthable, omniauth_providers: [:facebook, :twitter, :google_oauth2], request_keys: [:env]
 
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: Decidim::Organization
     has_many :authorizations, foreign_key: "decidim_user_id", class_name: Decidim::Authorization, inverse_of: :user
@@ -51,6 +51,14 @@ module Decidim
 
     def name
       super || I18n.t("decidim.anonymous_user")
+    end
+
+    def self.find_for_authentication(warden_conditions)
+      organization = warden_conditions.dig(:env, "decidim.current_organization")
+      where(
+        email: warden_conditions[:email],
+        decidim_organization_id: organization.id
+      ).first
     end
 
     private

--- a/decidim-core/spec/features/authentication_spec.rb
+++ b/decidim-core/spec/features/authentication_spec.rb
@@ -407,4 +407,26 @@ describe "Authentication", type: :feature, perform_enqueued: true do
       end
     end
   end
+
+  context "when a user with the same email is already registered in another organization" do
+    let(:organization2) { create(:organization) }
+
+    let!(:user2) { create(:user, :confirmed, email: "fake@user.com", name: "Wrong user", organization: organization2) }
+    let!(:user) { create(:user, :confirmed, email: "fake@user.com", name: "Right user", organization: organization) }
+
+    describe "Sign in" do
+      it "authenticates the right user" do
+        find(".sign-in-link").click
+
+        within ".new_user" do
+          fill_in :user_email, with: user.email
+          fill_in :user_password, with: "password1234"
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_content("successfully")
+        expect(page).to have_content("Right user")
+      end
+    end
+  end
 end

--- a/decidim-core/spec/features/authorizations_spec.rb
+++ b/decidim-core/spec/features/authorizations_spec.rb
@@ -10,7 +10,7 @@ describe "Authorizations", type: :feature, perform_enqueued: true do
   end
 
   context "a new user" do
-    let(:user) { create(:user, :confirmed) }
+    let(:user) { create(:user, :confirmed, organization: organization) }
 
     context "when one authorization has been configured" do
       before do


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes issues when logging in using a user whose email previously existed in another organization.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/7mMRX7gWzDVwA/giphy.gif)
