### PR TITLE
Revert "Lock ChromeDriver to the latest working version"

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -51,11 +51,7 @@ runs:
     - run: mkdir -p ./spec/decidim_dummy_app/tmp/screenshots
       name: Create the screenshots folder
       shell: "bash"
-    - uses: nanasess/setup-chromedriver@v1.0.1
-      with:
-        # TODO: Unpin when nanasess/setup-chromedriver#190 is fixed:
-        #       https://github.com/nanasess/setup-chromedriver/issues/190
-        chromedriver-version: 114.0.5735.90
+    - uses: nanasess/setup-chromedriver@v2
     - run: RAILS_ENV=test bundle exec rails assets:precompile
       name: Precompile assets
       working-directory: ./spec/decidim_dummy_app/


### PR DESCRIPTION
#### :tophat: What? Why?
This reverts commit [2450714dee4df4281c52e1c9979f8d2de22453cd](https://github.com/decidim/decidim/commit/2450714dee4df4281c52e1c9979f8d2de22453cd) from PR [#11391](https://github.com/decidim/decidim/pull/11391).

This is no longer required, see the related issues (it has been fixed upstream).

#### :pushpin: Related Issues
- Related to
  * #11391
  * nanasess/setup-chromedriver#201
  * nanasess/setup-chromedriver#200
  * nanasess/setup-chromedriver#190

#### Testing
See that the CI is green and system specs are running normally.