### PR TITLE
Fix devise plugins for multi-orgs

### DIFF
--- a/decidim-core/app/commands/decidim/invite_user.rb
+++ b/decidim-core/app/commands/decidim/invite_user.rb
@@ -35,7 +35,7 @@ module Decidim
     end
 
     def invite_user
-      @user = Decidim::User.invite!(
+      @user = Decidim::User.create(
         {
           name: form.name,
           email: form.email.downcase,
@@ -43,7 +43,8 @@ module Decidim
           roles: form.roles,
           comments_notifications: true,
           replies_notifications: true
-        },
+        })
+      .invite!(
         form.invited_by,
         invitation_instructions: form.invitation_instructions
       )

--- a/decidim-core/app/commands/decidim/invite_user.rb
+++ b/decidim-core/app/commands/decidim/invite_user.rb
@@ -44,7 +44,7 @@ module Decidim
           comments_notifications: true,
           replies_notifications: true
         })
-      .invite!(
+      @user.invite!(
         form.invited_by,
         invitation_instructions: form.invitation_instructions
       )

--- a/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
@@ -4,6 +4,21 @@ module Decidim
     # Custom Devise PasswordsController to avoid namespace problems.
     class PasswordsController < ::Devise::PasswordsController
       include Decidim::DeviseControllers
+
+      private
+
+      # Since we're using a single Devise installation for multiple
+      # organizations, and user emails can be repeated across organizations,
+      # we need to identify the user by both the email and the organization.
+      # Setting the organization ID here will be used by Devise internally to
+      # find the correct user.
+      #
+      # Note that in orther for this to work we need to define the `reset_password_keys`
+      # Devise attribute in the `Decidim::User` model to include the
+      # `decidim_organization_id` attribute.
+      def resource_params
+        super.merge(decidim_organization_id: current_organization.id)
+      end
     end
   end
 end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -8,7 +8,8 @@ module Decidim
 
     devise :invitable, :database_authenticatable, :registerable, :confirmable,
            :recoverable, :rememberable, :trackable, :decidim_validatable,
-           :omniauthable, omniauth_providers: [:facebook, :twitter, :google_oauth2], request_keys: [:env]
+           :omniauthable, omniauth_providers: [:facebook, :twitter, :google_oauth2],
+           request_keys: [:env], reset_password_keys: [:decidim_organization_id, :email]
 
     belongs_to :organization, foreign_key: "decidim_organization_id", class_name: Decidim::Organization
     has_many :authorizations, foreign_key: "decidim_user_id", class_name: Decidim::Authorization, inverse_of: :user

--- a/decidim-core/app/views/decidim/devise/passwords/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/passwords/edit.html.erb
@@ -22,7 +22,7 @@
             </div>
 
             <div class="actions">
-              <%= f.submit t("devise.passwords.edit.change_my_password", class: "button expanded") %>
+              <%= f.submit t("devise.passwords.edit.change_my_password"), class: "button expanded" %>
             </div>
           <% end %>
 


### PR DESCRIPTION
#### :tophat: What? Why?
Some devise features are broken for multi-org installations. 

This PR fixes these cases:

- When a user exists in an organization, that email cannot be used as admin email for a new organization (created from `system`)
- Given a user with a given email is created in organization A, and the same email is used to create a user for organization B, when asking for a new password for the B user the email links point to organization A.

#### :pushpin: Related Issues
- Related to #1237 

#### :clipboard: Subtasks
- [x] Fix invitations
- [x] Fix forget password
