### PR TITLE
Fix size in project's title

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -48,7 +48,7 @@
       <% end %>
       <%= cell("decidim/budgets/project_selected_status", project, as_label: true) %>
 
-      <h1 class="h1 decorator budget__definition-project__title editor-content">
+      <h1 class="h3 decorator budget__definition-project__title">
         <%= decidim_sanitize translated_attribute project.title %>
       </h1>
     </section>


### PR DESCRIPTION
#### :tophat: What? Why?

Doing some UX testing we found out that the title is the same size as the description in the projects' budgets, so this PR fixes it. 

#### Testing

1. Go to a project in budgets

### :camera: Screenshots

#### Before

![image](https://github.com/user-attachments/assets/22049c71-069c-4274-8ddb-f2ae491ba5f7)

#### After

![image](https://github.com/user-attachments/assets/02e005c1-f4c4-4acc-9854-20b38ba1c991)

:hearts: Thank you!
