### PR TITLE
Add missing i18n strings from ca/es

### DIFF
--- a/decidim-admin/config/locales/ca.yml
+++ b/decidim-admin/config/locales/ca.yml
@@ -919,6 +919,8 @@ ca:
         edit:
           submit: Enviar
           title: Edita els permisos
+        options_form:
+          ephemeral_warning: Per habilitar aquest mètode d'autorització, necessites <a href="%{path}">revocar totes les autoritzacions existents</a>. Això minimitza el risc de conflictes de verificació. Totes les autoritzacions d'aquest tipus seran revocades automàticament a l'organització si envies els canvis afegint aquest mètode o modificant la teva configuració una vegada desada.
         update:
           success: Els permisos s'han actualitzat correctament.
       resources:

--- a/decidim-admin/config/locales/es.yml
+++ b/decidim-admin/config/locales/es.yml
@@ -919,6 +919,8 @@ es:
         edit:
           submit: Enviar
           title: Editar permisos
+        options_form:
+          ephemeral_warning: Para habilitar este método de autorización, necesitas <a href="%{path}">revocar todas las autorizaciones existentes</a>. Esto minimiza el riesgo de conflictos de verificación. Todas las autorizaciones de este tipo serán revocadas automáticamente en la organización si envías los cambios añadiendo este método o modificando tu configuración una vez guardada.
         update:
           success: Los permisos se han actualizado correctamente.
       resources:

--- a/decidim-budgets/config/locales/ca.yml
+++ b/decidim-budgets/config/locales/ca.yml
@@ -213,6 +213,25 @@ ca:
             id: ID
             map: Mapa
             title: Títol
+      order:
+        status:
+          continue_voting: Seguir votant
+          download_vote: Descarrega el teu vot
+          pending_to_vote_budgets:
+            one: Pots votar en un altre pressupost
+            other: Pots votar en altres pressupostos
+          share_text: "Acabes de votar pels teus projectes favorits a: \"%{space_name}\"!  🎉 Pots seguir votant a: \"%{component_url}\""
+          share_vote: Comparteix el teu vot
+          title: El teu vot s'ha tramitat correctament
+          view_votes:
+            one: Veure vot
+            other: Veure vots
+          votes_count:
+            one: El teu vot a %{budget_name} ja s'ha registrat.
+            other: El teus %{count} vots a %{budget_name} ja s'han registrat.
+      order_pdf:
+        text: 'Has votat a "%{space_name}", on has seleccionat els projectes següents:'
+        title: El teu vot s'ha acceptat correctament.
       order_summary_mailer:
         order_summary:
           selected_projects: 'Els projectes que has seleccionat són:'
@@ -237,7 +256,7 @@ ca:
             title: Màxim de projectes excedit
         budget_summary:
           are_you_sure: Segur que vols cancel·lar el teu vot?
-          cancel_order: eliminar el teu vot i començar de nou
+          cancel_order: Esborra el teu vot
           checked_out:
             description: Ja has votat pel pressupost. Si has canviat d'idea, pots esborrar el teu vot.
             title: Vot pels pressupostos completat
@@ -270,13 +289,13 @@ ca:
             start_adding_projects: Començar a afegir projectes
           minimum: Mínim
           minimum_projects_rule:
-            description: Selecciona com a mínim %{minimum_number} projectes que vulguis i vota segons les teves preferències per a definir el pressupost.
+            description: Selecciona com a mínim %{minimum_number} projectes que vulguis i vota segons les teves preferències.
           projects_rule:
             description: Selecciona entre %{minimum_number} i %{maximum_number} projectes que vulguis i vota segons les teves preferències per a definir el pressupost.
           projects_rule_maximum_only:
-            description: Selecciona fins a %{maximum_number} projectes que vulguis i vota segons les teves preferències per a definir el pressupost.
+            description: Selecciona fins a %{maximum_number} projectes que vulguis i vota segons les teves preferències.
           vote_threshold_percent_rule:
-            description: Assigna com a mínim %{minimum_budget} amb els projectes que vulguis i vota segons les teves preferències per a definir el pressupost.
+            description: Selecciona els projectes que vulguis fins com a mínim el %{minimum_budget} del total del pressupost i vota segons les teves preferències.
         orders:
           highest_cost: Major cost
           label: Ordenar projectes per
