### PR TITLE
Fix resource_icon with component or manifest nil

### DIFF
--- a/decidim-core/app/helpers/decidim/icon_helper.rb
+++ b/decidim-core/app/helpers/decidim/icon_helper.rb
@@ -42,9 +42,9 @@ module Decidim
     def resource_icon(resource, options = {})
       if resource.class.name == "Decidim::Comments::Comment"
         icon "comment-square", options
-      elsif resource.respond_to?(:component)
+      elsif resource.respond_to?(:component) && resource.component.present?
         component_icon(resource.component, options)
-      elsif resource.respond_to?(:manifest)
+      elsif resource.respond_to?(:manifest) && resource.manifest.present?
         manifest_icon(resource.manifest, options)
       elsif resource.is_a?(Decidim::User)
         icon "person", options

--- a/decidim-core/app/helpers/decidim/icon_helper.rb
+++ b/decidim-core/app/helpers/decidim/icon_helper.rb
@@ -24,7 +24,7 @@ module Decidim
     #
     # Returns an HTML tag with the icon.
     def manifest_icon(manifest, options = {})
-      if manifest&.icon
+      if manifest.respond_to?(:icon) && manifest.icon.present?
         external_icon manifest.icon, options
       else
         icon "question-mark", options

--- a/decidim-core/app/helpers/decidim/icon_helper.rb
+++ b/decidim-core/app/helpers/decidim/icon_helper.rb
@@ -24,7 +24,7 @@ module Decidim
     #
     # Returns an HTML tag with the icon.
     def manifest_icon(manifest, options = {})
-      if manifest.icon
+      if manifest&.icon
         external_icon manifest.icon, options
       else
         icon "question-mark", options


### PR DESCRIPTION
<!--
NOTE: We're in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
*Fix `resource_icon` when `component` or `manifest` is nil*

#### Testing
*Generate a notification with a resource with a nil component and go to `/notifications`*

:hearts: Thank you!
