### PR TITLE
Fix i18n key for category `parent` field

### DIFF
--- a/decidim-admin/app/views/decidim/admin/categories/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/categories/index.html.erb
@@ -14,7 +14,7 @@
         <table class="table-list">
           <thead>
             <tr>
-              <th><%= t("models.category.fields.name", scope: "decidim.admin") %></th>
+              <th><%= t("activemodel.attributes.category.name") %></th>
               <th class="actions"></th>
             </tr>
           </thead>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -11,7 +11,7 @@ en:
       category:
         description: Description
         name: Name
-        parent: Parent
+        parent_id: Parent
       feature:
         name: Name
         weight: Weight
@@ -235,8 +235,6 @@ en:
             title: Title
           name: Attachment
         category:
-          fields:
-            name: Name
           name: Category
         newsletter:
           fields:


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes the i18n key for `parent` field on categories, so it can properly be translated.

#### :pushpin: Related Issues
- Fixes #1243 

#### :clipboard: Subtasks
None