### PR TITLE
Fix initiative authors style

### DIFF
--- a/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/initiatives.scss
+++ b/decidim-initiatives/app/packs/stylesheets/decidim/initiatives/initiatives.scss
@@ -33,7 +33,7 @@
   }
 
   .author{
-    margin-right: 15px;
+    margin-right: 30px;
   }
 
   .author__avatar--small{


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
*When an initiative has committee members, the name of the member is overlayed by the next*

![Screenshot 2022-10-05 at 16 11 11](https://user-images.githubusercontent.com/6973564/194082026-11598852-049d-4fee-bc86-d09ca7a834e7.png)

#### Testing
*Go to an initiative with committee members.*

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*
![Screenshot 2022-10-05 at 16 11 01](https://user-images.githubusercontent.com/6973564/194082467-081f453f-b280-4a7f-ae28-6146018d9f41.png)

:hearts: Thank you!