@@ -301,9 +320,10 @@ ca:
           added: Afegit
           all: Tots
         projects_for: Projectes per a %{name}
-        select_projects: Selecciona projectes
+        select_projects: Afegeix projectes
         show:
           budget: Pressupost
+        start_voting: Començar a votar
       prompt: Seleccionar pressupost
       vote_reminder_mailer:
         vote_reminder:

--- a/decidim-budgets/config/locales/es.yml
+++ b/decidim-budgets/config/locales/es.yml
@@ -213,6 +213,25 @@ es:
             id: ID
             map: Mapa
             title: Título
+      order:
+        status:
+          continue_voting: Seguir votando
+          download_vote: Descarga tu voto
+          pending_to_vote_budgets:
+            one: Puedes votar en otro presupuesto
+            other: Puedes votar en otros presupuestos
+          share_text: "¡Acabas de votar por tus proyectos favoritos en: ·%{space_name}·! 🎉 Puedes seguir votando en: \"%{component_url}\""
+          share_vote: Comparte tu voto
+          title: Tu voto se ha tramitado correctamente
+          view_votes:
+            one: Ver voto
+            other: Ver votos
+          votes_count:
+            one: Tu voto en %{budget_name} ya se ha registrado.
+            other: Tus %{count} votos en %{budget_name} ya se han registrado.
+      order_pdf:
+        text: 'Has votado en "%{space_name}", donde has seleccionado los siguientes proyectos:'
+        title: Tu voto se ha aceptado correctamente.
       order_summary_mailer:
         order_summary:
           selected_projects: 'Lo proyectos que has seleccionado son:'
@@ -270,13 +289,13 @@ es:
             start_adding_projects: Empezar a añadir proyectos
           minimum: Mínimo
           minimum_projects_rule:
-            description: Selecciona al menos %{minimum_number} proyectos que quieras y vota de acuerdo a tus preferencias para definir el presupuesto.
+            description: Selecciona al menos %{minimum_number} proyectos que quieras y vota de acuerdo a tus preferencias.
           projects_rule:
             description: Selecciona al menos %{minimum_number} y hasta %{maximum_number} proyectos que quieras y vota de acuerdo a tus preferencias para definir el presupuesto.
           projects_rule_maximum_only:
-            description: Selecciona hasta %{maximum_number} proyectos que quieras y vota de acuerdo a tus preferencias para definir el presupuesto.
+            description: Selecciona hasta %{maximum_number} proyectos que quieras y vota de acuerdo a tus preferencias.
           vote_threshold_percent_rule:
-            description: Asigna al menos %{minimum_budget} a los proyectos que quieras y vota de acuerdo a tus preferencias para definir el presupuesto.
+            description: Selecciona los proyectos que quieras hasta al menos el %{minimum_budget} del total del presupuesto y vota según tus preferencias.
         orders:
           highest_cost: Mayor coste
           label: Ordenar proyectos por
@@ -301,9 +320,10 @@ es:
           added: Añadido
           all: Todos
         projects_for: Proyectos de %{name}
-        select_projects: Selecciona proyectos
+        select_projects: Añadir proyectos
         show:
           budget: Presupuesto
+        start_voting: Empezar a votar
       prompt: Seleccionar presupuesto
       vote_reminder_mailer:
         vote_reminder:

--- a/decidim-core/config/locales/ca.yml
+++ b/decidim-core/config/locales/ca.yml
@@ -396,7 +396,15 @@ ca:
           scope_id: Àmbit
         name: Autorització d'exemple
       dummy_authorization_workflow:
+        explanation: Exemple de flux de verificació
         name: Flux de treball d'autorització d'exemple
+      ephemeral_dummy_authorization_handler:
+        explanation: Verifica't introduint un número de document que finalitzi amb "X".
+        fields:
+          allowed_postal_codes: Codis postals permesos (separats per comes)
+          document_number: Número de document
+          postal_code: Codi postal
+        name: Una altra autorització d'exemple
       errors:
         duplicate_authorization: Ja hi ha una participant autoritzada amb les mateixes dades. Una administradora es posarà en contacte amb tu per verificar les teves dades.
       expired_at: Vençut el %{timestamp}
