### PR TITLE
Add edit proposal answer link

### DIFF
--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -27,6 +27,21 @@ module Decidim
 
         I18n.t(value, scope: "decidim.proposals.answers")
       end
+
+      # Public: The css class applied based on the proposal state.
+      #
+      # state - The String state of the proposal.
+      #
+      # Returns a String.
+      def proposal_state_css_class(state)
+        if state == "accepted"
+          "text-success"
+        elsif state == "rejected"
+          "text-alert"
+        else
+          "text-warning"
+        end
+      end
     end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -40,17 +40,14 @@
                 <% end %>
               </td>
               <td>
-                <% if proposal.state.nil? %>
-                  <% if can? :update, proposal %>
-                    <%= link_to t("actions.answer", scope: "decidim.proposals"), edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id), class: "button tiny" %>
-                  <% end %>
-                <% else %>
-                  <strong class="<%= proposal.state == 'accepted' ? 'text-success' : 'text-alert' %>">
-                    <%= humanize_proposal_state proposal.state %>
-                  </strong>
-                <% end %>
+                <strong class="<%= proposal_state_css_class proposal.state %>">
+                  <%= humanize_proposal_state proposal.state %>
+                </strong>
               </td>
               <td class="table-list__actions">
+                <% if can? :update, proposal %>
+                  <%= icon_link_to "chat", edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id), t("actions.answer", scope: "decidim.proposals"), class: "action-icon--preview" %>
+                <% end %>
                 <%= icon_link_to "eye", decidim_proposals.proposal_path(id: proposal, feature_id: current_feature, participatory_process_id: current_participatory_process), t("actions.preview", scope: "decidim.proposals.admin"), class: "action-icon--preview", target: :blank %>
               </td>
             </tr>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -46,7 +46,7 @@
               </td>
               <td class="table-list__actions">
                 <% if can? :update, proposal %>
-                  <%= icon_link_to "chat", edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id), t("actions.answer", scope: "decidim.proposals"), class: "action-icon--preview" %>
+                  <%= icon_link_to "chat", edit_proposal_proposal_answer_path(proposal_id: proposal.id, id: proposal.id), t("actions.answer", scope: "decidim.proposals"), class: "action-icon--edit-answer" %>
                 <% end %>
                 <%= icon_link_to "eye", decidim_proposals.proposal_path(id: proposal, feature_id: current_feature, participatory_process_id: current_participatory_process), t("actions.preview", scope: "decidim.proposals.admin"), class: "action-icon--preview", target: :blank %>
               </td>

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -232,6 +232,40 @@ RSpec.shared_examples "manage proposals" do
           end
         end
       end
+
+      it "can edit a proposal answer" do
+        proposal.update_attributes!(
+          state: 'rejected',
+          answer: {
+            'en' => "I don't like it"
+          },
+          answered_at: Time.current
+        )
+
+        visit decidim_admin.manage_feature_path(participatory_process_id: participatory_process, feature_id: current_feature)
+
+        within find("tr", text: proposal.title) do
+          within find("td:nth-child(4)") do
+            expect(page).to have_content("Rejected")
+          end
+          find("a.action-icon--edit-answer").click
+        end
+
+        within ".edit_proposal_answer" do
+          choose "Accepted"
+          click_button "Answer proposal"
+        end
+
+        within ".callout-wrapper" do
+          expect(page).to have_content("Proposal successfully answered")
+        end
+
+        within find("tr", text: proposal.title) do
+          within find("td:nth-child(4)") do
+            expect(page).to have_content("Accepted")
+          end
+        end
+      end
     end
 
     context "when the proposal_answering step setting is disabled" do

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -186,7 +186,7 @@ RSpec.shared_examples "manage proposals" do
 
       it "can reject a proposal" do
         within find("tr", text: proposal.title) do
-          click_link "Answer"
+          find("a.action-icon--edit-answer").click
         end
 
         within ".edit_proposal_answer" do
@@ -214,7 +214,7 @@ RSpec.shared_examples "manage proposals" do
 
       it "can accept a proposal" do
         within find("tr", text: proposal.title) do
-          click_link "Answer"
+          find("a.action-icon--edit-answer").click
         end
 
         within ".edit_proposal_answer" do


### PR DESCRIPTION
#### :tophat: What? Why?

The edit proposal answer link was missing in the admin proposals table. I included the link and used the same style as the other actions.

#### :pushpin: Related Issues
- Fixes #1256

#### :clipboard: Subtasks
None

### :camera: Screenshots (optional)
![image](https://cloud.githubusercontent.com/assets/106021/25168726/eb1b364e-24e4-11e7-8028-28d732ec3973.png)

#### :ghost: GIF
None
