### PR TITLE
Change messages in the budget's voting explanation

### DIFF
--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -44,13 +44,13 @@ module Decidim
         current_order&.can_checkout?
       end
 
-      # Returns false if the current order does not have a rule for minimum budget
-      # Returns false if the current order has not reached the minimum budget
+      # Returns false if the current order does not have a rule for minimum projects
+      # Returns false if the current order has not reached the minimum projects
       # Otherwise returns true
       def current_order_minimum_reached?
-        return false if current_order.minimum_budget.zero?
+        return false if current_order.minimum_projects.zero?
 
-        current_order.total > current_order.minimum_budget
+        current_order.total_projects >= current_order.minimum_projects
       end
 
       def current_rule_call_for_action_text

--- a/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
+++ b/decidim-budgets/app/helpers/decidim/budgets/projects_helper.rb
@@ -98,7 +98,7 @@ module Decidim
                         minimum_budget: budget_to_currency(current_order.minimum_budget)
                       )
                     end
-        %(<strong>#{current_rule_call_for_action_text}</strong>. #{rule_text}).html_safe
+        %(#{current_rule_call_for_action_text}. #{rule_text}).html_safe
       end
 
       # Serialize a collection of geocoded projects to be used by the dynamic map component

--- a/decidim-budgets/config/locales/ca.yml
+++ b/decidim-budgets/config/locales/ca.yml
@@ -285,11 +285,11 @@ ca:
           budget: Pressupost
           dynamic_help:
             keep_adding_projects: Seguir afegint projectes
-            minimum_reached: Has arribat al mínim per a poder votar
+            minimum_reached: <b>Has arribat al mínim per a poder votar</b>
             start_adding_projects: Començar a afegir projectes
           minimum: Mínim
           minimum_projects_rule:
-            description: Selecciona com a mínim %{minimum_number} projectes que vulguis i vota segons les teves preferències.
+            description: <b>Selecciona com a mínim %{minimum_number} projectes</b> que vulguis i vota segons les teves preferències.
           projects_rule:
             description: Selecciona entre %{minimum_number} i %{maximum_number} projectes que vulguis i vota segons les teves preferències per a definir el pressupost.
           projects_rule_maximum_only:

--- a/decidim-budgets/config/locales/ca.yml
+++ b/decidim-budgets/config/locales/ca.yml
@@ -285,11 +285,11 @@ ca:
           budget: Pressupost
           dynamic_help:
             keep_adding_projects: Seguir afegint projectes
-            minimum_reached: <b>Has arribat al mínim per a poder votar</b>
+            minimum_reached: "<b>Has arribat al mínim per a poder votar</b>"
             start_adding_projects: Començar a afegir projectes
           minimum: Mínim
           minimum_projects_rule:
-            description: <b>Selecciona com a mínim %{minimum_number} projectes</b> que vulguis i vota segons les teves preferències.
+            description: "<b>Selecciona com a mínim %{minimum_number} projectes</b> que vulguis i vota segons les teves preferències."
           projects_rule:
             description: Selecciona entre %{minimum_number} i %{maximum_number} projectes que vulguis i vota segons les teves preferències per a definir el pressupost.
           projects_rule_maximum_only:

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -287,11 +287,11 @@ en:
           budget: Budget
           dynamic_help:
             keep_adding_projects: Keep adding projects
-            minimum_reached: You have reached the minimum to be able to vote
+            minimum_reached: <b>You have reached the minimum to be able to vote</b>
             start_adding_projects: Start adding projects
           minimum: Minimum
           minimum_projects_rule:
-            description: Select at least %{minimum_number} projects you want and vote according to your preferences.
+            description: <b>Select at least %{minimum_number} projects</b> you want and vote according to your preferences.
           projects_rule:
             description: Select at least %{minimum_number} and up to %{maximum_number} projects you want and vote according to your preferences.
           projects_rule_maximum_only:

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -287,11 +287,11 @@ en:
           budget: Budget
           dynamic_help:
             keep_adding_projects: Keep adding projects
-            minimum_reached: <b>You have reached the minimum to be able to vote</b>
+            minimum_reached: "<b>You have reached the minimum to be able to vote</b>"
             start_adding_projects: Start adding projects
           minimum: Minimum
           minimum_projects_rule:
-            description: <b>Select at least %{minimum_number} projects</b> you want and vote according to your preferences.
+            description: "<b>Select at least %{minimum_number} projects</b> you want and vote according to your preferences."
           projects_rule:
             description: Select at least %{minimum_number} and up to %{maximum_number} projects you want and vote according to your preferences.
           projects_rule_maximum_only:

--- a/decidim-budgets/config/locales/es.yml
+++ b/decidim-budgets/config/locales/es.yml
@@ -285,11 +285,11 @@ es:
           budget: Presupuesto
           dynamic_help:
             keep_adding_projects: Seguir añadiendo proyectos
-            minimum_reached: <b>Has alcanzado el mínimo para poder votar</b>
+            minimum_reached: "<b>Has alcanzado el mínimo para poder votar</b>"
             start_adding_projects: Empezar a añadir proyectos
           minimum: Mínimo
           minimum_projects_rule:
-            description: <b>Selecciona al menos %{minimum_number} proyectos</b> que quieras y vota de acuerdo a tus preferencias.
+            description: "<b>Selecciona al menos %{minimum_number} proyectos</b> que quieras y vota de acuerdo a tus preferencias."
           projects_rule:
             description: Selecciona al menos %{minimum_number} y hasta %{maximum_number} proyectos que quieras y vota de acuerdo a tus preferencias para definir el presupuesto.
           projects_rule_maximum_only:

--- a/decidim-budgets/config/locales/es.yml
+++ b/decidim-budgets/config/locales/es.yml
@@ -285,11 +285,11 @@ es:
           budget: Presupuesto
           dynamic_help:
             keep_adding_projects: Seguir añadiendo proyectos
-            minimum_reached: Has alcanzado el mínimo para poder votar
+            minimum_reached: <b>Has alcanzado el mínimo para poder votar</b>
             start_adding_projects: Empezar a añadir proyectos
           minimum: Mínimo
           minimum_projects_rule:
-            description: Selecciona al menos %{minimum_number} proyectos que quieras y vota de acuerdo a tus preferencias.
+            description: <b>Selecciona al menos %{minimum_number} proyectos</b> que quieras y vota de acuerdo a tus preferencias.
           projects_rule:
             description: Selecciona al menos %{minimum_number} y hasta %{maximum_number} proyectos que quieras y vota de acuerdo a tus preferencias para definir el presupuesto.
           projects_rule_maximum_only:


### PR DESCRIPTION
#### :tophat: What? Why?

This PR does two things related to the message in the top of the projects lists:

- Changes the bold to show the actual rule (on the case of Barcelona is `minimum_projects`)
- Changes the behavior so the rule that changes this message is the `minimum_projects` instead of the `minimum_budgets` rule

#### Testing

1. Sign in as admin
3. Change the configuration to use the rule "Enable rule: Minimum number of projects to be voted on" with a value of 2
2. Go to the projects list page, add one, two and three projects and check the top message

### :camera: Screenshots

#### Before

![image](https://github.com/user-attachments/assets/29bd9bdb-929f-4462-9e20-0135aec60714)
![image](https://github.com/user-attachments/assets/15c4b59d-9e87-421d-859c-3f7b95a7878a)
![image](https://github.com/user-attachments/assets/e04d8664-4189-4e4c-9c0f-121db38eb233)

#### After

![image](https://github.com/user-attachments/assets/1a3c0345-0093-4b05-b473-84a9b5118595)
![image](https://github.com/user-attachments/assets/c5c391f2-6eda-4701-83ba-f6188b9ce1b5)
![image](https://github.com/user-attachments/assets/da305415-cdd9-49c7-a527-af7040ee9c52)

:hearts: Thank you!