@@ -608,6 +616,7 @@ ca:
           sign_in_disabled: Pots accedir amb un compte extern.
           sign_up_disabled: La creació de comptes està deshabilitada, pots fer servir un compte existent per accedir-hi.
         user:
+          ephemeral_session_closed: La teva sessió de convidada ha finalitzat
           timed_out: Has estat sense activitat durant massa temps i la teva sessió s'ha tancat automàticament. Si vols continuar participant, torna a iniciar sessió.
       shared:
         newsletter_modal:
@@ -669,6 +678,7 @@ ca:
         select_identity: Selecciona identitat
     endorsers_list:
       endorsed_by: Li agrada a…
+    ephemeral_user: Visitant
     errors:
       files:
         file_cannot_be_processed: No s'ha pogut processar el fitxer
@@ -1293,6 +1303,16 @@ ca:
         message_1: Sembla que no tens connexió a Internet.
         message_2: Si us plau, torneu-ho a provar més tard.
         retry: Torna-ho a provar
+    onboarding_action_message:
+      click_link: Fes clic aquí
+      cta_html: <a href="%{path}">%{link_text}</a> per %{action} a %{resource_name} <strong>%{resource_title}</strong>
+      ephemeral_authorized_message: Has estat autoritzada amb èxit.<br/>Has iniciat una sessió de convidada, ara hi pots participar.
+      expired_authorization_active_title: La teva autorització ha caducat.
+      finish_authorization_process: Pots finalitzar el procés de verificació
+      incomplete_authorization_active_title: La teva verificació no s'ha completat amb tota la informació necessària.
+      pending_authorization_active_message: Si us plau, completa el formulari per a continuar amb aquesta acció.
+      pending_authorization_active_title: Necessitem verificar la teva identitat.
+      pending_ephemeral_authorization: Si us plau, verifica la teva identitat per continuar.
     open_data:
       not_available_yet: Els fitxers Open Data encara no estan disponibles, torna-ho a provar d'aquí a uns minuts.
     pad_iframe:
@@ -1387,6 +1407,10 @@ ca:
           resend_email_confirmation_instructions: Reenvia un correu electrònic amb les instruccions de confirmació
         confirmation_instructions_sent: Instruccions de confirmació enviades per correu electrònic.
         fill_in_email_to_confirm_it: Si us plau, omple el correu electrònic del teu grup per confirmar-lo.
+    qr:
+      show:
+        scan: Escaneja el codi QR
+        title: Codi QR per %{resource_title}
     reported_mailer:
       hide:
         hello: Hola %{name},
@@ -1451,6 +1475,10 @@ ca:
       selfxss_warning:
         description: Aquesta funció de navegador està pensada per a desenvolupadors i no hauries d'enganxar res aquí si se t'ha demanat que ho facis. Enganxar contingut en aquesta finestra pot comprometre la teva privacitat i donar accés a hackers al teu compte.
         title: Aturar!
+    share_widget:
+      download: Descarregar
+      print: Imprimir el cartell
+      qr_code: Codi QR
     shared:
       confirm_modal:
         cancel: Cancel·lar
@@ -1517,6 +1545,7 @@ ca:
         copy_share_link: Còpia
         copy_share_link_clarification: Copia l'enllaç al porta-retalls
         copy_share_link_copied: Copiat!
+        copy_share_link_cta: O copiar l'enllaç
         copy_share_link_message: S'ha copiat l'enllaç al porta-retalls.
         share: Compartir
         share_link: Compartir l'enllaç
@@ -1930,6 +1959,10 @@ ca:
         sign_up: Crea un compte
         terms_of_service: Termes i condicions d'ús
       header:
+        back: Tornar al llistat
+        cancel: Cancel·lar
+        close: Tancar
+        confirm_close_ephemeral_session: Si abandones la navegació, es tancarà la sessió temporal. Tot el teu progrés i activitat, però, es guardaran. Si has acabat la teva activitat, fes clic a Ok.
         log_in: Entra
         main_menu: Menú principal
         user_menu: Menú d'usuari

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1418,6 +1418,10 @@ en:
           resend_email_confirmation_instructions: Resend email confirmation instructions
         confirmation_instructions_sent: Email confirmation instructions sent.
         fill_in_email_to_confirm_it: Please, fill in your group's email to confirm it.
