### PR TITLE
Downgrade `wicked_pdf` from 2.8.0 to 2.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -769,7 +769,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked_pdf (2.8.0)
+    wicked_pdf (2.7.0)
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)

--- a/decidim-conferences/config/initializers/wicked_pdf.rb
+++ b/decidim-conferences/config/initializers/wicked_pdf.rb
@@ -10,13 +10,14 @@
 #
 # https://github.com/mileszs/wicked_pdf/blob/master/README.md
 
-WickedPdf.configure do |config|
+WickedPdf.config = {
   # Path to the wkhtmltopdf executable: This usually is not needed if using
   # one of the wkhtmltopdf-binary family of gems.
+  # exe_path: '/usr/local/bin/wkhtmltopdf',
   #   or
-  # config.exe_path = '/usr/local/bin/wkhtmltopdf',
+  # exe_path: Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)
-  # config.layout = 'pdf.html'
-end
+  # layout: 'pdf.html',
+}

--- a/decidim-forms/config/initializers/wicked_pdf.rb
+++ b/decidim-forms/config/initializers/wicked_pdf.rb
@@ -14,13 +14,14 @@ require "wicked_pdf"
 #
 # https://github.com/mileszs/wicked_pdf/blob/master/README.md
 
-WickedPdf.configure do |config|
+WickedPdf.config = {
   # Path to the wkhtmltopdf executable: This usually is not needed if using
   # one of the wkhtmltopdf-binary family of gems.
+  # exe_path: '/usr/local/bin/wkhtmltopdf',
   #   or
-  # config.exe_path = '/usr/local/bin/wkhtmltopdf',
+  # exe_path: Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)
-  # config.layout = 'pdf.html'
-end
+  # layout: 'pdf.html',
+}

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -770,7 +770,7 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    wicked_pdf (2.8.0)
+    wicked_pdf (2.7.0)
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)

--- a/decidim-initiatives/config/initializers/wicked_pdf.rb
+++ b/decidim-initiatives/config/initializers/wicked_pdf.rb
@@ -10,13 +10,14 @@
 #
 # https://github.com/mileszs/wicked_pdf/blob/master/README.md
 
-WickedPdf.configure do |config|
+WickedPdf.config = {
   # Path to the wkhtmltopdf executable: This usually is not needed if using
   # one of the wkhtmltopdf-binary family of gems.
+  # exe_path: '/usr/local/bin/wkhtmltopdf',
   #   or
-  # config.exe_path = '/usr/local/bin/wkhtmltopdf',
+  # exe_path: Gem.bin_path("wkhtmltopdf-binary", "wkhtmltopdf")
 
   # Layout file to be used for all PDFs
   # (but can be overridden in `render :pdf` calls)
-  # config.layout = 'pdf.html'
-end
+  # layout: 'pdf.html',
+}


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes the error below

```
ActionView::Template::Error uninitialized constant WickedPdf::WickedPdfHelper::Assets::SprocketsEnvironment::Sprockets 
```

#### :pushpin: Related Issues

- Related to https://github.com/mileszs/wicked_pdf/issues/1102
- Related to https://github.com/AjuntamentdeBarcelona/decidim-barcelona/pull/617

:hearts: Thank you!
