### PR TITLE
Remove 'Download your vote' from the success page in Budgets

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/orders/status.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/orders/status.html.erb
@@ -36,11 +36,6 @@
              button_classes: "button button__sm md:button__lg button__text-secondary",
              button_text: t("share_vote", scope: "decidim.budgets.order.status") %>
 
-    <%= link_to export_pdf_budget_order_path(current_order.budget), class: "button button__sm md:button__lg button__transparent-secondary" do %>
-      <span><%= t("download_vote", scope: "decidim.budgets.order.status") %></span>
-      <%= icon "download-line", class: "fill-current" %>
-    <% end %>
-
     <%= link_to budgets_path, class: "button button__sm md:button__lg button__secondary" do %>
       <span>
         <% if pending_to_vote_budgets.present? %>

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -218,7 +218,6 @@ en:
       order:
         status:
           continue_voting: Continue voting
-          download_vote: Download your vote
           pending_to_vote_budgets:
             one: You can vote in other budget
             other: You can vote in other budgets

--- a/decidim-budgets/lib/decidim/budgets/engine.rb
+++ b/decidim-budgets/lib/decidim/budgets/engine.rb
@@ -23,7 +23,6 @@ module Decidim
             member do
               post :checkout
               get :status
-              get :export_pdf
             end
             resource :line_item, only: [:create, :destroy]
           end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1418,10 +1418,6 @@ en:
           resend_email_confirmation_instructions: Resend email confirmation instructions
         confirmation_instructions_sent: Email confirmation instructions sent.
         fill_in_email_to_confirm_it: Please, fill in your group's email to confirm it.
-    qr:
-      show:
-        scan: Scan the QR code
-        title: QR Code for %{resource_title}
     reported_mailer:
       hide:
         hello: Hello %{name},
@@ -1486,10 +1482,6 @@ en:
       selfxss_warning:
         description: This browser feature is meant for developers and you should not paste anything here if you were asked to do so. Pasting content in this window can compromise your privacy and give hackers access to your account.
         title: Stop!
-    share_widget:
-      download: Download
-      print: Print poster
-      qr_code: QR Code
     shared:
       confirm_modal:
         cancel: Cancel
@@ -1556,7 +1548,6 @@ en:
         copy_share_link: Copy
         copy_share_link_clarification: Copy share link to clipboard
         copy_share_link_copied: Copied!
-        copy_share_link_cta: Or copy link
         copy_share_link_message: The link was successfully copied to clipboard.
         share: Share
         share_link: Share link


### PR DESCRIPTION
#### :tophat: What? Why?

After some UX testing we don't like the "Download your vote" button, so we're removing it. 

### :camera: Screenshots

#### Before

![image](https://github.com/user-attachments/assets/7e969f19-0c62-4f66-815b-4698d3bd8574)

#### After

![image](https://github.com/user-attachments/assets/a03c5989-7a38-414e-acbc-f6ee7ae8680f)

:hearts: Thank you!