+    qr:
+      show:
+        scan: Scan the QR code
+        title: QR Code for %{resource_title}
     reported_mailer:
       hide:
         hello: Hello %{name},
@@ -1482,6 +1486,10 @@ en:
       selfxss_warning:
         description: This browser feature is meant for developers and you should not paste anything here if you were asked to do so. Pasting content in this window can compromise your privacy and give hackers access to your account.
         title: Stop!
+    share_widget:
+      download: Download
+      print: Print poster
+      qr_code: QR Code
     shared:
       confirm_modal:
         cancel: Cancel
@@ -1548,6 +1556,7 @@ en:
         copy_share_link: Copy
         copy_share_link_clarification: Copy share link to clipboard
         copy_share_link_copied: Copied!
+        copy_share_link_cta: Or copy link
         copy_share_link_message: The link was successfully copied to clipboard.
         share: Share
         share_link: Share link

--- a/decidim-core/config/locales/es.yml
+++ b/decidim-core/config/locales/es.yml
@@ -396,7 +396,15 @@ es:
           scope_id: Ámbito
         name: Autorización de ejemplo
       dummy_authorization_workflow:
+        explanation: Ejemplo de flujo de verificación
         name: Flujo de trabajo de autorización de ejemplo
+      ephemeral_dummy_authorization_handler:
+        explanation: Verifícate introduciendo un número de documento que termine con "X".
+        fields:
+          allowed_postal_codes: Códigos postales permitidos (separados por comas)
+          document_number: Número de documento
+          postal_code: Código postal
+        name: Otro ejemplo de autorización
       errors:
         duplicate_authorization: Ya hay una participante autorizada con los mismos datos. Una administradora se pondrá en contacto contigo para verificar tus datos.
       expired_at: Caducado el %{timestamp}
@@ -608,6 +616,7 @@ es:
           sign_in_disabled: Puedes acceder con una cuenta externa.
           sign_up_disabled: La creación de cuentas está deshabilitada, puedes utilizar una cuenta existente para acceder.
         user:
+          ephemeral_session_closed: Su sesión de invitada ha finalizado
           timed_out: Has estado sin actividad durante demasiado tiempo y tu sesión se ha cerrado automáticamente. Si quieres seguir participando, inicia sesión de nuevo.
       shared:
         newsletter_modal:
@@ -669,6 +678,7 @@ es:
         select_identity: Seleccionar identidad
     endorsers_list:
       endorsed_by: Le gusta a…
+    ephemeral_user: Visitante
     errors:
       files:
         file_cannot_be_processed: No se ha podido procesar el archivo
@@ -1293,6 +1303,16 @@ es:
         message_1: Parece que no tienes conexión a Internet.
         message_2: Por favor, inténtalo de nuevo más tarde.
         retry: Reintentar
+    onboarding_action_message:
+      click_link: Haz clic aquí
+      cta_html: <a href="%{path}">%{link_text}</a> para %{action} en %{resource_name} <strong>%{resource_title}</strong>
+      ephemeral_authorized_message: Ha sido autorizada con éxito.<br/>Has iniciado una sesión de invitada, ahora puedes participar.
+      expired_authorization_active_title: Tu autorización ha expirado.
+      finish_authorization_process: Puedes terminar el proceso de verificación
+      incomplete_authorization_active_title: Tu verificación no se ha completado con toda la información necesaria.
+      pending_authorization_active_message: Por favor, complete el formulario para continuar con esta acción.
+      pending_authorization_active_title: Necesitamos verificar tu identidad.
+      pending_ephemeral_authorization: Por favor, verifica tu identidad para continuar.
     open_data:
       not_available_yet: Los ficheros Open Data aún no están disponibles, inténtalo de nuevo en unos minutos.
     pad_iframe:
@@ -1387,6 +1407,10 @@ es:
           resend_email_confirmation_instructions: Reenvia un correo electrónico con las instrucciones de confirmación
         confirmation_instructions_sent: Instrucciones de confirmación enviadas por correo electrónico.
         fill_in_email_to_confirm_it: Por favor, introduce el correo electrónico de tu grupo para confirmarlo.
