### PR TITLE
Show `updated_at` in authorizations list

### DIFF
--- a/decidim-core/app/views/decidim/authorizations/index.html.erb
+++ b/decidim-core/app/views/decidim/authorizations/index.html.erb
@@ -10,7 +10,7 @@
                 <h5 class="card--list__heading">
                   <%= t("#{authorization.name}.name", scope: "decidim.authorization_handlers") %>
                 </h5>
-                <span class="text-small"><%= l(authorization.created_at, format: :long) %></span>
+                <span class="text-small"><%= l(authorization.updated_at, format: :long) %></span>
               </div>
             </div>
             <div class="card--list__data">


### PR DESCRIPTION
#### :tophat: What? Why?
Authorizations are currently displaying `created_at` instead which is misleading after updating an authorization. This displays `updated_at` instead.

#### :pushpin: Related Issues
*None*

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*

#### :ghost: GIF
![](https://media.giphy.com/media/j3gsT2RsH9K0w/giphy.gif)
