### PR TITLE
Allow iframes on meeting minutes

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/show.html.erb
@@ -162,7 +162,7 @@ edit_link(
     <% if meeting.closed? && meeting.closing_visible? %>
       <div class="section">
         <h3 class="section-heading"><%= t(".meeting_minutes") %></h3>
-        <%= decidim_sanitize_editor translated_attribute meeting.closing_report %>
+        <%= decidim_sanitize_editor_admin translated_attribute meeting.closing_report %>
       </div>
     <% end %>
 


### PR DESCRIPTION
<!--
NOTE: We are in the middle of a big redesign of the frontend.
That could mean that your PR will not get through on the next few months.
Please see https://github.com/decidim/decidim/discussions/9512
-->

#### :tophat: What? Why?
Allow meeting minutes to show videos.

#### :pushpin: Related Issues
- Fixes DECIDIM-753

#### Testing
Close a meeting adding a video in the closing minutes and see the result.

### :camera: Screenshots
![Screenshot 2023-09-12 at 17-08-25 Neque facilis  - Meetings - Velit enim quam rerum aut  - Schuppe Inc](https://github.com/AjuntamentdeBarcelona/decidim/assets/6973564/0dc03a60-74c9-498f-96dc-555ee6f11628)

:hearts: Thank you!