+    qr:
+      show:
+        scan: Escanea el código QR
+        title: Código QR para %{resource_title}
     reported_mailer:
       hide:
         hello: Hola %{name},
@@ -1451,6 +1475,10 @@ es:
       selfxss_warning:
         description: Esta función de navegador está pensada para desarrolladores y no deberías pegar nada aquí si se te ha pedido que lo hagas. Pegar contenido en esta ventana puede comprometer tu privacidad y dar acceso a hackers a tu cuenta.
         title: Detener!
+    share_widget:
+      download: Descargar
+      print: Imprimir el cartel
+      qr_code: Código QR
     shared:
       confirm_modal:
         cancel: Cancelar
@@ -1517,6 +1545,7 @@ es:
         copy_share_link: Copia
         copy_share_link_clarification: Copiar al portapapeles el enlace para compartir
         copy_share_link_copied: '¡Copiado!'
+        copy_share_link_cta: O copiar el enlace
         copy_share_link_message: Se ha copiado el enlace al portapapeles correctamente.
         share: Compartir
         share_link: Compartir enlace
@@ -1930,6 +1959,10 @@ es:
         sign_up: Crea una cuenta
         terms_of_service: Términos y condiciones de uso
       header:
+        back: Volver al listado
+        cancel: Cancelar
+        close: Cerrar
+        confirm_close_ephemeral_session: Si abandonas la navegación, se cerrará tu sesión temporal. Sin embargo, todo tu progreso y actividad se guardarán. Si has terminado tu actividad, haz clic en Ok.
         log_in: Entra
         main_menu: Menú principal
         user_menu: Menú de usuario

--- a/decidim-debates/config/locales/ca.yml
+++ b/decidim-debates/config/locales/ca.yml
@@ -30,7 +30,7 @@ ca:
       debates:
         actions:
           comment: Comentar
-          create: Crear
+          create: Crear un debat
           endorse: Adherir-se
         name: Debats
         settings:

--- a/decidim-debates/config/locales/es.yml
+++ b/decidim-debates/config/locales/es.yml
@@ -30,7 +30,7 @@ es:
       debates:
         actions:
           comment: Comentar
-          create: Crear
+          create: Crear un debate
           endorse: Adherirse
         name: Debates
         settings:

--- a/decidim-initiatives/config/locales/ca.yml
+++ b/decidim-initiatives/config/locales/ca.yml
@@ -607,7 +607,7 @@ ca:
           comment: Comentar
       initiatives_type:
         actions:
-          create: Crear
+          create: Crear una iniciativa
           title: Accions
           vote: Signar
   layouts:

--- a/decidim-initiatives/config/locales/es.yml
+++ b/decidim-initiatives/config/locales/es.yml
@@ -607,7 +607,7 @@ es:
           comment: Comentar
       initiatives_type:
         actions:
-          create: Crear
+          create: Crear una iniciativa
           title: Acciones
           vote: Firmar
   layouts:

--- a/decidim-proposals/config/locales/ca.yml
+++ b/decidim-proposals/config/locales/ca.yml
@@ -143,7 +143,7 @@ ca:
         actions:
           amend: Esmena
           comment: Comentar
-          create: Crea
+          create: Crea una proposta
           endorse: Adherir-se
           vote: Donar suport
           vote_comment: Votar el comentari

--- a/decidim-proposals/config/locales/es.yml
+++ b/decidim-proposals/config/locales/es.yml
@@ -143,7 +143,7 @@ es:
         actions:
           amend: Enmendar
           comment: Comentar
-          create: Crear
+          create: Crear una propuesta
           endorse: Adherirse
           vote: Apoyar
           vote_comment: Votar comentario

--- a/decidim-verifications/config/locales/ca.yml
+++ b/decidim-verifications/config/locales/ca.yml
@@ -75,6 +75,12 @@ ca:
             - Un exemple de gestor d'autorització perquè les desenvolupadores puguin entendre com funciona una verificació simple.
             - Està dirigit a les desenvolupadores perquè puguin entendre com implementar el seu propi sistema de verificació.
             - Verifica't introduint un número de document que finalitzi amb "X".
