### PR TITLE
Add reference after saving so we can have the ID

### DIFF
--- a/decidim-budgets/db/migrate/20170410074214_remove_not_null_reference_budgets.rb
+++ b/decidim-budgets/db/migrate/20170410074214_remove_not_null_reference_budgets.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullReferenceBudgets < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :decidim_budgets_projects, :reference, true
+  end
+end

--- a/decidim-core/lib/decidim/has_reference.rb
+++ b/decidim-core/lib/decidim/has_reference.rb
@@ -8,9 +8,9 @@ module Decidim
     extend ActiveSupport::Concern
 
     included do
-      before_save :store_reference
+      after_commit :store_reference
 
-      validates :reference, presence: true
+      validates :reference, presence: true, on: :update
 
       def reference
         self[:reference] || calculate_reference
@@ -44,6 +44,7 @@ module Decidim
       # Returns nothing.
       def store_reference
         self[:reference] ||= calculate_reference
+        self.save if self.changed?
       end
     end
   end

--- a/decidim-meetings/db/migrate/20170410074252_remove_not_null_reference_meetings.rb
+++ b/decidim-meetings/db/migrate/20170410074252_remove_not_null_reference_meetings.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullReferenceMeetings < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :decidim_meetings_meetings, :reference, true
+  end
+end

--- a/decidim-proposals/db/migrate/20170410073742_remove_not_null_reference_proposals.rb
+++ b/decidim-proposals/db/migrate/20170410073742_remove_not_null_reference_proposals.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullReferenceProposals < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :decidim_proposals_proposals, :reference, true
+  end
+end

--- a/decidim-results/db/migrate/20170410074358_remove_not_null_reference_results.rb
+++ b/decidim-results/db/migrate/20170410074358_remove_not_null_reference_results.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullReferenceResults < ActiveRecord::Migration[5.0]
+  def change
+    change_column_null :decidim_results_results, :reference, true
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Calculates the reference *after saving the resource* so we can have the ID. We currently don't have it since we're calculating the reference before saving. Some resources have the reference with the ID because we generated it when they were already created, but new resources don't show the ID.

We need to find a way to detect those resources with the misshapen reference and recalculate it. All those elements whose reference ends with a dash (`-`) will be wrong.

#### :pushpin: Related Issues
- Fixes #1245

#### :clipboard: Subtasks
- [x] Fix reference calculation
