### PR TITLE
Fix admin navigation for mobile devices

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
         "Quill": false,
         "SVGInjector": false,
         "require": false,
+        "DecidimAdmin": false,
         "L": false
     },
     "rules": {

--- a/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/application.js.es6
@@ -6,12 +6,17 @@
 // = require html.sortable
 // = require ./sort_steps
 // = require ./tab_focus
+// = require ./toggle_nav
 // = require decidim/editor
 // = require_self
 
 const pageLoad = () => {
   $(document).foundation();
   sortSteps();
+
+  if (DecidimAdmin) {
+    DecidimAdmin.toggleNav();
+  }
 };
 
 $(() => {

--- a/decidim-admin/app/assets/javascripts/decidim/admin/toggle_nav.js.es6
+++ b/decidim-admin/app/assets/javascripts/decidim/admin/toggle_nav.js.es6
@@ -1,0 +1,17 @@
+((exports) => {
+  const showHideNav = (evt) => {
+    const navMenu = document.querySelector(".layout-nav");
+
+    evt.preventDefault();
+    navMenu.classList.toggle("is-nav-open");
+  }
+
+  const toggleNav = () => {
+    const navTrigger = document.querySelector(".menu-trigger");
+
+    navTrigger.addEventListener("click", showHideNav);
+  }
+
+  exports.DecidimAdmin = exports.DecidimAdmin || {};
+  exports.DecidimAdmin.toggleNav = toggleNav;
+})(window);


### PR DESCRIPTION
#### :tophat: What? Why?
Admin navigation is broken on mobile devices, the hamburger menu does not do anything. This PR adds a missing JS file that toggles the navigation for mobile devices, thus making the hamburger menu work.

#### :pushpin: Related Issues
- Fixes #1239

#### :clipboard: Subtasks
None