+        ephemeral_dummy_authorization_handler:
+          help:
+            - Un exemple de gestor d'autorització perquè les desenvolupadores puguin entendre com funciona una verificació simple.
+            - Està dirigit a les desenvolupadores perquè puguin entendre com implementar el seu propi sistema de verificació.
+            - És una còpia de l'Autorització d'exemple.
+            - Verifica't introduint un número de document que finalitzi amb "X".
         id_documents:
           help:
             - Les participants omplen la informació de la seva identitat i carreguen una còpia del seu document.
@@ -147,6 +153,14 @@ ca:
         new:
           authorize: Enviar
           authorize_with: Verifica amb %{authorizer}
+          tos_agreement: En verificar la teva identitat, acceptes els %{link}.
+        onboarding_pending:
+          completed_verifications: El teu perfil s'ha verificat amb èxit, ara pots %{action} a %{resource_name}
+          granted_verifications: Verificacions concedides
+          onboarding_message_html: Manquen uns passos previs per a poder %{action} a <strong>%{resource_title}</strong> %{resource_name}. Si us plau, verifica el teu compte completant les següents verificacions:.
+          pending_admin_approval_verifications: Verificacions pendents de l'aprovació d'una administradora
+          pending_verifications: Verificacions pendents
+          unauthorized: No tens l'autorització corresponent per a %{action} en aquest recurs
         renew_modal:
           cancel: Cancel·lar
           continue: Continua

--- a/decidim-verifications/config/locales/es.yml
+++ b/decidim-verifications/config/locales/es.yml
@@ -75,6 +75,12 @@ es:
             - Un ejemplo de gestor de autorización para que las desarrolladoras puedan entender como funciona una verificación simple.
             - Está dirigido a las desarrolladoras para que puedan entender cómo implementar su propio sistema de verificación.
             - Verifícate introduciendo un número de documento que termine con "X".
+        ephemeral_dummy_authorization_handler:
+          help:
+            - Un ejemplo de gestor de autorización para que las desarrolladoras puedan entender como funciona una verificación simple.
+            - Está dirigido a las desarrolladoras para que puedan entender cómo implementar su propio sistema de verificación.
+            - Es una copia de la Autorización de ejemplo.
+            - Verifícate introduciendo un número de documento que termine con "X".
         id_documents:
           help:
             - Las participantes rellenan la información de su identidad y suben una copia de su documento.
@@ -147,6 +153,14 @@ es:
         new:
           authorize: Enviar
           authorize_with: Verificar con %{authorizer}
+          tos_agreement: Al verificar tu identidad, aceptas los %{link}.
+        onboarding_pending:
+          completed_verifications: Tu perfil se ha verificado con éxito, ahora puedes %{action} en %{resource_name}
+          granted_verifications: Verificaciones concedidas
+          onboarding_message_html: 'Faltan unos pasos previos para poder %{action} en <strong>%{resource_title}</strong>%{resource_name}. Por favor, verifica tu cuenta completando las siguientes verificaciones:'
+          pending_admin_approval_verifications: Verificaciones pendientes de aprobación de una administradora
+          pending_verifications: Verificaciones pendientes
+          unauthorized: No tienes la autorización correspondiente para %{action} en este recurso
         renew_modal:
           cancel: Cancelar
           continue: Continuar


### PR DESCRIPTION
#### :tophat: What? Why?

While working on preprod, we detected some missing i18n strings for the Spanish and Catalan locales. This PR adds them.

This is based on https://github.com/AjuntamentdeBarcelona/decidim/pull/46, so it should be merged to that branch (or merged to `develop` after merging that one first) 
 
This is related to 

- https://github.com/decidim/decidim/pull/13579
- https://github.com/decidim/decidim/pull/13981
- https://github.com/decidim/decidim/pull/14283
- https://github.com/decidim/decidim/pull/13295
- https://github.com/decidim/decidim/pull/14512
- https://github.com/decidim/decidim/pull/14086



#### Testing

I went to each related PR to check the new keys that were added and manually added the strings for `ca`/`es` from upstream (`decidim/decidim`). I even found one or two cases where it was missing the `en` too, so I added them. 

There was a case where we were removing strings. Just to be careful, I didn't remove them. 


 

:hearts: Thank you!
