### PR TITLE
scope_id is mandatory for new initiative

### DIFF
--- a/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/initiative_form.rb
@@ -24,7 +24,7 @@ module Decidim
       attachments_attribute :photos
       attachments_attribute :documents
 
-      validates :title, :description, presence: true
+      validates :title, :description, :scope_id, presence: true
       validates :title, length: { maximum: 150 }
       validates :signature_type, presence: true
       validates :type_id, presence: true


### PR DESCRIPTION
#### :tophat: What? Why?
It align the mandatory fields in the form with the model logic 


#### Testing
Create a new initiative and try to pass to the third step without filling the scope field

#### :clipboard: Checklist
:rotating_light: Please review the [guidelines for contributing](https://github.com/decidim/decidim/blob/develop/CONTRIBUTING.adoc) to this repository.

- [ ] :question: **CONSIDER** adding a unit test if your PR resolves an issue.
- [ ] :heavy_check_mark: **DO** check open PR's to avoid duplicates.
- [ ] :heavy_check_mark: **DO** keep pull requests small so they can be easily reviewed.
- [ ] :heavy_check_mark: **DO** build locally before pushing.
- [ ] :heavy_check_mark: **DO** make sure tests pass.
- [ ] :heavy_check_mark: **DO** make sure any new changes are documented in `docs/`.
- [ ] :heavy_check_mark: **DO** add and modify seeds if necessary.
- [ ] :heavy_check_mark: **DO** add CHANGELOG upgrade notes if required.
- [ ] :heavy_check_mark: **DO** add to GraphQL API if there are new public fields.
- [ ] :heavy_check_mark: **DO** add link to MetaDecidim if it's a new feature.
- [ ] :x:**AVOID** breaking the continuous integration build.
- [ ] :x:**AVOID** making significant changes to the overall architecture.

### :camera: Screenshots
*Please add screenshots of the changes you're proposing*

The scope_id fields presents the star (*) as a mandatory field

![MicrosoftTeams-image](https://user-images.githubusercontent.com/16348967/194297508-e44c8b7b-2adf-497d-b3c2-616ef35732b1.png)


:hearts: Thank you!
