### PR TITLE
Fix budget detail with "You voted for this" string (#14284)

### DIFF
--- a/decidim-budgets/app/cells/decidim/budgets/project_voted_hint_cell.rb
+++ b/decidim-budgets/app/cells/decidim/budgets/project_voted_hint_cell.rb
@@ -9,20 +9,23 @@ module Decidim
       def show
         return unless voted_for?(model)
 
-        content_tag :span, safe_join(hint), class: css_class
+        content_tag :span, hint, class: css_class
       end
 
       private
 
       def hint
-        contents = []
-        contents << icon("check-line", role: "img", "aria-hidden": true)
-        contents << " "
-        contents << t("decidim.budgets.projects.project.you_voted")
+        content_tag :div, class: "success" do
+          contents = []
+          contents << icon("check-line", role: "img", "aria-hidden": true)
+          contents << " "
+          contents << t("decidim.budgets.projects.project.you_voted")
+          safe_join(contents)
+        end
       end
 
       def css_class
-        css = ["text-sm", "text-success"]
+        css = ["card__list-metadata"]
         css << options[:class] if options[:class]
         css.join(" ")
       end

--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -151,6 +151,10 @@
       }
     }
 
+    & > div.success {
+      @apply text-sm text-success;
+    }
+
     [data-author] + [data-author] {
       @apply -ml-4;
     }


### PR DESCRIPTION
#### :tophat: What? Why?

While doing UX testing, we found out that the "You voted this" string isn't aligned with the icon.

This PR fixes it by cherry-picking the fix from upstream. 

#### :pushpin: Related Issues
 
- Related to  https://github.com/decidim/decidim/pull/14284 

#### Testing

1. Go to a budget component
2. Enable voting
3. Vote for a project
4. Visit the budget page
5. See error
6. Apply patch
7. See error is gone

### :camera: Screenshots

#### Before

![2025-05-06-115742_hyprshot](https://github.com/user-attachments/assets/b817416e-3b0a-43e3-a046-6d22de63bcd2)

##### After 

![2025-05-06-115720_hyprshot](https://github.com/user-attachments/assets/4ae24a22-4bed-4246-90eb-1e84eca430a3)

:hearts: Thank you!
